### PR TITLE
Fix React #418: Cloudflare email obfuscation breaks hydration

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -40,7 +40,7 @@ export default function ContactPage() {
           <div className="bg-white border border-gray-200 rounded-lg p-4">
             <Mail className="w-4 h-4 text-orange-500 mb-2" />
             <p className="text-xs font-medium text-gray-700">Email</p>
-            <p className="text-xs text-gray-500">support@chainreact.app</p>
+            <p className="text-xs text-gray-500">support<span>@</span>chainreact.app</p>
           </div>
           <div className="bg-white border border-gray-200 rounded-lg p-4">
             <MessageSquare className="w-4 h-4 text-orange-500 mb-2" />

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -84,7 +84,7 @@ export default function SecurityPage() {
               href="mailto:security@chainreact.app"
               className="text-orange-600 underline hover:text-orange-700 transition-colors"
             >
-              security@chainreact.app
+              security<span>@</span>chainreact.app
             </a>
             . We take all reports seriously and will respond promptly.
           </p>

--- a/components/legal/PrivacyPolicy.tsx
+++ b/components/legal/PrivacyPolicy.tsx
@@ -136,7 +136,7 @@ export function PrivacyPolicy() {
               </li>
             </ul>
             <p className="text-gray-600 mt-4">
-              To exercise these rights, please contact us at privacy@chainreact.app.
+              To exercise these rights, please contact us at privacy<span>@</span>chainreact.app.
             </p>
           </section>
 
@@ -199,7 +199,7 @@ export function PrivacyPolicy() {
             </p>
             <div className="bg-gray-50 border border-gray-200 p-4 rounded-lg">
               <p className="text-gray-600 text-sm">
-                <strong className="text-gray-900">Email:</strong> privacy@chainreact.app
+                <strong className="text-gray-900">Email:</strong> privacy<span>@</span>chainreact.app
               </p>
             </div>
           </section>

--- a/components/legal/TermsOfService.tsx
+++ b/components/legal/TermsOfService.tsx
@@ -232,7 +232,7 @@ export function TermsOfService() {
             <p className="text-gray-600 mb-4">If you have any questions about these Terms, please contact us:</p>
             <div className="bg-gray-50 border border-gray-200 p-4 rounded-lg">
               <p className="text-gray-600 text-sm">
-                <strong className="text-gray-900">Email:</strong> legal@chainreact.app
+                <strong className="text-gray-900">Email:</strong> legal<span>@</span>chainreact.app
               </p>
             </div>
           </section>


### PR DESCRIPTION
Real root cause of the persistent React error #418 on /privacy and /terms — confirmed via direct diff of server-rendered HTML vs post-hydration DOM:

  SERVER:  ...contact us at <a href="/cdn-cgi/l/email-protection"
           class="__cf_email__"
           data-cfemail="...">[email&#160;protected]</a>...
  CLIENT:  ...contact us at privacy@chainreact.app...

Cloudflare's "Email Address Obfuscation" feature rewrites plain-text email addresses in the SSR response into <a class="__cf_email__"> tags on the way to the browser, then a CF client script decodes them back. React's hydration sees different text in the same DOM position and throws "Text content does not match server-rendered HTML" (#418).

Fix: split the @ into its own <span> in JSX text content. Same visual output (`privacy@chainreact.app` looks identical), but Cloudflare's regex matcher (which scans serialized HTML) won't recognize it as an email across the tag boundary.

Pages touched:
  - components/legal/PrivacyPolicy.tsx (2× emails)
  - components/legal/TermsOfService.tsx (1×)
  - app/contact/page.tsx (1×)
  - app/security/page.tsx (1× in <a> link text — href stays as mailto: which CF doesn't obfuscate)

Long-term fix: disable Email Address Obfuscation in the Cloudflare dashboard (Speed → Optimization or Scrape Shield → Email Address Obfuscation). It's a deliberately-enabled feature that breaks any React app rendering emails in JSX text.