### PR TITLE
Fix React #418 on /privacy + /terms — replace HTML entities with Unicode

### DIFF
--- a/components/legal/PrivacyPolicy.tsx
+++ b/components/legal/PrivacyPolicy.tsx
@@ -16,7 +16,7 @@ export function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-xl font-semibold text-gray-900 mb-4">1. Introduction</h2>
             <p className="text-gray-600 mb-4">
-              Welcome to ChainReact (&ldquo;we,&rdquo; &ldquo;our,&rdquo; or &ldquo;us&rdquo;). We are committed to protecting your privacy and ensuring the
+              Welcome to ChainReact (“we,” “our,” or “us”). We are committed to protecting your privacy and ensuring the
               security of your personal information. This Privacy Policy explains how we collect, use, disclose, and
               safeguard your information when you use our workflow automation platform and services.
             </p>
@@ -175,7 +175,7 @@ export function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">10. Children&apos;s Privacy</h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">10. Children’s Privacy</h2>
             <p className="text-gray-600">
               Our services are not intended for children under 13 years of age. We do not knowingly collect personal
               information from children under 13. If you become aware that a child has provided us with personal
@@ -187,7 +187,7 @@ export function PrivacyPolicy() {
             <h2 className="text-xl font-semibold text-gray-900 mb-4">11. Changes to This Privacy Policy</h2>
             <p className="text-gray-600">
               We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new
-              Privacy Policy on this page and updating the &ldquo;Last updated&rdquo; date. We encourage you to review this Privacy
+              Privacy Policy on this page and updating the “Last updated” date. We encourage you to review this Privacy
               Policy periodically.
             </p>
           </section>

--- a/components/legal/TermsOfService.tsx
+++ b/components/legal/TermsOfService.tsx
@@ -16,8 +16,8 @@ export function TermsOfService() {
           <section className="mb-8">
             <h2 className="text-xl font-semibold text-gray-900 mb-4">1. Acceptance of Terms</h2>
             <p className="text-gray-600 mb-4">
-              Welcome to ChainReact. These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the ChainReact platform and
-              services (&ldquo;Service&rdquo;) operated by ChainReact, Inc. (&ldquo;us&rdquo;, &ldquo;we&rdquo;, or &ldquo;our&rdquo;).
+              Welcome to ChainReact. These Terms of Service (“Terms”) govern your use of the ChainReact platform and
+              services (“Service”) operated by ChainReact, Inc. (“us”, “we”, or “our”).
             </p>
             <p className="text-gray-600">
               By accessing or using our Service, you agree to be bound by these Terms. If you disagree with any part of
@@ -171,7 +171,7 @@ export function TermsOfService() {
             <h3 className="text-lg font-semibold text-gray-900 mb-3">10.1 Service Availability</h3>
             <p className="text-gray-600 mb-4">
               We strive to maintain high availability but cannot guarantee that the Service will be available 100% of
-              the time. The Service is provided &ldquo;as is&rdquo; without warranties of any kind.
+              the time. The Service is provided “as is” without warranties of any kind.
             </p>
 
             <h3 className="text-lg font-semibold text-gray-900 mb-3">10.2 Limitation of Liability</h3>
@@ -222,7 +222,7 @@ export function TermsOfService() {
             <h2 className="text-xl font-semibold text-gray-900 mb-4">14. Changes to Terms</h2>
             <p className="text-gray-600">
               We reserve the right to modify these Terms at any time. We will notify you of any changes by posting the
-              new Terms on this page and updating the &ldquo;Last updated&rdquo; date. Your continued use of the Service after such
+              new Terms on this page and updating the “Last updated” date. Your continued use of the Service after such
               changes constitutes acceptance of the new Terms.
             </p>
           </section>


### PR DESCRIPTION
The PublicPageHeader fix from the prior commit handled the auth-store hydration path, but /privacy and /terms still showed React #418 in the prod baseline (4× per session). They were the only routes affected.

Root cause: PrivacyPolicy.tsx and TermsOfService.tsx use HTML entities (&ldquo;, &rdquo;, &apos;) in JSX text content. React serializes these differently in SSR streaming vs client parsing in some cases — specifically the smart-quote variants — producing a "Text content does not match server-rendered HTML" mismatch on first hydration.

Comparison with /security which uses the same shell (PublicPageHeader, TempFooter, ForceTheme) but has zero HTML entities — and /security shows no React #418.

Fix: replace HTML entities with the literal Unicode characters they represent (U+201C, U+201D, U+2019). Visual rendering is unchanged (curly typographic quotes), but the JSX text now passes through React without any entity-decoding round-trip.

Attribute strings (className="...") remain ASCII; only text-content entities were touched.