### PR TITLE
fix(builder): connection-required dialog mis-flagged built-in providers

### DIFF
--- a/components/workflows/builder/DisconnectedIntegrationsDialog.tsx
+++ b/components/workflows/builder/DisconnectedIntegrationsDialog.tsx
@@ -14,10 +14,16 @@ import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw } from "l
 import { cn } from "@/lib/utils"
 import { getProviderDisplayName, getProviderIcon } from "@/lib/workflows/ai-agent/providerDisambiguation"
 
-// Providers that don't need OAuth connection
+// Built-in providers that don't need OAuth connection. Sourced from a
+// grep of `providerId:` across lib/workflows/nodes/providers/ — only the
+// IDs that actually appear in node schemas are listed.
 const CONNECTION_EXEMPT_PROVIDERS = [
-  'logic', 'mapper', 'core', 'manual', 'schedule', 'delay', 'filter',
-  'ai', 'ai_agent', 'ai_router', 'webhook', 'http', 'utility', 'transformer'
+  'ai',          // AI Agent / AI Router (platform-managed keys)
+  'ask-human',   // HITL Conversation
+  'automation',  // Manual Trigger, Wait-for-Event
+  'logic',       // if/router/loop/delay/http_request
+  'utility',     // built-in utility nodes
+  'webhook',     // built-in webhook trigger (HMAC-secured, no OAuth)
 ]
 
 interface DisconnectedIntegration {


### PR DESCRIPTION
`DisconnectedIntegrationsDialog.getDisconnectedIntegrations` filtered nodes against `CONNECTION_EXEMPT_PROVIDERS`, but the list was a stale mix of strings — half didn't match any actual providerId in the node schemas, while real built-ins were missing.

Real symptoms:
  - Workflows with a Manual Trigger (`providerId: 'automation'`) hit the dialog and tried to OAuth-connect "automation". No such /api/oauth/automation/authorize endpoint exists, so the dialog span on "Connecting…" forever.
  - Same for HITL Conversation (`providerId: 'ask-human'`).

Replaced the fuzzy/stale list with the exact set of built-in providerIds that appear in `lib/workflows/nodes/providers/*` and don't have an OAuth flow:

  ai, ask-human, automation, logic, utility, webhook

Verified by grepping every `providerId:` occurrence in lib/workflows/nodes/providers/ — every other ID is a real third-party integration with an OAuth flow at /api/oauth/{provider}/authorize.

Removed: 'mapper', 'core', 'manual', 'schedule', 'delay', 'filter', 'ai_agent', 'ai_router', 'http', 'transformer'. None match any actual providerId; safe to drop pre-launch.