### PR TITLE
Fix undefined variable in onedrive callback

### DIFF
--- a/app/api/integrations/onedrive/callback/route.ts
+++ b/app/api/integrations/onedrive/callback/route.ts
@@ -23,8 +23,8 @@ export async function GET(req: NextRequest) {
   const error = searchParams.get("error")
   const error_description = searchParams.get("error_description")
 
-  const baseUrl = getBaseUrl(request)
-  const redirectUri = `${getBaseUrl(request)}/api/integrations/onedrive/callback`
+  const baseUrl = getBaseUrl(req)
+  const redirectUri = `${getBaseUrl(req)}/api/integrations/onedrive/callback`
 
   if (error) {
     console.error("OneDrive Auth Error:", error, error_description)

--- a/lib/oauth/teams.ts
+++ b/lib/oauth/teams.ts
@@ -164,10 +164,10 @@ export class TeamsOAuthService extends BaseOAuthService {
       }
 
       console.log("Teams: Saving integration data with scopes:", grantedScopes)
-      const integrationId = await saveIntegrationToDatabase(integrationData)
+      const savedIntegrationId = await saveIntegrationToDatabase(integrationData)
 
       try {
-        await validateAndUpdateIntegrationScopes(integrationId, grantedScopes)
+        await validateAndUpdateIntegrationScopes(savedIntegrationId, grantedScopes)
       } catch (err) {
         console.error("Teams scope validation failed:", err)
       }


### PR DESCRIPTION
## Summary
- fix undefined variable `request` in onedrive callback

## Testing
- `pnpm lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: TypeScript errors / missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6843c9e1baa88324a441911f8e84c036