### PR TITLE
Post-deploy fixes: dead hrefs + Cloudflare CSP whitelist

### DIFF
--- a/app/auth/confirm/page.tsx
+++ b/app/auth/confirm/page.tsx
@@ -253,7 +253,7 @@ export default function EmailConfirmPage() {
 
               <div className="mt-6 text-xs text-orange-300/60">
                 Need help getting started? Visit our{" "}
-                <Link href="/help" className="text-orange-300 hover:text-orange-200 underline">
+                <Link href="/support" className="text-orange-300 hover:text-orange-200 underline">
                   help center
                 </Link>
               </div>

--- a/app/auth/sso-error/page.tsx
+++ b/app/auth/sso-error/page.tsx
@@ -36,7 +36,7 @@ function SSOErrorContent() {
 
           <div className="flex flex-col gap-2">
             <Button asChild variant="default" className="w-full">
-              <Link href="/login">
+              <Link href="/auth/login">
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 Back to Login
               </Link>

--- a/app/request-integration/page.tsx
+++ b/app/request-integration/page.tsx
@@ -54,7 +54,7 @@ export default function RequestIntegrationPage() {
       <nav className="relative z-40 px-4 sm:px-6 lg:px-8 py-6 bg-slate-900/50 backdrop-blur-lg border-b border-white/10">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <Link
-            href="/home"
+            href="/"
             className="flex items-center gap-2 text-white/80 hover:text-white transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -115,8 +115,8 @@ const nextConfig = {
               "form-action 'self'",
               // Script sources - 'unsafe-inline' needed for Next.js, 'unsafe-eval' needed for some libs
               // In production, consider using nonces instead
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://apis.google.com https://www.gstatic.com",
-              "script-src-elem 'self' 'unsafe-inline' https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://apis.google.com https://www.gstatic.com",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://apis.google.com https://www.gstatic.com https://static.cloudflareinsights.com",
+              "script-src-elem 'self' 'unsafe-inline' https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://apis.google.com https://www.gstatic.com https://static.cloudflareinsights.com",
               // Style sources
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               // Font sources

--- a/tests/design-audit/specs/03-prod-public-baseline.spec.ts
+++ b/tests/design-audit/specs/03-prod-public-baseline.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { captureRoute } from '../utils/capture'
+import { collectConsole } from '../utils/console-collector'
+import { publicRoutes } from '../fixtures/routes'
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'https://chainreact.app'
+const PHASE = 'prod-baseline'
+
+test.describe('Prod public-routes baseline', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  for (const route of publicRoutes()) {
+    if (route.needsSeed) continue
+    test(`[prod] ${route.slug}`, async ({ page }) => {
+      test.setTimeout(120_000)
+      const con = collectConsole(page, route.slug, PHASE)
+      const resp = await page
+        .goto(`${BASE}${route.path}`, { waitUntil: 'domcontentloaded', timeout: 25_000 })
+        .catch(() => null)
+      if (resp && resp.ok()) {
+        await captureRoute(page, route.slug, PHASE, { watchSkeletons: false })
+      }
+      con.flush()
+      expect(page.url()).toContain(BASE)
+    })
+  }
+})

--- a/tests/design-audit/specs/04-prod-public-a11y.spec.ts
+++ b/tests/design-audit/specs/04-prod-public-a11y.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { runAxe } from '../utils/axe-runner'
+import { waitForStable } from '../utils/stability'
+import { publicRoutes } from '../fixtures/routes'
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'https://chainreact.app'
+const PHASE = 'prod-a11y'
+
+for (const route of publicRoutes()) {
+  if (route.needsSeed) continue
+  test(`[prod-public-a11y] ${route.slug}`, async ({ page }) => {
+    test.setTimeout(60_000)
+    const resp = await page
+      .goto(`${BASE}${route.path}`, { waitUntil: 'domcontentloaded', timeout: 25_000 })
+      .catch(() => null)
+    if (!resp) return
+    await waitForStable(page)
+    const summary = await runAxe(page, route.slug, PHASE)
+    expect.soft(summary.criticalCount, `axe critical violations on ${route.slug}`).toBe(0)
+  })
+}


### PR DESCRIPTION
Surfaced by running the audit against production:

- /auth/sso-error: "Back to Login" pointed to /login (404) → /auth/login
- /auth/confirm: "help center" pointed to /help (404) → /support
- /request-integration: "Back to Home" pointed to /home (404) → /

CSP: added https://static.cloudflareinsights.com to script-src and script-src-elem so the Cloudflare Web Analytics beacon loads (85 console errors per session in prod baseline run).

Plus prod-targeted Playwright specs that hit chainreact.app directly for public routes (no auth needed).