### PR TITLE
Add execution analytics to store

### DIFF
--- a/app/api/analytics/executions/route.ts
+++ b/app/api/analytics/executions/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const executions = [
+    {
+      id: "1",
+      status: "success",
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+      execution_time_ms: 1200,
+    },
+    {
+      id: "2",
+      status: "error",
+      started_at: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+      completed_at: new Date().toISOString(),
+      execution_time_ms: 2000,
+      error_message: "Sample error",
+    },
+  ]
+
+  return NextResponse.json(executions)
+}


### PR DESCRIPTION
## Summary
- extend `AnalyticsState` with execution history state and method
- fetch execution data from `/api/analytics/executions`
- expose placeholder execution API route

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9d5483a48324935be62c7faf0636