### PR TITLE
feat(oauth): thread PKCE verifier from oauth_states row through dispatcher

### DIFF
--- a/contracts/integration.ts
+++ b/contracts/integration.ts
@@ -105,6 +105,17 @@ export interface ProviderAccountInfo {
 }
 
 /**
+ * PKCE inputs persisted on the `oauth_states` row at connect time and
+ * forwarded to the provider's callback handler at consume time. The
+ * `codeVerifier` is the secret half — it lives only on the row, never in
+ * the signed state JWT.
+ */
+export interface PkceInputs {
+  codeVerifier: string;
+  codeChallengeMethod: string;
+}
+
+/**
  * Per-provider OAuth implementation. Each provider in `integrations/<id>/oauth.ts`
  * exports an object that satisfies this shape. The generic dispatcher in
  * `services/oauth/dispatcher.ts` is the only caller.
@@ -112,10 +123,15 @@ export interface ProviderAccountInfo {
 export interface ProviderOAuth {
   /** Builds the redirect URL the user is sent to. `state` is the signed token from createState(). */
   buildAuthUrl(state: string, scopes: readonly string[]): string;
-  /** Exchanges the authorization code for tokens. */
+  /**
+   * Exchanges the authorization code for tokens. `pkce` is non-null only for
+   * providers that asked the dispatcher to issue a PKCE challenge at connect
+   * time (manifest-driven). Non-PKCE providers receive `null` and ignore it.
+   */
   handleCallback(
     code: string,
     state: string,
+    pkce: PkceInputs | null,
   ): Promise<{ tokens: EncryptedTokens; account: ProviderAccountInfo }>;
   /** Returns fresh tokens, or throws RefreshNotSupportedError on non-refreshable providers. */
   refreshToken(refreshToken: string): Promise<EncryptedTokens>;

--- a/services/oauth/dispatcher.ts
+++ b/services/oauth/dispatcher.ts
@@ -78,7 +78,10 @@ export async function handleCallback(
   // We consume BEFORE checking provider mismatch on purpose: a malformed
   // request (wrong provider in URL but valid state) still uses up the nonce
   // so it can't be replayed against the correct provider's route either.
-  const payload = await consumeState(input.state);
+  //
+  // pkce is non-null only for providers whose connect path issued a PKCE
+  // challenge (Gmail and future PKCE providers). Slack default v2 → null.
+  const { payload, pkce } = await consumeState(input.state);
   if (payload.provider !== input.provider) {
     throw new InvalidStateError("provider mismatch between state and route");
   }
@@ -90,7 +93,7 @@ export async function handleCallback(
     );
   }
 
-  const { tokens, account } = await oauth.handleCallback(input.code, input.state);
+  const { tokens, account } = await oauth.handleCallback(input.code, input.state, pkce);
 
   const integration = await upsertActive({
     userId: payload.userId,

--- a/services/oauth/state.ts
+++ b/services/oauth/state.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { PkceInputs } from "@/contracts/integration";
 import * as oauthStatesRepo from "@/repositories/oauthStates";
 
 /**
@@ -153,6 +154,18 @@ export function verifyState(token: string): OAuthStatePayload {
 }
 
 /**
+ * Result of a successful state consume: the verified JWT payload plus any
+ * PKCE inputs persisted on the row at create time. `pkce` is null for
+ * providers whose connect path didn't issue a PKCE challenge (Slack default
+ * v2). PKCE-enabled providers receive a non-null `{ codeVerifier,
+ * codeChallengeMethod }` to forward to their token endpoint.
+ */
+export interface ConsumeStateResult {
+  payload: OAuthStatePayload;
+  pkce: PkceInputs | null;
+}
+
+/**
  * The dispatcher's callback path uses this. It does verifyState (signature +
  * expiry) AND atomically consumes the DB row in one step. A second call with
  * the same token throws InvalidStateError("already consumed or expired") —
@@ -162,7 +175,7 @@ export function verifyState(token: string): OAuthStatePayload {
  * without touching the DB); DB consume second. The atomic delete-if-fresh
  * makes concurrent consumes race-safe — only one wins, the other rejects.
  */
-export async function consumeState(token: string): Promise<OAuthStatePayload> {
+export async function consumeState(token: string): Promise<ConsumeStateResult> {
   const payload = verifyState(token);
   const row = await oauthStatesRepo.consumeByNonce(payload.nonce);
   if (!row) {
@@ -173,5 +186,14 @@ export async function consumeState(token: string): Promise<OAuthStatePayload> {
     // upstream is broken (key rotation mid-flow, DB tampering, …). Fail safe.
     throw new InvalidStateError("state row mismatch");
   }
-  return payload;
+  // createState writes both PKCE fields together (or neither). A
+  // half-populated row indicates upstream corruption — treat as invalid and
+  // ignore by returning pkce: null. This slice doesn't add a stricter mode;
+  // a future provider that requires PKCE can throw on null pkce inside its
+  // own handleCallback.
+  const pkce =
+    row.pkceCodeVerifier !== null && row.pkceCodeChallengeMethod !== null
+      ? { codeVerifier: row.pkceCodeVerifier, codeChallengeMethod: row.pkceCodeChallengeMethod }
+      : null;
+  return { payload, pkce };
 }

--- a/tests/__mocks__/integrations/_pkceMockProvider/oauth.ts
+++ b/tests/__mocks__/integrations/_pkceMockProvider/oauth.ts
@@ -1,0 +1,71 @@
+import type { ProviderOAuth, PkceInputs } from "@/contracts/integration";
+
+/**
+ * Test-only PKCE-aware mock provider.
+ *
+ * Slice 2a ships PKCE plumbing through the OAuth dispatcher but no real
+ * PKCE-using provider yet (Gmail lands in 2c). This factory returns a
+ * `ProviderOAuth` whose `handleCallback` captures whatever `pkce` argument
+ * the dispatcher threads through, so tests can assert the plumbing without
+ * coupling to a real provider's network shape.
+ *
+ * NOT registered in `integrations/_registry.ts` — it lives under
+ * `tests/__mocks__` and is only imported by tests. Production code never
+ * sees it.
+ *
+ * Reusable beyond the dispatcher tests: future Gmail tests (Slice 2c) can
+ * borrow this factory or swap in their own ProviderOAuth — the capture
+ * shape `PkceMockState` doubles as a contract-level assertion.
+ */
+export interface PkceMockState {
+  buildAuthUrlCalls: Array<{ state: string; scopes: readonly string[] }>;
+  handleCallbackCalls: Array<{ code: string; state: string; pkce: PkceInputs | null }>;
+}
+
+export interface CreatePkceMockProviderOptions {
+  accessTokenEncrypted?: string;
+  refreshTokenEncrypted?: string | null;
+  providerAccountId?: string;
+  scopes?: readonly string[];
+}
+
+export function createPkceMockProvider(
+  options: CreatePkceMockProviderOptions = {},
+): { provider: ProviderOAuth; state: PkceMockState } {
+  const state: PkceMockState = {
+    buildAuthUrlCalls: [],
+    handleCallbackCalls: [],
+  };
+  const provider: ProviderOAuth = {
+    buildAuthUrl(jwtState, scopes) {
+      state.buildAuthUrlCalls.push({ state: jwtState, scopes });
+      return `https://mock.example.com/authorize?state=${jwtState}`;
+    },
+    async handleCallback(code, jwtState, pkce) {
+      state.handleCallbackCalls.push({ code, state: jwtState, pkce });
+      return {
+        tokens: {
+          accessTokenEncrypted: options.accessTokenEncrypted ?? "ENC-MOCK-ACCESS",
+          refreshTokenEncrypted:
+            options.refreshTokenEncrypted === undefined
+              ? "ENC-MOCK-REFRESH"
+              : options.refreshTokenEncrypted,
+          accessTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+          scopes: options.scopes ?? ["mock.read"],
+        },
+        account: {
+          providerAccountId: options.providerAccountId ?? "mock-acct-1",
+          displayName: "Mock Account",
+          metadata: {},
+        },
+      };
+    },
+    async refreshToken(_refreshToken) {
+      throw new Error("refreshToken not exercised in Slice 2a");
+    },
+    async revoke(_token) {
+      // no-op for tests
+    },
+  };
+  return { provider, state };
+}

--- a/tests/unit/integrations/slack/oauth-callback.test.ts
+++ b/tests/unit/integrations/slack/oauth-callback.test.ts
@@ -53,7 +53,7 @@ describe("slackOAuth.handleCallback", () => {
         ),
       );
 
-    await slackOAuth.handleCallback("auth-code-xyz", "state-token");
+    await slackOAuth.handleCallback("auth-code-xyz", "state-token", null);
 
     expect(fetchSpy).toHaveBeenCalledWith(
       "https://slack.com/api/oauth.v2.access",
@@ -83,7 +83,7 @@ describe("slackOAuth.handleCallback", () => {
         team: { id: "T123", name: "Acme" },
       },
     });
-    const result = await slackOAuth.handleCallback("code", "state");
+    const result = await slackOAuth.handleCallback("code", "state", null);
     expect(result.tokens.accessTokenEncrypted).not.toContain("xoxb-real-bot-token");
     expect(decryptToken(result.tokens.accessTokenEncrypted)).toBe("xoxb-real-bot-token");
   });
@@ -98,7 +98,7 @@ describe("slackOAuth.handleCallback", () => {
         team: { id: "T", name: "N" },
       },
     });
-    const result = await slackOAuth.handleCallback("c", "s");
+    const result = await slackOAuth.handleCallback("c", "s", null);
     expect(result.tokens.refreshTokenEncrypted).toBeNull();
     expect(result.tokens.accessTokenExpiresAt).toBeNull();
   });
@@ -113,7 +113,7 @@ describe("slackOAuth.handleCallback", () => {
         team: { id: "T", name: "N" },
       },
     });
-    const result = await slackOAuth.handleCallback("c", "s");
+    const result = await slackOAuth.handleCallback("c", "s", null);
     expect(result.tokens.scopes).toEqual([
       "chat:write",
       "channels:read",
@@ -135,7 +135,7 @@ describe("slackOAuth.handleCallback", () => {
         authed_user: { id: "U-user-1" },
       },
     });
-    const result = await slackOAuth.handleCallback("c", "s");
+    const result = await slackOAuth.handleCallback("c", "s", null);
     expect(result.account.providerAccountId).toBe("T-team-123");
     expect(result.account.displayName).toBe("Acme Inc");
     expect(result.account.metadata).toEqual({
@@ -152,19 +152,19 @@ describe("slackOAuth.handleCallback", () => {
       ok: true,
       json: { ok: false, error: "invalid_code" },
     });
-    await expect(slackOAuth.handleCallback("bad-code", "s")).rejects.toThrow(/invalid_code/);
+    await expect(slackOAuth.handleCallback("bad-code", "s", null)).rejects.toThrow(/invalid_code/);
   });
 
   it("throws on HTTP-level failure", async () => {
     jest
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response("ratelimit", { status: 429 }));
-    await expect(slackOAuth.handleCallback("c", "s")).rejects.toThrow(/HTTP 429/);
+    await expect(slackOAuth.handleCallback("c", "s", null)).rejects.toThrow(/HTTP 429/);
   });
 
   it("throws when SLACK_CLIENT_SECRET is missing", async () => {
     delete process.env.SLACK_CLIENT_SECRET;
-    await expect(slackOAuth.handleCallback("c", "s")).rejects.toThrow(/SLACK_CLIENT_SECRET/);
+    await expect(slackOAuth.handleCallback("c", "s", null)).rejects.toThrow(/SLACK_CLIENT_SECRET/);
   });
 
   it("throws when response is missing access_token or team.id", async () => {
@@ -172,7 +172,7 @@ describe("slackOAuth.handleCallback", () => {
       ok: true,
       json: { ok: true, scope: "chat:write", team: {} },
     });
-    await expect(slackOAuth.handleCallback("c", "s")).rejects.toThrow(/missing/);
+    await expect(slackOAuth.handleCallback("c", "s", null)).rejects.toThrow(/missing/);
   });
 
   it("uses SLACK_API_BASE override for the token exchange (e2e mock surface)", async () => {
@@ -188,7 +188,7 @@ describe("slackOAuth.handleCallback", () => {
         { status: 200 },
       ),
     );
-    await slackOAuth.handleCallback("c", "s");
+    await slackOAuth.handleCallback("c", "s", null);
     expect(fetchSpy).toHaveBeenCalledWith(
       "http://localhost:9876/api/oauth.v2.access",
       expect.any(Object),

--- a/tests/unit/services/oauth/dispatcher-callback.test.ts
+++ b/tests/unit/services/oauth/dispatcher-callback.test.ts
@@ -32,6 +32,7 @@ jest.mock("@/repositories/oauthStates", () => ({
 
 import { handleCallback } from "@/services/oauth/dispatcher";
 import { createState, InvalidStateError } from "@/services/oauth/state";
+import { createPkceMockProvider } from "../../../__mocks__/integrations/_pkceMockProvider/oauth";
 
 beforeEach(() => {
   process.env.OAUTH_STATE_SIGNING_KEY = randomBytes(32).toString("base64");
@@ -51,19 +52,30 @@ async function freshStateWithConsumeWired(input: {
   userId: string;
   provider: string;
   scopes?: readonly string[];
+  pkceVerifier?: string;
+  pkceMethod?: string;
 }): Promise<string> {
   const { token, payload } = await createState({
     userId: input.userId,
     provider: input.provider,
     requestedScopes: input.scopes ?? [],
+    ...(input.pkceVerifier !== undefined
+      ? {
+          pkce: {
+            codeVerifier: input.pkceVerifier,
+            codeChallengeMethod: input.pkceMethod ?? "S256",
+          },
+        }
+      : {}),
   });
   mockOAuthStatesConsume.mockResolvedValueOnce({
     nonce: payload.nonce,
     userId: payload.userId,
     provider: payload.provider,
     expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
-    pkceCodeVerifier: null,
-    pkceCodeChallengeMethod: null,
+    pkceCodeVerifier: input.pkceVerifier ?? null,
+    pkceCodeChallengeMethod:
+      input.pkceVerifier !== undefined ? (input.pkceMethod ?? "S256") : null,
     createdAt: new Date().toISOString(),
   });
   return token;
@@ -108,7 +120,7 @@ describe("dispatcher.handleCallback", () => {
     const result = await handleCallback({ provider: "slack", code: "auth-code", state });
 
     expect(mockOAuthStatesConsume).toHaveBeenCalledTimes(1);
-    expect(mockSlackHandleCallback).toHaveBeenCalledWith("auth-code", state);
+    expect(mockSlackHandleCallback).toHaveBeenCalledWith("auth-code", state, null);
     expect(mockUpsertActive).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user-abc",
@@ -154,5 +166,121 @@ describe("dispatcher.handleCallback", () => {
     // state can't be re-played at the correct provider's route either.
     expect(mockOAuthStatesConsume).toHaveBeenCalledTimes(1);
     expect(mockSlackHandleCallback).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Slice 2a: dispatcher threads the PKCE row through to provider.handleCallback.
+ *
+ * The "slack" provider id is reused as the test surface — the mocked
+ * handleCallback is a generic jest.fn() acting as a stand-in for any
+ * ProviderOAuth, so what we're really asserting is the dispatcher's
+ * plumbing, not Slack's behavior. A reusable factory at
+ * tests/__mocks__/integrations/_pkceMockProvider/oauth.ts gives the same
+ * shape for future Slice 2c (Gmail) tests.
+ */
+describe("dispatcher.handleCallback — PKCE plumbing (Slice 2a)", () => {
+  function arrangeUpsert(): void {
+    mockUpsertActive.mockResolvedValueOnce({
+      id: "int-pkce",
+      userId: "u-pkce",
+      provider: "slack",
+      providerAccountId: "acct",
+      displayName: null,
+      accessTokenEncrypted: "ENC",
+      refreshTokenEncrypted: null,
+      accessTokenExpiresAt: null,
+      scopes: [],
+      accountMetadata: {},
+      disconnectedAt: null,
+      createdAt: "2026-05-07T00:00:00Z",
+      updatedAt: "2026-05-07T00:00:00Z",
+    });
+    mockSlackHandleCallback.mockResolvedValueOnce({
+      tokens: {
+        accessTokenEncrypted: "ENC",
+        refreshTokenEncrypted: null,
+        accessTokenExpiresAt: null,
+        scopes: [],
+      },
+      account: { providerAccountId: "acct", displayName: null, metadata: {} },
+    });
+  }
+
+  it("passes PKCE inputs to provider.handleCallback when the consumed row has both fields (asserted via factory's capture state)", async () => {
+    // Drive the mocked slackOAuth.handleCallback through the factory so the
+    // factory's PkceMockState records every call. This is the pattern
+    // future Slice 2c (Gmail) tests will reuse.
+    const { provider: pkceProvider, state: captureState } = createPkceMockProvider();
+    mockSlackHandleCallback.mockImplementation(pkceProvider.handleCallback);
+
+    const stateToken = await freshStateWithConsumeWired({
+      userId: "u-pkce",
+      provider: "slack",
+      pkceVerifier: "verifier-secret-abc",
+      pkceMethod: "S256",
+    });
+    mockUpsertActive.mockResolvedValueOnce({
+      id: "int-pkce",
+      userId: "u-pkce",
+      provider: "slack",
+      providerAccountId: "mock-acct-1",
+      displayName: "Mock Account",
+      accessTokenEncrypted: "ENC-MOCK-ACCESS",
+      refreshTokenEncrypted: "ENC-MOCK-REFRESH",
+      accessTokenExpiresAt: null,
+      scopes: ["mock.read"],
+      accountMetadata: {},
+      disconnectedAt: null,
+      createdAt: "2026-05-07T00:00:00Z",
+      updatedAt: "2026-05-07T00:00:00Z",
+    });
+
+    await handleCallback({ provider: "slack", code: "code-pkce", state: stateToken });
+
+    expect(captureState.handleCallbackCalls).toHaveLength(1);
+    expect(captureState.handleCallbackCalls[0]!.code).toBe("code-pkce");
+    expect(captureState.handleCallbackCalls[0]!.state).toBe(stateToken);
+    expect(captureState.handleCallbackCalls[0]!.pkce).toEqual({
+      codeVerifier: "verifier-secret-abc",
+      codeChallengeMethod: "S256",
+    });
+  });
+
+  it("passes pkce: null when the consumed row has no PKCE fields (Slack-shaped path)", async () => {
+    const state = await freshStateWithConsumeWired({
+      userId: "u",
+      provider: "slack",
+    });
+    arrangeUpsert();
+
+    await handleCallback({ provider: "slack", code: "c", state });
+
+    expect(mockSlackHandleCallback).toHaveBeenCalledWith("c", state, null);
+  });
+
+  it("treats a half-populated PKCE row as null (defensive AND in consumeState)", async () => {
+    // Manually wire the consume mock to return a row with verifier set but
+    // method NULL — simulates upstream corruption that createState's all-or-
+    // nothing write should normally prevent.
+    const { token, payload } = await createState({
+      userId: "u",
+      provider: "slack",
+      requestedScopes: [],
+    });
+    mockOAuthStatesConsume.mockResolvedValueOnce({
+      nonce: payload.nonce,
+      userId: payload.userId,
+      provider: payload.provider,
+      expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
+      pkceCodeVerifier: "stranded",
+      pkceCodeChallengeMethod: null,
+      createdAt: new Date().toISOString(),
+    });
+    arrangeUpsert();
+
+    await handleCallback({ provider: "slack", code: "c", state: token });
+
+    expect(mockSlackHandleCallback).toHaveBeenCalledWith("c", token, null);
   });
 });

--- a/tests/unit/services/oauth/state.test.ts
+++ b/tests/unit/services/oauth/state.test.ts
@@ -164,7 +164,8 @@ describe("consumeState — verify-and-consume (replay protection)", () => {
       createdAt: "2026-05-07T00:00:00Z",
     });
     const result = await consumeState(token);
-    expect(result.userId).toBe("user-1");
+    expect(result.payload.userId).toBe("user-1");
+    expect(result.pkce).toBeNull();
     expect(mockConsumeByNonce).toHaveBeenCalledWith(payload.nonce);
   });
 
@@ -245,5 +246,69 @@ describe("consumeState — verify-and-consume (replay protection)", () => {
       .digest("base64url");
     await expect(consumeState(`${data}.${sig}`)).rejects.toThrow(/expired/);
     expect(mockConsumeByNonce).not.toHaveBeenCalled();
+  });
+});
+
+describe("consumeState — PKCE round-trip (Slice 2a plumbing)", () => {
+  it("returns pkce inputs when the row has both verifier + method", async () => {
+    const { token, payload } = await createState({
+      userId: "u-pkce",
+      provider: "google",
+      requestedScopes: ["openid"],
+      pkce: { codeVerifier: "verifier-secret-xyz", codeChallengeMethod: "S256" },
+    });
+    mockConsumeByNonce.mockResolvedValueOnce({
+      nonce: payload.nonce,
+      userId: payload.userId,
+      provider: payload.provider,
+      expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
+      pkceCodeVerifier: "verifier-secret-xyz",
+      pkceCodeChallengeMethod: "S256",
+      createdAt: new Date().toISOString(),
+    });
+    const result = await consumeState(token);
+    expect(result.payload.userId).toBe("u-pkce");
+    expect(result.pkce).toEqual({
+      codeVerifier: "verifier-secret-xyz",
+      codeChallengeMethod: "S256",
+    });
+  });
+
+  it("returns pkce: null when only verifier is present (half-populated row)", async () => {
+    const { token, payload } = await createState({
+      userId: "u",
+      provider: "slack",
+      requestedScopes: [],
+    });
+    mockConsumeByNonce.mockResolvedValueOnce({
+      nonce: payload.nonce,
+      userId: payload.userId,
+      provider: payload.provider,
+      expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
+      pkceCodeVerifier: "stranded-verifier",
+      pkceCodeChallengeMethod: null,
+      createdAt: new Date().toISOString(),
+    });
+    const result = await consumeState(token);
+    expect(result.pkce).toBeNull();
+  });
+
+  it("returns pkce: null when only method is present (half-populated row)", async () => {
+    const { token, payload } = await createState({
+      userId: "u",
+      provider: "slack",
+      requestedScopes: [],
+    });
+    mockConsumeByNonce.mockResolvedValueOnce({
+      nonce: payload.nonce,
+      userId: payload.userId,
+      provider: payload.provider,
+      expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
+      pkceCodeVerifier: null,
+      pkceCodeChallengeMethod: "S256",
+      createdAt: new Date().toISOString(),
+    });
+    const result = await consumeState(token);
+    expect(result.pkce).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Wires the existing `oauth_states.pkce_code_verifier` + `pkce_code_challenge_method` columns through `consumeState` and the OAuth dispatcher so a future PKCE-using provider's `handleCallback` can receive the verifier. Slack stays non-PKCE; behavior unchanged. The path is exercised end-to-end against a test-only mock provider — no real PKCE provider is added in this slice.

This is **Slice 2a** of the Slice 2 plan: shared OAuth infrastructure first, Gmail (2c) and refreshAndRetry (2b) follow in their own PRs.

## What ships

**Source (3 files):**
- `contracts/integration.ts` — new exported `PkceInputs` type. `ProviderOAuth.handleCallback` signature gains a third param `pkce: PkceInputs | null`.
- `services/oauth/state.ts` — `consumeState` returns `ConsumeStateResult` (`{ payload, pkce }`). `pkce` is non-null only when the row has BOTH `pkceCodeVerifier` and `pkceCodeChallengeMethod`. Half-populated rows are treated as invalid and ignored (defensive AND with explanatory comment).
- `services/oauth/dispatcher.ts` — `handleCallback` destructures `{ payload, pkce }` and threads `pkce` to `oauth.handleCallback`.

**Tests (4 files, +6 tests):**
- `tests/__mocks__/integrations/_pkceMockProvider/oauth.ts` — new test-only `ProviderOAuth` factory with a `PkceMockState` capture object. Reusable for Slice 2c (Gmail) tests. **Not registered in `integrations/_registry.ts`.**
- `tests/unit/services/oauth/state.test.ts` — +3 tests for PKCE round-trip via `consumeState` and both half-populated variants returning null. 1 existing test updated to destructure the new shape.
- `tests/unit/services/oauth/dispatcher-callback.test.ts` — +3 tests for dispatcher threading `pkce` through (asserted via the factory's capture state), null on Slack-shaped path, and defensive null on half-populated row. 1 existing assertion updated for the `(code, state, null)` call shape.
- `tests/unit/integrations/slack/oauth-callback.test.ts` — 10 direct `slackOAuth.handleCallback` calls now pass `null` as the 3rd arg. The Slack `slackOAuth: ProviderOAuth` typing means external callers see the new 3-arg interface and TS requires it explicitly. The Slack source file itself is byte-for-byte unchanged.

## Backward compatibility

- **No DB migration.** PKCE columns shipped in `20260507000003_oauth_states.sql` (Slice 1).
- **No production registry change.** Mock provider lives under `tests/__mocks__`.
- **Slack production source untouched.** `integrations/slack/oauth.ts` keeps its 2-arg `handleCallback(code, _state)`. TS contextual typing accepts a narrower function as the value of an interface property whose declared type is wider — same principle as standard parameter-bivariant assignability.
- **Slice 1 e2e regression smoke green.** `slice-1-slack-walkthrough.spec.ts` runs in 19.5s, matching the Slice 1 baseline of 19.2–19.3s.
- `consumeState`'s only non-test caller is `services/oauth/dispatcher.ts`; updated in this commit.

## Out of scope (intentionally deferred to later sub-slices)

- `dispatcher.refresh()` operation (Slice 2b).
- `core/integrations/refreshAndRetry.ts` Q3 helper (Slice 2b).
- Gmail manifest, OAuth implementation, actions, trigger (Slices 2c–2e).
- `dispatcher.revoke()` and Slack `revoke()` (Slice 2.5 or later).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run lint:structure` — OK (one new leaf folder, well under 50 files)
- [x] `npm run lint:migrations` — OK (no migration changes)
- [x] `npx jest tests/unit/services/oauth/state.test.ts` — 21 passed
- [x] `npx jest tests/unit/services/oauth/dispatcher.test.ts tests/unit/services/oauth/dispatcher-callback.test.ts` — 11 passed
- [x] `npm test` — 70 suites / 617 tests passed (was 611; +6 new)
- [x] `npx playwright test tests/e2e/slice-1-slack-walkthrough.spec.ts` — 1 passed in 19.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
