### PR TITLE
Store scopes and validate on Dropbox, Teams, Trello callbacks

### DIFF
--- a/app/api/integrations/dropbox/callback/route.ts
+++ b/app/api/integrations/dropbox/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
+import { validateAndUpdateIntegrationScopes } from "@/lib/integrations/scopeValidation"
 
 // Use direct Supabase client with service role for reliable database operations
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -81,6 +82,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const accessToken = tokenData.access_token
     const refreshToken = tokenData.refresh_token
     const accountId = tokenData.account_id
+    let grantedScopes: string[] = []
+    if (tokenData.scope) {
+      if (typeof tokenData.scope === "string") {
+        grantedScopes = tokenData.scope.split(/\s+/).map((s: string) => s.trim()).filter((s: string) => s)
+      } else if (Array.isArray(tokenData.scope)) {
+        grantedScopes = tokenData.scope
+      }
+    }
+    if (grantedScopes.length === 0) {
+      grantedScopes = ["files.content.read", "files.content.write"]
+    }
 
     if (!accessToken) {
       console.error("No access token received from Dropbox")
@@ -120,8 +132,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       access_token: accessToken,
       refresh_token: refreshToken,
       expires_at: tokenData.expires_in ? new Date(Date.now() + tokenData.expires_in * 1000).toISOString() : null,
-      status: "connected",
-      scopes: ["files.content.read", "files.content.write"],
+      status: "connected" as const,
+      scopes: grantedScopes,
+      granted_scopes: grantedScopes,
       metadata: {
         email: userData.email,
         name: userData.name.display_name,
@@ -130,22 +143,42 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       updated_at: now,
     }
 
+    let integrationId: string | undefined
     if (existingIntegration) {
-      const { error } = await supabase.from("integrations").update(integrationData).eq("id", existingIntegration.id)
+      const { data, error } = await supabase
+        .from("integrations")
+        .update(integrationData)
+        .eq("id", existingIntegration.id)
+        .select("id")
+        .single()
 
       if (error) {
         console.error("Error updating Dropbox integration:", error)
         return NextResponse.redirect(`${baseUrl}/integrations?error=database_update_failed&provider=dropbox`)
       }
+      integrationId = data.id
     } else {
-      const { error } = await supabase.from("integrations").insert({
-        ...integrationData,
-        created_at: now,
-      })
+      const { data, error } = await supabase
+        .from("integrations")
+        .insert({
+          ...integrationData,
+          created_at: now,
+        })
+        .select("id")
+        .single()
 
       if (error) {
         console.error("Error inserting Dropbox integration:", error)
         return NextResponse.redirect(`${baseUrl}/integrations?error=database_insert_failed&provider=dropbox`)
+      }
+      integrationId = data.id
+    }
+
+    if (integrationId) {
+      try {
+        await validateAndUpdateIntegrationScopes(integrationId, grantedScopes)
+      } catch (err) {
+        console.error("Dropbox scope validation failed:", err)
       }
     }
 

--- a/lib/oauth/teams.ts
+++ b/lib/oauth/teams.ts
@@ -1,5 +1,6 @@
 import { BaseOAuthService } from "./BaseOAuthService"
 import { saveIntegrationToDatabase, generateSuccessRedirect } from "./callbackHandler"
+import { validateAndUpdateIntegrationScopes } from "../integrations/scopeValidation"
 
 export class TeamsOAuthService extends BaseOAuthService {
   private static getClientCredentials() {
@@ -141,6 +142,7 @@ export class TeamsOAuthService extends BaseOAuthService {
         expires_at: expires_in ? new Date(Date.now() + expires_in * 1000).toISOString() : null,
         status: "connected" as const,
         scopes: grantedScopes,
+        granted_scopes: grantedScopes,
         metadata: {
           display_name: userData.displayName,
           email: userData.userPrincipalName || userData.mail,
@@ -161,7 +163,13 @@ export class TeamsOAuthService extends BaseOAuthService {
       }
 
       console.log("Teams: Saving integration data with scopes:", grantedScopes)
-      await saveIntegrationToDatabase(integrationData)
+      const integrationId = await saveIntegrationToDatabase(integrationData)
+
+      try {
+        await validateAndUpdateIntegrationScopes(integrationId, grantedScopes)
+      } catch (err) {
+        console.error("Teams scope validation failed:", err)
+      }
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- include `granted_scopes` when saving integrations
- return integration id from `saveIntegrationToDatabase`
- store granted scopes and validate them for Teams
- parse Dropbox scopes from provider response and validate
- record default Trello scopes and validate

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c049fcbc8324b35458b0ac362154