### PR TITLE
Update env var to NEXT_PUBLIC_APP_URL

### DIFF
--- a/app/api/integrations/discord/callback/route.ts
+++ b/app/api/integrations/discord/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import { createClient } from "@/utils/supabase/server"
+import { getBaseUrl } from "@/lib/utils"
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -14,7 +15,7 @@ export async function GET(request: Request) {
     const tokenEndpoint = "https://discord.com/api/oauth2/token"
     const client_id = process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID
     const client_secret = process.env.DISCORD_CLIENT_SECRET
-    const redirect_uri = "https://chainreact.app/api/integrations/discord/callback"
+    const redirect_uri = `${getBaseUrl()}/api/integrations/discord/callback`
 
     const tokenParams = new URLSearchParams({
       client_id: client_id || "",
@@ -37,7 +38,7 @@ export async function GET(request: Request) {
     if (tokenData.error) {
       console.error("Error exchanging code for token:", tokenData.error_description || tokenData.error)
       return NextResponse.redirect(
-        `https://chainreact.app/integrations?error=discord_token_exchange_failed&description=${tokenData.error_description || tokenData.error}`,
+        `${getBaseUrl()}/integrations?error=discord_token_exchange_failed&description=${tokenData.error_description || tokenData.error}`,
       )
     }
 
@@ -54,7 +55,7 @@ export async function GET(request: Request) {
     if (userData.error) {
       console.error("Error fetching user data:", userData.error)
       return NextResponse.redirect(
-        `https://chainreact.app/integrations?error=discord_user_fetch_failed&description=${userData.error}`,
+        `${getBaseUrl()}/integrations?error=discord_user_fetch_failed&description=${userData.error}`,
       )
     }
 
@@ -63,7 +64,7 @@ export async function GET(request: Request) {
 
     if (!userId) {
       console.error("No user ID found in session.")
-      return NextResponse.redirect(`https://chainreact.app/integrations?error=no_user_session`)
+      return NextResponse.redirect(`${getBaseUrl()}/integrations?error=no_user_session`)
     }
 
     // After successful token exchange and user info retrieval, add:
@@ -108,8 +109,8 @@ export async function GET(request: Request) {
       if (error) throw error
     }
 
-    return NextResponse.redirect(`https://chainreact.app/integrations?success=discord_connected&provider=discord`)
+    return NextResponse.redirect(`${getBaseUrl()}/integrations?success=discord_connected&provider=discord`)
   } else {
-    return NextResponse.redirect(`https://chainreact.app/integrations?error=discord_no_code`)
+    return NextResponse.redirect(`${getBaseUrl()}/integrations?error=discord_no_code`)
   }
 }

--- a/app/api/integrations/hubspot/callback/route.ts
+++ b/app/api/integrations/hubspot/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
+import { getBaseUrl } from "@/lib/utils"
 
 // Use direct Supabase client with service role for reliable database operations
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -18,7 +19,7 @@ const supabase = createClient(supabaseUrl, supabaseKey, {
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code")
   const state = request.nextUrl.searchParams.get("state")
-  const baseUrl = "https://chainreact.app"
+  const baseUrl = getBaseUrl()
 
   if (!code || !state) {
     console.error("No code or state received")
@@ -60,7 +61,7 @@ export async function GET(request: NextRequest) {
         grant_type: "authorization_code",
         client_id: clientId,
         client_secret: clientSecret,
-        redirect_uri: "https://chainreact.app/api/integrations/hubspot/callback",
+        redirect_uri: `${getBaseUrl()}/api/integrations/hubspot/callback`,
         code,
       }),
     })

--- a/app/api/integrations/onedrive/callback/route.ts
+++ b/app/api/integrations/onedrive/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
+import { getBaseUrl } from "@/lib/utils"
 
 // Use direct Supabase client with service role for reliable database operations
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -22,8 +23,8 @@ export async function GET(req: NextRequest) {
   const error = searchParams.get("error")
   const error_description = searchParams.get("error_description")
 
-  const baseUrl = "https://chainreact.app"
-  const redirectUri = "https://chainreact.app/api/integrations/onedrive/callback"
+  const baseUrl = getBaseUrl()
+  const redirectUri = `${getBaseUrl()}/api/integrations/onedrive/callback`
 
   if (error) {
     console.error("OneDrive Auth Error:", error, error_description)

--- a/app/api/integrations/slack/callback/route.ts
+++ b/app/api/integrations/slack/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
+import { getBaseUrl } from "@/lib/utils"
 
 const slackClientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID
 const slackClientSecret = process.env.SLACK_CLIENT_SECRET
@@ -30,12 +31,12 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     console.error("Slack OAuth error:", error)
-    return NextResponse.redirect(`https://chainreact.app/integrations?error=slack_oauth_failed&message=${error}`)
+    return NextResponse.redirect(`${getBaseUrl()}/integrations?error=slack_oauth_failed&message=${error}`)
   }
 
   if (!code || !state) {
     console.error("Missing code or state in Slack callback")
-    return NextResponse.redirect(`https://chainreact.app/integrations?error=slack_oauth_failed`)
+    return NextResponse.redirect(`${getBaseUrl()}/integrations?error=slack_oauth_failed`)
   }
 
   try {
@@ -45,14 +46,14 @@ export async function GET(request: NextRequest) {
       stateData = JSON.parse(atob(state))
     } catch (e) {
       console.error("Failed to parse state:", e)
-      return NextResponse.redirect(`https://chainreact.app/integrations?error=invalid_state`)
+      return NextResponse.redirect(`${getBaseUrl()}/integrations?error=invalid_state`)
     }
 
     const userId = stateData.userId
 
     if (!userId) {
       console.error("No user ID in state")
-      return NextResponse.redirect(`https://chainreact.app/integrations?error=missing_user_id`)
+      return NextResponse.redirect(`${getBaseUrl()}/integrations?error=missing_user_id`)
     }
 
     // Exchange code for token
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
         client_id: slackClientId,
         client_secret: slackClientSecret,
         code: code,
-        redirect_uri: "https://chainreact.app/api/integrations/slack/callback",
+        redirect_uri: `${getBaseUrl()}/api/integrations/slack/callback`,
       }),
     })
 
@@ -75,7 +76,7 @@ export async function GET(request: NextRequest) {
     if (!tokenData.ok) {
       console.error("Slack token exchange error:", tokenData)
       return NextResponse.redirect(
-        `https://chainreact.app/integrations?error=token_exchange_failed&message=${encodeURIComponent(tokenData.error || "Unknown error")}`,
+        `${getBaseUrl()}/integrations?error=token_exchange_failed&message=${encodeURIComponent(tokenData.error || "Unknown error")}`,
       )
     }
 
@@ -88,7 +89,7 @@ export async function GET(request: NextRequest) {
 
     if (!botToken) {
       console.error("No bot token in response")
-      return NextResponse.redirect(`https://chainreact.app/integrations?error=missing_bot_token`)
+      return NextResponse.redirect(`${getBaseUrl()}/integrations?error=missing_bot_token`)
     }
 
     // Use bot token to get team/workspace info
@@ -112,7 +113,7 @@ export async function GET(request: NextRequest) {
     if (!botInfoData.ok) {
       console.error("Bot info error:", botInfoData)
       return NextResponse.redirect(
-        `https://chainreact.app/integrations?error=bot_info_failed&message=${encodeURIComponent(botInfoData.error || "Unknown error")}`,
+        `${getBaseUrl()}/integrations?error=bot_info_failed&message=${encodeURIComponent(botInfoData.error || "Unknown error")}`,
       )
     }
 
@@ -157,7 +158,7 @@ export async function GET(request: NextRequest) {
 
       if (error) {
         console.error("Error updating Slack integration:", error)
-        return NextResponse.redirect(`https://chainreact.app/integrations?error=database_update_failed`)
+        return NextResponse.redirect(`${getBaseUrl()}/integrations?error=database_update_failed`)
       }
     } else {
       const { error } = await supabase.from("integrations").insert({
@@ -167,7 +168,7 @@ export async function GET(request: NextRequest) {
 
       if (error) {
         console.error("Error inserting Slack integration:", error)
-        return NextResponse.redirect(`https://chainreact.app/integrations?error=database_insert_failed`)
+        return NextResponse.redirect(`${getBaseUrl()}/integrations?error=database_insert_failed`)
       }
     }
 
@@ -175,12 +176,12 @@ export async function GET(request: NextRequest) {
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
     return NextResponse.redirect(
-      `https://chainreact.app/integrations?success=slack_connected&provider=slack&t=${Date.now()}`,
+      `${getBaseUrl()}/integrations?success=slack_connected&provider=slack&t=${Date.now()}`,
     )
   } catch (error: any) {
     console.error("Error during Slack callback:", error)
     return NextResponse.redirect(
-      `https://chainreact.app/integrations?error=slack_oauth_failed&message=${encodeURIComponent(error.message)}`,
+      `${getBaseUrl()}/integrations?error=slack_oauth_failed&message=${encodeURIComponent(error.message)}`,
     )
   }
 }

--- a/app/api/integrations/youtube/callback/route.ts
+++ b/app/api/integrations/youtube/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
+import { getBaseUrl } from "@/lib/utils"
 
 // Use direct Supabase client with service role for reliable database operations
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -70,7 +71,7 @@ export async function GET(request: NextRequest) {
         client_secret: clientSecret,
         code,
         grant_type: "authorization_code",
-        redirect_uri: "https://chainreact.app/api/integrations/youtube/callback", // Exact same URI
+        redirect_uri: `${getBaseUrl()}/api/integrations/youtube/callback`, // Exact same URI
       }),
     })
 

--- a/app/integrations/trello-auth/page.tsx
+++ b/app/integrations/trello-auth/page.tsx
@@ -2,6 +2,7 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import { db } from "@/lib/db"
+import { getBaseUrl } from "@/lib/utils"
 
 async function getTrelloToken(userId: string) {
   const trelloIntegration = await db.trelloIntegration.findUnique({
@@ -30,7 +31,7 @@ async function TrelloAuthPage() {
   }
 
   const trelloApiKey = process.env.TRELLO_API_KEY
-  const trelloAuthUrl = `https://trello.com/1/authorize?expiration=never&name=Taskify&scope=read,write,account&response_type=token&key=${trelloApiKey}&return_url=${process.env.NEXT_PUBLIC_SITE_URL}/integrations/trello-auth/callback`
+  const trelloAuthUrl = `https://trello.com/1/authorize?expiration=never&name=Taskify&scope=read,write,account&response_type=token&key=${trelloApiKey}&return_url=${getBaseUrl()}/integrations/trello-auth/callback`
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -1,7 +1,9 @@
+import { getBaseUrl } from "@/lib/utils"
+
 export const discord = {
   clientId: process.env.NEXT_PUBLIC_DISCORD_CLIENT_ID,
   clientSecret: process.env.DISCORD_CLIENT_SECRET,
-  redirectUri: `${process.env.NEXT_PUBLIC_SITE_URL}/api/integrations/discord/callback`,
+  redirectUri: `${getBaseUrl()}/api/integrations/discord/callback`,
 
   getAuthUrl(state: string) {
     const params = new URLSearchParams({

--- a/lib/oauth/BaseOAuthService.ts
+++ b/lib/oauth/BaseOAuthService.ts
@@ -1,4 +1,5 @@
 import { createAdminSupabaseClient, upsertIntegration, validateScopes, getRequiredScopes } from "./utils"
+import { getBaseUrl } from "@/lib/utils"
 
 export interface OAuthResult {
   success: boolean
@@ -11,7 +12,7 @@ export class BaseOAuthService {
    * Get hardcoded redirect URI for a provider
    */
   static getRedirectUri(provider: string): string {
-    return `https://chainreact.app/api/integrations/${provider}/callback`
+    return `${getBaseUrl()}/api/integrations/${provider}/callback`
   }
 
   /**
@@ -87,7 +88,7 @@ export class BaseOAuthService {
 
         return {
           success: false,
-          redirectUrl: `https://chainreact.app/integrations?error=insufficient_scopes&provider=${provider}&message=${encodeURIComponent(
+          redirectUrl: `${getBaseUrl()}/integrations?error=insufficient_scopes&provider=${provider}&message=${encodeURIComponent(
             `Missing required permissions: ${scopeValidation.missingScopes.join(", ")}. Please reconnect and accept all permissions.`,
           )}`,
           error: "Insufficient scopes",
@@ -128,19 +129,19 @@ export class BaseOAuthService {
         await upsertIntegration(adminSupabase, integrationData)
       }
 
-      return {
-        success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=${provider}_connected&provider=${provider}`,
-      }
+        return {
+          success: true,
+          redirectUrl: `${getBaseUrl()}/integrations?success=${provider}_connected&provider=${provider}`,
+        }
     } catch (error: any) {
       console.error(`${provider} OAuth callback error:`, error)
-      return {
-        success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=${provider}&message=${encodeURIComponent(
-          error.message,
-        )}`,
-        error: error.message,
-      }
+        return {
+          success: false,
+          redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=${provider}&message=${encodeURIComponent(
+            error.message,
+          )}`,
+          error: error.message,
+        }
     }
   }
 }

--- a/lib/oauth/callbackHandler.ts
+++ b/lib/oauth/callbackHandler.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js"
+import { getBaseUrl } from "@/lib/utils"
 
 const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
 
@@ -62,7 +63,7 @@ export async function saveIntegrationToDatabase(integrationData: IntegrationData
 }
 
 export function generateSuccessRedirect(provider: string): string {
-  return `https://chainreact.app/integrations?success=${provider}_connected&provider=${provider}`
+  return `${getBaseUrl()}/integrations?success=${provider}_connected&provider=${provider}`
 }
 
 export function generateErrorRedirect(provider: string, error: string, message?: string): string {
@@ -75,5 +76,5 @@ export function generateErrorRedirect(provider: string, error: string, message?:
     params.append("message", message)
   }
 
-  return `https://chainreact.app/integrations?${params.toString()}`
+  return `${getBaseUrl()}/integrations?${params.toString()}`
 }

--- a/lib/oauth/discord.ts
+++ b/lib/oauth/discord.ts
@@ -1,4 +1,5 @@
 import { upsertIntegration, parseOAuthState } from "./utils"
+import { getBaseUrl } from "@/lib/utils"
 
 interface DiscordOAuthResult {
   success: boolean
@@ -19,7 +20,7 @@ export class DiscordOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/discord/callback"
+    return `${getBaseUrl()}/api/integrations/discord/callback`
   }
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {
@@ -116,7 +117,7 @@ export class DiscordOAuthService {
         console.error("Discord scope validation failed: missing identify scope")
         return {
           success: false,
-          redirectUrl: `https://chainreact.app/integrations?error=insufficient_scopes&provider=discord&message=${encodeURIComponent(
+          redirectUrl: `${getBaseUrl()}/integrations?error=insufficient_scopes&provider=discord&message=${encodeURIComponent(
             "Your Discord connection is missing the 'identify' permission. Please reconnect and accept all permissions.",
           )}`,
           error: "Insufficient scopes",
@@ -174,13 +175,13 @@ export class DiscordOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=discord_connected&provider=discord`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=discord_connected&provider=discord`,
       }
     } catch (error: any) {
       console.error("Discord OAuth callback error:", error)
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=discord&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=discord&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/dropbox.ts
+++ b/lib/oauth/dropbox.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from "@/lib/utils"
+
 interface DropboxOAuthResult {
   success: boolean
   redirectUrl: string
@@ -18,7 +20,7 @@ export class DropboxOAuthService {
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {
     const { clientId } = this.getClientCredentials()
-    const redirectUri = "https://chainreact.app/api/integrations/dropbox/callback"
+    const redirectUri = `${getBaseUrl()}/api/integrations/dropbox/callback`
 
     const state = btoa(
       JSON.stringify({
@@ -42,7 +44,7 @@ export class DropboxOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/dropbox/callback"
+    return `${getBaseUrl()}/api/integrations/dropbox/callback`
   }
 
   static async handleCallback(code: string, state: string, supabase: any, userId: string): Promise<DropboxOAuthResult> {
@@ -128,12 +130,12 @@ export class DropboxOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=dropbox_connected`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=dropbox_connected`,
       }
     } catch (error: any) {
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=dropbox&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=dropbox&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/github.ts
+++ b/lib/oauth/github.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from "@/lib/utils"
+
 interface GitHubOAuthResult {
   success: boolean
   redirectUrl: string
@@ -17,7 +19,7 @@ export class GitHubOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/github/callback"
+    return `${getBaseUrl()}/api/integrations/github/callback`
   }
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {
@@ -139,12 +141,12 @@ export class GitHubOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=github_connected&provider=github`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=github_connected&provider=github`,
       }
     } catch (error: any) {
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=github&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=github&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/handleOAuthCallback.ts
+++ b/lib/oauth/handleOAuthCallback.ts
@@ -10,7 +10,7 @@ export async function handleOAuthCallback(
   try {
     const { searchParams } = new URL(request.url)
     const baseUrl = getAbsoluteBaseUrl(request)
-    const redirectUri = getOAuthRedirectUri(baseUrl, provider)
+    const redirectUri = getOAuthRedirectUri(provider)
 
     console.log(`${provider} OAuth callback - using redirect URI:`, redirectUri)
 

--- a/lib/oauth/hubspot.ts
+++ b/lib/oauth/hubspot.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from "@/lib/utils"
+
 interface HubSpotOAuthResult {
   success: boolean
   redirectUrl: string
@@ -55,7 +57,7 @@ export class HubSpotOAuthService {
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string): string {
     const { clientId } = this.getClientCredentials()
-    const redirectUri = "https://chainreact.app/api/integrations/hubspot/callback"
+    const redirectUri = `${getBaseUrl()}/api/integrations/hubspot/callback`
 
     const scopes = [
       "crm.objects.contacts.read",
@@ -86,7 +88,7 @@ export class HubSpotOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/hubspot/callback"
+    return `${getBaseUrl()}/api/integrations/hubspot/callback`
   }
 
   static async handleCallback(
@@ -134,7 +136,7 @@ export class HubSpotOAuthService {
           grant_type: "authorization_code",
           client_id: clientId,
           client_secret: clientSecret,
-          redirect_uri: "https://chainreact.app/api/integrations/hubspot/callback",
+          redirect_uri: `${getBaseUrl()}/api/integrations/hubspot/callback`,
           code,
         }),
       })
@@ -156,7 +158,7 @@ export class HubSpotOAuthService {
       if (!scopeValidation.valid) {
         return {
           success: false,
-          redirectUrl: `https://chainreact.app/integrations?error=insufficient_scopes&provider=hubspot&missing=${scopeValidation.missing.join(",")}`,
+          redirectUrl: `${getBaseUrl()}/integrations?error=insufficient_scopes&provider=hubspot&missing=${scopeValidation.missing.join(",")}`,
         }
       }
 
@@ -165,7 +167,7 @@ export class HubSpotOAuthService {
       if (!isTokenValid) {
         return {
           success: false,
-          redirectUrl: `https://chainreact.app/integrations?error=invalid_token&provider=hubspot`,
+          redirectUrl: `${getBaseUrl()}/integrations?error=invalid_token&provider=hubspot`,
         }
       }
 
@@ -217,12 +219,12 @@ export class HubSpotOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=hubspot_connected`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=hubspot_connected`,
       }
     } catch (error: any) {
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=hubspot&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=hubspot&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/instagram.ts
+++ b/lib/oauth/instagram.ts
@@ -1,5 +1,6 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
+import { getBaseUrl } from "@/lib/utils"
 
 interface InstagramOAuthResult {
   success: boolean
@@ -51,7 +52,7 @@ export class InstagramOAuthService {
       throw new Error("Missing NEXT_PUBLIC_INSTAGRAM_CLIENT_ID environment variable")
     }
 
-    const redirectUri = `${baseUrl}/api/integrations/instagram/callback`
+    const redirectUri = `${getBaseUrl()}/api/integrations/instagram/callback`
     const scopes = "instagram_basic,instagram_content_publish"
     const state = JSON.stringify({ userId, integrationId, reconnect })
 
@@ -59,7 +60,7 @@ export class InstagramOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/instagram/callback"
+    return `${getBaseUrl()}/api/integrations/instagram/callback`
   }
 
   static async handleCallback(code: string, state: string, baseUrl: string): Promise<InstagramOAuthResult> {
@@ -98,7 +99,7 @@ export class InstagramOAuthService {
         body: new URLSearchParams({
           client_id: clientId,
           client_secret: clientSecret,
-          redirect_uri: "https://chainreact.app/api/integrations/instagram/callback",
+          redirect_uri: `${getBaseUrl()}/api/integrations/instagram/callback`,
           code,
         }),
       })

--- a/lib/oauth/notion.ts
+++ b/lib/oauth/notion.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from "@/lib/utils"
+
 interface NotionOAuthResult {
   success: boolean
   redirectUrl: string
@@ -187,7 +189,7 @@ export class NotionOAuthService {
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {
     const { clientId } = this.getClientCredentials()
-    const redirectUri = "https://chainreact.app/api/integrations/notion/callback"
+    const redirectUri = `${getBaseUrl()}/api/integrations/notion/callback`
 
     const state = btoa(
       JSON.stringify({
@@ -212,7 +214,7 @@ export class NotionOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/notion/callback"
+    return `${getBaseUrl()}/api/integrations/notion/callback`
   }
 
   static async handleCallback(code: string, state: string, supabase: any, userId: string): Promise<NotionOAuthResult> {
@@ -252,7 +254,7 @@ export class NotionOAuthService {
         body: JSON.stringify({
           grant_type: "authorization_code",
           code,
-          redirect_uri: "https://chainreact.app/api/integrations/notion/callback",
+          redirect_uri: `${getBaseUrl()}/api/integrations/notion/callback`,
         }),
       })
 
@@ -315,13 +317,13 @@ export class NotionOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=notion_connected&provider=notion`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=notion_connected&provider=notion`,
       }
     } catch (error: any) {
       console.error("Notion OAuth callback error:", error)
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=notion&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=notion&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/onedrive.ts
+++ b/lib/oauth/onedrive.ts
@@ -1,3 +1,5 @@
+import { getBaseUrl } from "@/lib/utils"
+
 export class OneDriveOAuthService {
   private static getClientCredentials() {
     const clientId = process.env.NEXT_PUBLIC_ONEDRIVE_CLIENT_ID
@@ -12,7 +14,7 @@ export class OneDriveOAuthService {
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {
     const { clientId } = this.getClientCredentials()
-    const redirectUri = "https://chainreact.app/api/integrations/onedrive/callback"
+    const redirectUri = `${getBaseUrl()}/api/integrations/onedrive/callback`
 
     const scopes = ["openid", "profile", "email", "offline_access", "Files.ReadWrite.All", "Sites.ReadWrite.All"]
 
@@ -39,7 +41,7 @@ export class OneDriveOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/onedrive/callback"
+    return `${getBaseUrl()}/api/integrations/onedrive/callback`
   }
 
   static async handleCallback(
@@ -67,7 +69,7 @@ export class OneDriveOAuthService {
           code,
           client_id: clientId,
           client_secret: clientSecret,
-          redirect_uri: "https://chainreact.app/api/integrations/onedrive/callback",
+          redirect_uri: `${getBaseUrl()}/api/integrations/onedrive/callback`,
           grant_type: "authorization_code",
         }),
       })
@@ -125,12 +127,12 @@ export class OneDriveOAuthService {
 
       return {
         success: true,
-        redirectUrl: `https://chainreact.app/integrations?success=onedrive_connected`,
+        redirectUrl: `${getBaseUrl()}/integrations?success=onedrive_connected`,
       }
     } catch (error: any) {
       return {
         success: false,
-        redirectUrl: `https://chainreact.app/integrations?error=callback_failed&provider=onedrive&message=${encodeURIComponent(error.message)}`,
+        redirectUrl: `${getBaseUrl()}/integrations?error=callback_failed&provider=onedrive&message=${encodeURIComponent(error.message)}`,
         error: error.message,
       }
     }

--- a/lib/oauth/slack.ts
+++ b/lib/oauth/slack.ts
@@ -1,4 +1,5 @@
 import { BaseOAuthService } from "./BaseOAuthService"
+import { getBaseUrl } from "@/lib/utils"
 
 export class SlackOAuthService extends BaseOAuthService {
   private static getClientCredentials() {
@@ -16,7 +17,7 @@ export class SlackOAuthService extends BaseOAuthService {
   }
 
   static getRedirectUri(): string {
-    return "https://chainreact.app/api/integrations/slack/callback"
+    return `${getBaseUrl()}/api/integrations/slack/callback`
   }
 
   static generateAuthUrl(baseUrl: string, reconnect = false, integrationId?: string, userId?: string): string {

--- a/lib/oauth/utils.ts
+++ b/lib/oauth/utils.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js"
 import type { NextRequest } from "next/server"
 import type { Database } from "@/types/supabase"
+import { getBaseUrl } from "@/lib/utils"
 
 /**
  * Create admin client only for server-side operations
@@ -33,7 +34,7 @@ export const createAdminSupabaseClient = () => {
  * Get hardcoded redirect URI for OAuth providers
  */
 export function getOAuthRedirectUri(provider: string): string {
-  return `https://chainreact.app/api/integrations/${provider}/callback`
+  return `${getBaseUrl()}/api/integrations/${provider}/callback`
 }
 
 /**
@@ -42,7 +43,7 @@ export function getOAuthRedirectUri(provider: string): string {
  */
 export function getAbsoluteBaseUrl(request: Request | NextRequest): string {
   // Always return production URL for OAuth consistency
-  return "https://chainreact.app"
+  return getBaseUrl()
 }
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getBaseUrl() {
+  return process.env.NEXT_PUBLIC_APP_URL || "https://chainreact.app"
+}


### PR DESCRIPTION
## Summary
- switch references from `NEXT_PUBLIC_SITE_URL` to `NEXT_PUBLIC_APP_URL`
- add `getBaseUrl` helper
- use `getBaseUrl` across OAuth helpers and callbacks

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c04cced88324afb77e9f36f24b17