### PR TITLE
Fix React #418 hydration mismatch in public headers

### DIFF
--- a/components/layout/PublicPageHeader.tsx
+++ b/components/layout/PublicPageHeader.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
@@ -13,6 +14,14 @@ interface PublicPageHeaderProps {
 export function PublicPageHeader({ breadcrumb }: PublicPageHeaderProps) {
   const router = useRouter()
   const { user } = useAuthStore()
+  // Auth state hydrates from localStorage on the client only; defer rendering of
+  // user-dependent text until after mount to avoid a hydration mismatch (React #418).
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const isAuthed = mounted && !!user
 
   return (
     <header className="sticky top-0 z-50 bg-white border-b border-gray-200">
@@ -26,10 +35,10 @@ export function PublicPageHeader({ breadcrumb }: PublicPageHeaderProps) {
           <span className="text-sm text-gray-500">{breadcrumb}</span>
         </div>
         <button
-          onClick={() => router.push(user ? "/workflows" : "/auth/register")}
+          onClick={() => router.push(isAuthed ? "/workflows" : "/auth/register")}
           className="inline-flex items-center gap-1.5 text-xs font-medium h-8 px-4 rounded-md bg-orange-600 text-white hover:bg-orange-700 transition-colors"
         >
-          {user ? "Go to Dashboard" : "Get Started"}
+          {isAuthed ? "Go to Dashboard" : "Get Started"}
           <ArrowRight className="w-3 h-3" />
         </button>
       </div>

--- a/components/temp-landing/TempHeader.tsx
+++ b/components/temp-landing/TempHeader.tsx
@@ -18,12 +18,18 @@ export function TempHeader() {
   const { user } = useAuthStore()
   const [menuOpen, setMenuOpen] = React.useState(false)
   const [scrolled, setScrolled] = React.useState(false)
+  // Defer auth-dependent CTA text until after mount so SSR ("Get started free")
+  // matches initial client render before localStorage hydrates the auth store.
+  const [mounted, setMounted] = React.useState(false)
 
   React.useEffect(() => {
+    setMounted(true)
     const handleScroll = () => setScrolled(window.scrollY > 20)
     window.addEventListener("scroll", handleScroll, { passive: true })
     return () => window.removeEventListener("scroll", handleScroll)
   }, [])
+
+  const isAuthed = mounted && !!user
 
   return (
     <header
@@ -65,7 +71,7 @@ export function TempHeader() {
 
         {/* Desktop CTA */}
         <div className="hidden md:flex items-center gap-3">
-          {user ? (
+          {isAuthed ? (
             <button
               onClick={() => router.push("/workflows")}
               className="inline-flex items-center gap-1.5 text-[13px] font-medium h-8 px-4 rounded-md bg-white text-slate-900 hover:bg-slate-100 transition-colors"
@@ -117,11 +123,11 @@ export function TempHeader() {
             ))}
             <div className="pt-2 border-t border-slate-800 mt-2">
               <Link
-                href={user ? "/workflows" : "/auth/register"}
+                href={isAuthed ? "/workflows" : "/auth/register"}
                 onClick={() => setMenuOpen(false)}
                 className="block w-full text-center bg-white text-slate-900 text-sm font-medium py-2.5 rounded-md hover:bg-slate-100 transition-colors"
               >
-                {user ? "Dashboard" : "Get started free"}
+                {isAuthed ? "Dashboard" : "Get started free"}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Fixes a hydration mismatch surfaced by the post-deploy audit on `/privacy` and `/terms`.

`PublicPageHeader` and `TempHeader` render different CTA text based on `useAuthStore().user`:
- Logged out: "Get Started" / "Get started free"
- Logged in: "Go to Dashboard" / "Dashboard"

The auth store hydrates from `localStorage` **on the client only**. The server-rendered HTML always shows the logged-out text, so logged-in returning users get a hydration mismatch on first paint of any page using these headers — React error #418.

## Fix
Standard `next-themes`-style mount gate:

```tsx
const [mounted, setMounted] = useState(false)
useEffect(() => { setMounted(true) }, [])
const isAuthed = mounted && !!user
```

Server + initial client render both show the logged-out text; post-mount client render swaps it. No flash for logged-out users; one short paint of "Get Started" → "Go to Dashboard" for returning logged-in users (acceptable tradeoff vs broken hydration).

## Pages that benefit
Every page using `PublicPageHeader`: `/about`, `/contact`, `/privacy`, `/terms`, `/security`, `/sub-processors`, `/support`, `/request-integration`.
Plus `TempHeader` on the marketing landing.

## Test plan
- [ ] Visit `/privacy` while logged in. Console should show no React error #418.
- [ ] Visit `/privacy` while logged out. CTA shows "Get Started".
- [ ] Visit `/` (landing) while logged in. CTA briefly shows "Get started free" then "Dashboard"; no React #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)