### PR TITLE
OAuth bypass email-confirmed + Profile Picture redesign + /org route

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -115,19 +115,27 @@ export async function GET(request: NextRequest) {
         .single()
       
       const isNewUser = !existingProfile
-      
+
+      // Determine the auth provider — OAuth users (google, github, etc.) should skip
+      // the email-confirmed success page entirely and go straight to the app.
+      const authProvider = data.user.app_metadata?.provider
+      const isOAuthProvider = !!authProvider && authProvider !== 'email'
+
       // Check if this is a recent email confirmation (within last 15 minutes of creation)
-      const userCreatedRecently = data.user.created_at && 
+      const userCreatedRecently = data.user.created_at &&
         (new Date().getTime() - new Date(data.user.created_at).getTime() < 900000) // 15 minutes
-      
+
       // Check if the email was recently confirmed (within last minute)
       const emailJustConfirmed = data.user.email_confirmed_at &&
         (new Date().getTime() - new Date(data.user.email_confirmed_at).getTime() < 60000) // 1 minute
-      
+
       // Determine if this is an email confirmation flow
-      // Priority: explicit type param > recent confirmation > new user detection
-      const isEmailConfirmation = type === 'email-confirmation' ||
+      // OAuth providers (Google, GitHub, etc.) are never an email-confirmation flow —
+      // their `email_confirmed_at` is set automatically by the provider on first sign-in.
+      const isEmailConfirmation = !isOAuthProvider && (
+        type === 'email-confirmation' ||
         (data.user.email_confirmed_at && (isNewUser || userCreatedRecently || emailJustConfirmed))
+      )
 
       logger.info('Auth callback - Email confirmation check:', {
         isNewUser,

--- a/components/common/AccessGuard.tsx
+++ b/components/common/AccessGuard.tsx
@@ -23,14 +23,14 @@ const PAGE_DISPLAY_NAMES: Record<string, string> = {
   '/ai-assistant': 'Assistant',
   '/analytics': 'Analytics',
   '/teams': 'Teams',
-  '/organization': 'Organization',
+  '/org': 'Organization',
 }
 
 const PAGE_DESCRIPTIONS: Record<string, string> = {
   '/ai-assistant': 'Build workflows faster with AI-powered assistance',
   '/analytics': 'Track workflow performance and usage metrics',
   '/teams': 'Collaborate with your team on shared workflows and integrations',
-  '/organization': 'Manage your organization, teams, members, and shared resources',
+  '/org': 'Manage your organization, teams, members, and shared resources',
 }
 
 /**
@@ -94,26 +94,36 @@ export function AccessGuard({ pathname, children }: AccessGuardProps) {
   const displayName = PAGE_DISPLAY_NAMES[pathname] ?? pathname.replace(/^\//, '').replace(/-/g, ' ')
   const description = PAGE_DESCRIPTIONS[pathname] ?? `Access ${displayName} features`
 
-  // Get features for the required plan, filtering out "Everything in X" lines
+  // Top 5 features keeps the card short enough to fit any reasonable viewport without
+  // a scrollbar. Plan feature arrays are ordered by importance, so head-of-list wins.
   const requiredPlanFeatures = (getPlanFeatures(requiredPlan) ?? [])
     .filter((f: string) => !f.startsWith('Everything in'))
+    .slice(0, 5)
+  const totalFeatureCount = (getPlanFeatures(requiredPlan) ?? [])
+    .filter((f: string) => !f.startsWith('Everything in'))
+    .length
+  const remainingFeatureCount = Math.max(0, totalFeatureCount - requiredPlanFeatures.length)
 
   return (
-    <div className="relative min-h-[60vh] w-full">
-      {/* Page content rendered but blurred - sidebar stays interactive */}
-      <div className="blur-sm pointer-events-none select-none opacity-40">
-        {children}
+    <div className="relative w-full min-h-[calc(100dvh-10rem)]">
+      {/* Blurred page content rendered as a clipped background so it never inflates the
+          section beyond the visible viewport (which would push the modal off-screen
+          and force a page scrollbar). */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="blur-sm select-none opacity-40">
+          {children}
+        </div>
       </div>
 
-      {/* Modal overlay - covers only content area, not sidebar. Top-aligned with padding so heading is always visible; scrolls if card is taller than viewport. */}
-      <div className="absolute inset-0 flex items-start justify-center z-10 overflow-y-auto py-8">
-        <div className="max-w-lg w-full mx-6 bg-white dark:bg-slate-900 rounded-xl border border-border shadow-xl p-8">
-          <div className="space-y-5">
-            <div className="text-center space-y-2">
-              <div className="mx-auto w-12 h-12 rounded-full bg-orange-50 dark:bg-orange-900/20 flex items-center justify-center">
-                <Lock className="w-6 h-6 text-orange-500" />
+      {/* Modal centered in the visible content area on every screen size. */}
+      <div className="relative min-h-[calc(100dvh-10rem)] flex items-center justify-center z-10 p-4">
+        <div className="max-w-md w-full bg-white dark:bg-slate-900 rounded-xl border border-border shadow-xl p-6">
+          <div className="space-y-4">
+            <div className="text-center space-y-1.5">
+              <div className="mx-auto w-10 h-10 rounded-full bg-orange-50 dark:bg-orange-900/20 flex items-center justify-center">
+                <Lock className="w-5 h-5 text-orange-500" />
               </div>
-              <h2 className="text-xl font-semibold text-foreground">
+              <h2 className="text-lg font-semibold text-foreground">
                 Unlock {displayName}
               </h2>
               <p className="text-sm text-muted-foreground">
@@ -122,25 +132,30 @@ export function AccessGuard({ pathname, children }: AccessGuardProps) {
             </div>
 
             {/* Plan card with benefits */}
-            <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-5 border border-border">
-              <div className="flex items-center justify-between mb-4">
+            <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-4 border border-border">
+              <div className="flex items-center justify-between mb-3">
                 <div className="flex items-center gap-2">
                   <Sparkles className="w-4 h-4 text-orange-500" />
                   <span className="font-semibold text-foreground">{planInfo.name} Plan</span>
                 </div>
-                <span className="text-lg font-bold text-foreground">
+                <span className="text-base font-bold text-foreground">
                   ${planInfo.price}<span className="text-sm font-normal text-muted-foreground">/mo</span>
                 </span>
               </div>
 
               {/* Benefits list */}
-              <ul className="space-y-2.5">
+              <ul className="space-y-2">
                 {requiredPlanFeatures.map((feature) => (
-                  <li key={feature} className="flex items-start gap-2.5">
+                  <li key={feature} className="flex items-start gap-2">
                     <Check className="w-4 h-4 text-orange-500 mt-0.5 shrink-0" />
-                    <span className="text-sm text-foreground">{feature}</span>
+                    <span className="text-sm text-foreground leading-snug">{feature}</span>
                   </li>
                 ))}
+                {remainingFeatureCount > 0 && (
+                  <li className="text-xs text-muted-foreground pl-6">
+                    + {remainingFeatureCount} more
+                  </li>
+                )}
               </ul>
             </div>
 

--- a/components/new-design/SettingsContentSidebar.tsx
+++ b/components/new-design/SettingsContentSidebar.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { useToast } from "@/hooks/use-toast"
 import { createClient } from "@/utils/supabaseClient"
-import { User, Bell, Shield, ShieldCheck, ShieldOff, Palette, Loader2, Sparkles, Camera, Key, Fingerprint, Monitor, LogOut } from "lucide-react"
+import { User, Bell, Shield, ShieldCheck, ShieldOff, Palette, Loader2, Sparkles, Camera, Key, Fingerprint, Monitor, LogOut, X } from "lucide-react"
 import { useTheme } from "next-themes"
 import { TwoFactorSetup } from "@/components/settings/TwoFactorSetup"
 import { SessionManagement } from "@/components/settings/SessionManagement"
@@ -57,13 +57,52 @@ export function SettingsContent({ initialSection }: SettingsContentProps) {
   const [newEmail, setNewEmail] = useState("")
   const [emailChanging, setEmailChanging] = useState(false)
   const [showEmailChange, setShowEmailChange] = useState(false)
+
+  // Avatar state
   const [avatarUploading, setAvatarUploading] = useState(false)
+  const [avatarDeleting, setAvatarDeleting] = useState(false)
   const [avatarError, setAvatarError] = useState<string | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [avatarImageError, setAvatarImageError] = useState(false)
+  const [gravatarFallbackUrl, setGravatarFallbackUrl] = useState<string | null>(null)
   const avatarInputRef = useRef<HTMLInputElement>(null)
 
-  const displayAvatarUrl = previewUrl || profile?.avatar_url
+  // Compute Gravatar URL from the user's email (SHA-256, ?d=404 so missing Gravatars 404)
+  const userEmail = (profile?.email || user?.email || "").trim().toLowerCase()
+  useEffect(() => {
+    if (!userEmail) {
+      setGravatarFallbackUrl(null)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const encoded = new TextEncoder().encode(userEmail)
+        const digest = await crypto.subtle.digest("SHA-256", encoded)
+        const hash = Array.from(new Uint8Array(digest))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("")
+        if (!cancelled) {
+          setGravatarFallbackUrl(`https://www.gravatar.com/avatar/${hash}?s=200&d=404`)
+        }
+      } catch {
+        if (!cancelled) setGravatarFallbackUrl(null)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [userEmail])
+
+  const displayAvatarUrl = previewUrl || profile?.avatar_url || gravatarFallbackUrl || undefined
   const { signedUrl: avatarSignedUrl } = useSignedAvatarUrl(displayAvatarUrl)
+  const hasUsableAvatar = !!avatarSignedUrl && !avatarImageError
+  // The X delete badge should only appear for an explicitly-set avatar — not for the Gravatar fallback
+  const hasExplicitAvatar = !!(previewUrl || profile?.avatar_url)
+
+  // Reset image-load error whenever the source URL changes
+  useEffect(() => {
+    setAvatarImageError(false)
+  }, [avatarSignedUrl])
+
   const [show2FASetup, setShow2FASetup] = useState(false)
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(false)
   const [twoFactorLoading, setTwoFactorLoading] = useState(true)
@@ -381,6 +420,30 @@ export function SettingsContent({ initialSection }: SettingsContentProps) {
     avatarInputRef.current?.click()
   }
 
+  const handleDeleteAvatar = async () => {
+    if (!profile?.avatar_url && !previewUrl) return
+
+    setAvatarError(null)
+    setAvatarDeleting(true)
+
+    try {
+      if (profile?.avatar_url?.includes("/user-avatars/")) {
+        const [, path] = profile.avatar_url.split("/user-avatars/")
+        if (path) {
+          await supabase.storage.from("user-avatars").remove([path]).catch(() => {})
+        }
+      }
+
+      setPreviewUrl(null)
+      await updateProfile({ avatar_url: null })
+      toast({ title: "Profile photo removed" })
+    } catch (error: any) {
+      setAvatarError(error?.message || "Unable to remove profile photo. Please try again.")
+    } finally {
+      setAvatarDeleting(false)
+    }
+  }
+
   const handleAvatarChange = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     if (!file) return
@@ -510,6 +573,117 @@ export function SettingsContent({ initialSection }: SettingsContentProps) {
 
       <div className="space-y-6 pb-16">
 
+        {/* ═══════════ Profile Picture ═══════════ */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-1">
+              <Camera className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-base font-semibold text-foreground">Profile Picture</h2>
+            </div>
+            <p className="text-sm text-muted-foreground mb-5">Your profile picture is visible to other members of your organization.</p>
+
+            <div className="flex items-center gap-4">
+              <div className="relative group">
+                <div className="w-16 h-16 rounded-full overflow-hidden bg-muted border-2 border-border">
+                  {hasUsableAvatar ? (
+                    <img
+                      src={avatarSignedUrl!}
+                      alt="Profile"
+                      className="w-full h-full object-cover"
+                      onError={() => setAvatarImageError(true)}
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-muted-foreground text-lg font-semibold">
+                      {(profile?.full_name || user?.email || "?")[0]?.toUpperCase()}
+                    </div>
+                  )}
+                </div>
+                <button
+                  onClick={handleAvatarButtonClick}
+                  disabled={avatarUploading || avatarDeleting}
+                  aria-label={avatarUploading ? "Uploading profile photo" : "Change profile photo"}
+                  className="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                >
+                  {avatarUploading ? (
+                    <Loader2 className="w-5 h-5 text-white animate-spin" />
+                  ) : (
+                    <Camera className="w-5 h-5 text-white" />
+                  )}
+                </button>
+                {hasExplicitAvatar && hasUsableAvatar && !avatarUploading && (
+                  <button
+                    onClick={handleDeleteAvatar}
+                    disabled={avatarDeleting}
+                    aria-label="Remove profile photo"
+                    className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-red-500 hover:bg-red-600 text-white flex items-center justify-center shadow-sm border-2 border-background opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity disabled:opacity-50"
+                  >
+                    {avatarDeleting ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <X className="w-3 h-3" strokeWidth={3} />
+                    )}
+                  </button>
+                )}
+                <input
+                  ref={avatarInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  onChange={handleAvatarChange}
+                  className="hidden"
+                />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Click your photo to upload. PNG, JPG, or GIF. Max 1.5MB.</p>
+                <a
+                  href="https://gravatar.com/profile"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 mt-2 text-sm font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-500 dark:hover:text-emerald-400 group/gravatar"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="w-4 h-4"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M12 2L21 7V17L12 22L3 17V7L12 2Z"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M8 12L11 15L16 9"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <span>Edit Gravatar</span>
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="w-3 h-3 transition-transform group-hover/gravatar:translate-x-0.5 group-hover/gravatar:-translate-y-0.5"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M7 17L17 7M17 7H8M17 7V16"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </a>
+                {avatarError && <p className="text-xs text-red-500 mt-1">{avatarError}</p>}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
         {/* ═══════════ Profile ═══════════ */}
         <Card id="section-account">
           <CardContent className="pt-6">
@@ -519,55 +693,14 @@ export function SettingsContent({ initialSection }: SettingsContentProps) {
             </div>
             <p className="text-sm text-muted-foreground mb-5">Your personal information associated with this account.</p>
 
-            <div className="space-y-5">
-              {/* Avatar upload */}
-              <div className="flex items-center gap-4">
-                <div className="relative group">
-                  <div className="w-16 h-16 rounded-full overflow-hidden bg-muted border-2 border-border">
-                    {avatarSignedUrl ? (
-                      <img src={avatarSignedUrl} alt="Profile" className="w-full h-full object-cover" />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-muted-foreground text-lg font-semibold">
-                        {(profile?.full_name || user?.email || "?")[0]?.toUpperCase()}
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    onClick={handleAvatarButtonClick}
-                    disabled={avatarUploading}
-                    aria-label={avatarUploading ? "Uploading profile photo" : "Change profile photo"}
-                    className="absolute inset-0 rounded-full bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
-                  >
-                    {avatarUploading ? (
-                      <Loader2 className="w-5 h-5 text-white animate-spin" />
-                    ) : (
-                      <Camera className="w-5 h-5 text-white" />
-                    )}
-                  </button>
-                  <input
-                    ref={avatarInputRef}
-                    type="file"
-                    accept="image/png,image/jpeg,image/gif,image/webp"
-                    onChange={handleAvatarChange}
-                    className="hidden"
-                  />
-                </div>
-                <div>
-                  <p className="text-sm font-medium">Profile photo</p>
-                  <p className="text-xs text-muted-foreground">Click to upload. PNG, JPG, or GIF. Max 1.5MB.</p>
-                  {avatarError && <p className="text-xs text-red-500 mt-1">{avatarError}</p>}
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="full-name" className="text-sm font-medium">Full name</Label>
-                <Input
-                  id="full-name"
-                  value={fullName}
-                  onChange={(e) => setFullName(e.target.value)}
-                  placeholder="Your name"
-                />
-              </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="full-name" className="text-sm font-medium">Full name</Label>
+              <Input
+                id="full-name"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                placeholder="Your name"
+              />
             </div>
 
             <div className="flex justify-end mt-5">

--- a/lib/access-policy/routeConfig.ts
+++ b/lib/access-policy/routeConfig.ts
@@ -11,7 +11,7 @@ export const ROUTE_ACCESS: Record<string, RouteRule> = {
   '/ai-assistant': { minPlan: 'pro', upgradeModal: true },
   '/analytics': { minPlan: 'pro', upgradeModal: true },
   '/teams': { minPlan: 'team', upgradeModal: true },
-  '/organization': { minPlan: 'business', upgradeModal: true },
+  '/org': { minPlan: 'business', upgradeModal: true },
   // allowedPlansExact (not minPlan) because /enterprise is gated to the enterprise
   // billing tier specifically - admin bypasses via isAdmin, not via plan hierarchy
   '/enterprise': { allowedPlansExact: ['enterprise'] },

--- a/middleware.ts
+++ b/middleware.ts
@@ -165,7 +165,7 @@ export const config = {
     '/integrations/:path*',
     '/analytics/:path*',
     '/teams/:path*',
-    '/organization/:path*',
+    '/org/:path*',
     '/ai-assistant/:path*',
     '/admin/:path*',
     '/settings/:path*',

--- a/stores/authBootMachine.ts
+++ b/stores/authBootMachine.ts
@@ -34,7 +34,7 @@ export interface Profile {
   full_name?: string
   first_name?: string
   last_name?: string
-  avatar_url?: string
+  avatar_url?: string | null
   company?: string
   job_title?: string
   secondary_email?: string


### PR DESCRIPTION
## Summary

Two independent changes bundled into one PR (one commit each, easy to review separately):

**Commit 1 — Auth + profile picture redesign** ([1e8fc0de5](https://github.com/Chain-React-Org/chainreact-app/commit/1e8fc0de5))
- OAuth sign-ins (Google etc.) now skip `/auth/email-confirmed` and go straight to `/workflows`. Their `email_confirmed_at` is set by the provider, not by an email-confirmation flow.
- New "Profile Picture" card in settings with camera-icon header and "Your profile picture is visible to other members of your organization." description.
- Avatar circle keeps hover-to-upload (camera) and hover-to-delete (X badge). X only shows for an *explicit* avatar — not for the Gravatar fallback.
- Avatar fallback chain: uploaded preview → stored `avatar_url` → Gravatar (SHA-256 of email, `?d=404`) → initials. Stale/broken URLs trip `<img onError>` and fall through.
- Green "Edit Gravatar" link out to gravatar.com.
- Widened `Profile.avatar_url` type from `string` to `string | null` so deletes can null the column.

**Commit 2 — `/organization` → `/org` route rename + AccessGuard polish** ([9ecd25eef](https://github.com/Chain-React-Org/chainreact-app/commit/9ecd25eef))
- `routeConfig`, `middleware` matcher, and AccessGuard display-name/description maps all updated to `/org`.
- AccessGuard modal: clipped blurred background, top-5 plan features with overflow indicator, smaller modal sizing — fits any viewport without page scrollbar.

## Test plan

- [ ] Sign in with Google as an existing user → land on `/workflows` (not email-confirmed page)
- [ ] Sign up via email + click confirmation link → still lands on email-confirmed page
- [ ] Settings → Profile Picture: hover avatar → camera icon shows, click → file picker
- [ ] Upload PNG/JPG → avatar updates, hover X → deletes, falls back to Gravatar/initials
- [ ] Account with no `avatar_url` and a Gravatar → Gravatar renders automatically
- [ ] Account with no `avatar_url` and no Gravatar → initials render
- [ ] "Edit Gravatar" link opens gravatar.com in new tab
- [ ] Visit `/org` on free plan → AccessGuard modal appears, fits viewport
- [ ] Visit `/organization` on any plan → no longer matched by middleware
- [ ] AccessGuard plan card shows top 5 features + overflow indicator if more

🤖 Generated with [Claude Code](https://claude.com/claude-code)