### PR TITLE
Add analytics endpoints

### DIFF
--- a/app/api/analytics/chart-data/route.ts
+++ b/app/api/analytics/chart-data/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const chartData = [
+    { name: "Mon", workflows: 0, executions: 0 },
+    { name: "Tue", workflows: 0, executions: 0 },
+    { name: "Wed", workflows: 0, executions: 0 },
+    { name: "Thu", workflows: 0, executions: 0 },
+    { name: "Fri", workflows: 0, executions: 0 },
+    { name: "Sat", workflows: 0, executions: 0 },
+    { name: "Sun", workflows: 0, executions: 0 },
+  ]
+
+  return NextResponse.json({ success: true, data: chartData })
+}

--- a/app/api/analytics/metrics/route.ts
+++ b/app/api/analytics/metrics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const metrics = {
+    workflowsRun: 0,
+    hoursSaved: 0,
+    integrations: 0,
+    aiCommands: 0,
+  }
+
+  return NextResponse.json({ success: true, data: metrics })
+}


### PR DESCRIPTION
## Summary
- add `/api/analytics/metrics` returning static metrics
- add `/api/analytics/chart-data` returning sample chart data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d51304c83248e69d0a6d67b0efe