### PR TITLE
feat(gmail): add manifest and OAuth handler with PKCE S256

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,15 @@ SLACK_CLIENT_ID=
 SLACK_CLIENT_SECRET=
 SLACK_SIGNING_SECRET=
 
+# Gmail / Google OAuth (Slice 2c vertical slice). Use developer creds for
+# now; an org-owned Google Cloud project + OAuth consent setup lands
+# before production readiness.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# E2e mocking only — leave unset in production. Defaults point at real Google.
+# GOOGLE_AUTHORIZE_BASE=
+# GOOGLE_TOKEN_BASE=
+# GMAIL_API_BASE=
+
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/contracts/integration.ts
+++ b/contracts/integration.ts
@@ -116,13 +116,48 @@ export interface PkceInputs {
 }
 
 /**
+ * The PKCE challenge half — what gets embedded in the authorize URL.
+ * Distinct from `PkceInputs` because the verifier (secret) does NOT go in
+ * the URL. Providers that use PKCE return both halves from
+ * `generatePkce()`; the dispatcher routes the verifier to `createState`
+ * and the challenge to `buildAuthUrl`.
+ */
+export interface PkceChallenge {
+  codeChallenge: string;
+  codeChallengeMethod: string;
+}
+
+/**
+ * Full output of a provider's PKCE generation step. Combines the verifier
+ * (persisted server-side) and the challenge (embedded in the authorize URL).
+ */
+export interface PkceGeneration extends PkceInputs, PkceChallenge {}
+
+/**
  * Per-provider OAuth implementation. Each provider in `integrations/<id>/oauth.ts`
  * exports an object that satisfies this shape. The generic dispatcher in
  * `services/oauth/dispatcher.ts` is the only caller.
  */
 export interface ProviderOAuth {
-  /** Builds the redirect URL the user is sent to. `state` is the signed token from createState(). */
-  buildAuthUrl(state: string, scopes: readonly string[]): string;
+  /**
+   * Optional. Providers that use PKCE (Gmail, future PKCE-required
+   * providers) implement this; the dispatcher calls it at connect time
+   * and routes the verifier to `createState` (persisted on the
+   * `oauth_states` row) AND the challenge into the call to `buildAuthUrl`.
+   * Non-PKCE providers (Slack default v2) omit this method.
+   */
+  generatePkce?(): PkceGeneration;
+  /**
+   * Builds the redirect URL the user is sent to. `state` is the signed
+   * token from `createState()`. `pkce` is non-null only when the provider
+   * declared `generatePkce` at connect time; non-PKCE providers receive
+   * `null` and ignore it.
+   */
+  buildAuthUrl(
+    state: string,
+    scopes: readonly string[],
+    pkce: PkceChallenge | null,
+  ): string;
   /**
    * Exchanges the authorization code for tokens. `pkce` is non-null only for
    * providers that asked the dispatcher to issue a PKCE challenge at connect

--- a/integrations/_registry.ts
+++ b/integrations/_registry.ts
@@ -3,6 +3,7 @@ import {
   type ProviderManifest,
   ProviderManifestSchema,
 } from "@/contracts/integration";
+import { gmailManifest } from "./gmail/manifest";
 import { slackManifest } from "./slack/manifest";
 
 /**
@@ -16,7 +17,7 @@ import { slackManifest } from "./slack/manifest";
  *   - The exported PROVIDERS object is frozen — no runtime mutation.
  */
 
-const ALL_MANIFESTS: readonly ProviderManifest[] = [slackManifest];
+const ALL_MANIFESTS: readonly ProviderManifest[] = [slackManifest, gmailManifest];
 
 // Validate every manifest against the schema at module load. parse() throws
 // on any malformed manifest; loading any importer of this module fails the

--- a/integrations/gmail/manifest.ts
+++ b/integrations/gmail/manifest.ts
@@ -1,0 +1,62 @@
+import { ProviderManifestSchema, type ProviderManifest } from "@/contracts/integration";
+
+/**
+ * Gmail provider manifest.
+ *
+ * Slice 2c ships OAuth + manifest only. Action handlers (`gmail.send`) and
+ * polling triggers (`new_email`) land in Slices 2d and 2e respectively.
+ * Capability flags reflect honest current state — `actions` and
+ * `pollingTrigger` start `false` and flip when their slices ship. This
+ * keeps `tests/structure/integration-manifests.test.ts` truthful and
+ * prevents the registry from advertising capabilities that don't exist.
+ *
+ * OAuth shape (via integrations/gmail/oauth.ts):
+ *   - PKCE S256 (Slice 2a infra; Gmail is the first real consumer).
+ *   - access_type=offline + prompt=consent — guarantees a refresh token on
+ *     every connect (Google's quirk: refresh token only returned on first
+ *     consent OR when prompt=consent forces re-consent). UX cost accepted
+ *     per Slice 2 plan deferred-polish status.
+ *   - tokenScope: "user" — one Gmail integration row per (user, email).
+ *     Multi-account users connect each inbox separately.
+ *   - accountIdField: "email" — providerAccountId is the Gmail
+ *     emailAddress fetched from users.getProfile at callback time.
+ *   - refreshable: true — Gmail's refreshToken is the first end-to-end
+ *     refresh path against a real provider (Slice 2b infra).
+ *
+ * Scopes (Slice 2 Q6 confirmation — narrowest practical set):
+ *   - gmail.readonly: required for the polling trigger AND for the
+ *     callback-time accountId lookup via users.getProfile.
+ *   - gmail.send: required for the send action handler.
+ *   - No gmail.modify, no openid/email/profile — userinfo lookup uses
+ *     gmail.googleapis.com/v1/users/me/profile (covered by gmail.readonly),
+ *     not the OAuth identity endpoint.
+ *
+ * Health-check interval: 6h matches the V1 cadence for Google integrations
+ * (CLAUDE.md "Google/Microsoft: 6h"). The future health engine consumes
+ * this; Slice 2c just declares it.
+ */
+export const gmailManifest: ProviderManifest = ProviderManifestSchema.parse({
+  id: "gmail",
+  displayName: "Gmail",
+  isEnabled: true,
+  apiVersion: "v1",
+  tokenScope: "user",
+  oauthFlows: ["v2"],
+  accountIdField: "email",
+  scopes: {
+    required: [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.send",
+    ],
+    optional: [],
+    deprecated: [],
+  },
+  capabilities: {
+    oauth: true,
+    webhookTrigger: false,
+    pollingTrigger: false, // flips true in Slice 2e when newEmail trigger ships
+    actions: false, // flips true in Slice 2d when sendEmail handler ships
+  },
+  healthCheckIntervalMs: 6 * 60 * 60 * 1000, // 6h
+  refreshable: true,
+});

--- a/integrations/gmail/oauth.ts
+++ b/integrations/gmail/oauth.ts
@@ -1,0 +1,288 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  type EncryptedTokens,
+  type ProviderOAuth,
+} from "@/contracts/integration";
+import { encryptToken } from "@/core/encryption/tokens";
+
+/**
+ * Gmail OAuth implementation.
+ *
+ * Per docs/rules/oauth-dispatcher.md and the Slice 2 plan:
+ *   - PKCE S256 (Slice 2a infra; Gmail is the first real consumer).
+ *   - access_type=offline + prompt=consent — guarantees a refresh token on
+ *     every connect (Google's quirk: refresh token only returned on first
+ *     consent OR when prompt=consent forces re-consent).
+ *   - Token endpoint POSTs `code_verifier` from the consumed oauth_states
+ *     row alongside `code` + `client_id` + `client_secret`.
+ *   - accountId via users.getProfile → emailAddress (uses gmail.readonly).
+ *   - refreshToken preserves the existing encrypted refresh token when
+ *     Google's response omits a new one (Decision 2b-5: provider owns
+ *     rotation/preserve-old policy).
+ *   - revoke is a stub deferred to the disconnect-UX slice (matches
+ *     Slack's pattern for the same parent decision).
+ */
+
+/**
+ * Base URLs are env-overridable for e2e testing only. Production sets
+ * none of these; defaults point at real Google. Three separate vars per
+ * Slice 2 Decision 2c-5 — matches the per-endpoint pattern and lets the
+ * mock server (Slice 2f) own all three at once without coupling.
+ */
+function googleAuthorizeBase(): string {
+  return process.env.GOOGLE_AUTHORIZE_BASE ?? "https://accounts.google.com";
+}
+
+function googleTokenBase(): string {
+  return process.env.GOOGLE_TOKEN_BASE ?? "https://oauth2.googleapis.com";
+}
+
+function gmailApiBase(): string {
+  return process.env.GMAIL_API_BASE ?? "https://gmail.googleapis.com";
+}
+
+function getRedirectUrl(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  return `${baseUrl}/api/integrations/oauth/gmail/callback`;
+}
+
+function getClientId(): string {
+  const id = process.env.GOOGLE_CLIENT_ID;
+  if (!id) throw new Error("GOOGLE_CLIENT_ID env var is not set.");
+  return id;
+}
+
+function getClientSecret(): string {
+  const secret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!secret) throw new Error("GOOGLE_CLIENT_SECRET env var is not set.");
+  return secret;
+}
+
+interface GoogleTokenSuccess {
+  access_token: string;
+  expires_in: number;
+  /**
+   * Google may omit refresh_token on subsequent connects without
+   * prompt=consent (we always send prompt=consent, but per RFC the
+   * field is still optional in the response). When omitted, the provider
+   * preserves the existing refresh token (Decision 2b-5).
+   */
+  refresh_token?: string;
+  scope?: string;
+  token_type?: string;
+}
+
+interface GoogleTokenError {
+  error: string;
+  error_description?: string;
+}
+
+interface GmailUserProfile {
+  emailAddress: string;
+  messagesTotal?: number;
+  threadsTotal?: number;
+  historyId?: string;
+}
+
+export const gmailOAuth: ProviderOAuth = {
+  /**
+   * Generate a fresh PKCE pair. 32 random bytes → ~43 base64url chars
+   * (RFC 7636 §4.1 minimum), exceeds entropy needed for SHA-256.
+   * Method is hardcoded S256 per Slice 2 Decision 2c-3.
+   */
+  generatePkce() {
+    const codeVerifier = randomBytes(32).toString("base64url");
+    const codeChallenge = createHash("sha256")
+      .update(codeVerifier)
+      .digest("base64url");
+    return {
+      codeVerifier,
+      codeChallenge,
+      codeChallengeMethod: "S256",
+    };
+  },
+
+  buildAuthUrl(state, scopes, pkce) {
+    if (pkce === null) {
+      // Should be impossible — the dispatcher always passes PKCE for
+      // Gmail because generatePkce returned a non-null value. Defensive
+      // throw so a future refactor that breaks the connect-time threading
+      // surfaces immediately.
+      throw new Error(
+        "gmailOAuth.buildAuthUrl: PKCE challenge is required for Gmail. The dispatcher should have generated one via generatePkce().",
+      );
+    }
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: getClientId(),
+      redirect_uri: getRedirectUrl(),
+      scope: scopes.join(" "), // Google uses space-separated scopes
+      state,
+      access_type: "offline",
+      prompt: "consent",
+      code_challenge: pkce.codeChallenge,
+      code_challenge_method: pkce.codeChallengeMethod,
+    });
+    return `${googleAuthorizeBase()}/o/oauth2/v2/auth?${params.toString()}`;
+  },
+
+  async handleCallback(code, _state, pkce) {
+    if (pkce === null || !pkce.codeVerifier) {
+      // The state row was missing the code_verifier — either the connect
+      // path didn't issue PKCE (impossible if Gmail is the only caller),
+      // or the row was tampered with, or consumeState's defensive AND
+      // returned null on a half-populated row. Refuse to attempt the
+      // token exchange — Google would reject it anyway with
+      // invalid_grant.
+      throw new Error(
+        "gmailOAuth.handleCallback: PKCE code_verifier is required for Gmail; the consumed oauth_states row had none.",
+      );
+    }
+
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
+      redirect_uri: getRedirectUrl(),
+      code_verifier: pkce.codeVerifier,
+    });
+
+    const tokenRes = await fetch(`${googleTokenBase()}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+    if (!tokenRes.ok) {
+      const text = await tokenRes.text();
+      // Try to surface Google's error code without leaking tokens.
+      let errorCode = `HTTP ${tokenRes.status}`;
+      try {
+        const parsed = JSON.parse(text) as GoogleTokenError;
+        if (parsed.error) errorCode = parsed.error;
+      } catch {
+        // not JSON — keep HTTP status
+      }
+      throw new Error(`Google token exchange failed: ${errorCode}`);
+    }
+    const tokenJson = (await tokenRes.json()) as GoogleTokenSuccess;
+    if (!tokenJson.access_token) {
+      throw new Error("Google token response missing access_token.");
+    }
+    if (!tokenJson.refresh_token) {
+      // First-connect with prompt=consent should always return a refresh
+      // token. Missing one means scopes were re-granted without forcing
+      // re-consent (impossible if buildAuthUrl ran correctly). Fail loud
+      // — letting this through would silently break the refresh path.
+      throw new Error(
+        "Google token response missing refresh_token — Slice 2c expects offline access + prompt=consent to always issue one.",
+      );
+    }
+
+    const accessToken = tokenJson.access_token;
+    const expiresAt =
+      typeof tokenJson.expires_in === "number"
+        ? Math.floor(Date.now() / 1000) + tokenJson.expires_in
+        : null;
+    const scopesGranted = (tokenJson.scope ?? "").split(" ").filter(Boolean);
+
+    // Look up the connected account's email via the Gmail API. Uses the
+    // freshly-issued access token; gmail.readonly scope (which we always
+    // request) covers users.getProfile.
+    const profileRes = await fetch(`${gmailApiBase()}/gmail/v1/users/me/profile`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!profileRes.ok) {
+      throw new Error(
+        `Gmail users.getProfile failed: HTTP ${profileRes.status}`,
+      );
+    }
+    const profile = (await profileRes.json()) as GmailUserProfile;
+    if (!profile.emailAddress) {
+      throw new Error("Gmail users.getProfile response missing emailAddress.");
+    }
+
+    return {
+      tokens: {
+        accessTokenEncrypted: encryptToken(accessToken),
+        refreshTokenEncrypted: encryptToken(tokenJson.refresh_token),
+        accessTokenExpiresAt: expiresAt,
+        scopes: scopesGranted,
+      },
+      account: {
+        providerAccountId: profile.emailAddress,
+        displayName: profile.emailAddress,
+        metadata: {
+          email: profile.emailAddress,
+          historyId: profile.historyId ?? null,
+        },
+      },
+    };
+  },
+
+  /**
+   * Exchange a refresh token for fresh tokens. Per Decision 2b-5, this
+   * provider owns the rotation/preserve-old policy:
+   *   - Google's response includes `refresh_token` only when the token
+   *     rotates (uncommon for the default Gmail flow). When the field is
+   *     present, encrypt and return it as the new refreshTokenEncrypted.
+   *   - When the field is omitted, re-encrypt the input refreshToken
+   *     plaintext and return that — the row's refresh token stays
+   *     functionally unchanged (the ciphertext bytes change because of
+   *     fresh IV, but the underlying plaintext is the same).
+   */
+  async refreshToken(refreshToken: string): Promise<EncryptedTokens> {
+    const params = new URLSearchParams({
+      grant_type: "refresh_token",
+      client_id: getClientId(),
+      client_secret: getClientSecret(),
+      refresh_token: refreshToken,
+    });
+    const res = await fetch(`${googleTokenBase()}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params.toString(),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      let errorCode = `HTTP ${res.status}`;
+      try {
+        const parsed = JSON.parse(text) as GoogleTokenError;
+        if (parsed.error) errorCode = parsed.error;
+      } catch {
+        // not JSON
+      }
+      // invalid_grant from Google during refresh means the refresh token
+      // is dead (revoked, expired, or scopes shrunk). The wrapper translates
+      // this to IntegrationActionRequiredError(refresh_failed).
+      throw new Error(`Google token refresh failed: ${errorCode}`);
+    }
+    const json = (await res.json()) as GoogleTokenSuccess;
+    if (!json.access_token) {
+      throw new Error("Google refresh response missing access_token.");
+    }
+    const expiresAt =
+      typeof json.expires_in === "number"
+        ? Math.floor(Date.now() / 1000) + json.expires_in
+        : null;
+    const scopesGranted = (json.scope ?? "").split(" ").filter(Boolean);
+    return {
+      accessTokenEncrypted: encryptToken(json.access_token),
+      // Preserve-old when Google omits a new refresh_token (Decision 2b-5).
+      refreshTokenEncrypted: json.refresh_token
+        ? encryptToken(json.refresh_token)
+        : encryptToken(refreshToken),
+      accessTokenExpiresAt: expiresAt,
+      scopes: scopesGranted,
+    };
+  },
+
+  async revoke(_token: string): Promise<void> {
+    // Google provides https://oauth2.googleapis.com/revoke. Implementation
+    // deferred to the disconnect-UX slice (parent Slice 2 Decision 4 +
+    // Slice 2c Decision 2c-6) — matches Slack's stub pattern. When this
+    // slice ships, both providers' revoke methods land together with the
+    // disconnect button UI.
+  },
+};

--- a/services/oauth/dispatcher.ts
+++ b/services/oauth/dispatcher.ts
@@ -1,5 +1,6 @@
 import { type ProviderOAuth } from "@/contracts/integration";
 import { decryptToken } from "@/core/encryption/tokens";
+import { gmailOAuth } from "@/integrations/gmail/oauth";
 import { getProvider } from "@/integrations/_registry";
 import { slackOAuth } from "@/integrations/slack/oauth";
 import {
@@ -22,6 +23,7 @@ import { createState, consumeState, InvalidStateError } from "./state";
 
 const OAUTH_BY_PROVIDER: Readonly<Record<string, ProviderOAuth>> = Object.freeze({
   slack: slackOAuth,
+  gmail: gmailOAuth,
 });
 
 export interface ConnectInput {
@@ -50,12 +52,33 @@ export async function connect(input: ConnectInput): Promise<ConnectOutput> {
   }
 
   const requestedScopes = [...manifest.scopes.required, ...manifest.scopes.optional];
+
+  // Provider-owned PKCE. Providers that need PKCE implement generatePkce
+  // and the dispatcher routes the verifier to createState (persisted on
+  // the oauth_states row) and the challenge into buildAuthUrl. Non-PKCE
+  // providers (Slack default v2) omit generatePkce entirely → no PKCE
+  // metadata flows anywhere.
+  const pkceGen = oauth.generatePkce?.();
   const { token: state } = await createState({
     userId: input.userId,
     provider: input.provider,
     requestedScopes,
+    ...(pkceGen !== undefined
+      ? {
+          pkce: {
+            codeVerifier: pkceGen.codeVerifier,
+            codeChallengeMethod: pkceGen.codeChallengeMethod,
+          },
+        }
+      : {}),
   });
-  const redirectUrl = oauth.buildAuthUrl(state, requestedScopes);
+  const redirectUrl = oauth.buildAuthUrl(
+    state,
+    requestedScopes,
+    pkceGen !== undefined
+      ? { codeChallenge: pkceGen.codeChallenge, codeChallengeMethod: pkceGen.codeChallengeMethod }
+      : null,
+  );
   return { redirectUrl };
 }
 

--- a/tests/__mocks__/integrations/_pkceMockProvider/oauth.ts
+++ b/tests/__mocks__/integrations/_pkceMockProvider/oauth.ts
@@ -1,5 +1,7 @@
 import type {
   EncryptedTokens,
+  PkceChallenge,
+  PkceGeneration,
   PkceInputs,
   ProviderOAuth,
 } from "@/contracts/integration";
@@ -22,7 +24,12 @@ import type {
  * plan).
  */
 export interface PkceMockState {
-  buildAuthUrlCalls: Array<{ state: string; scopes: readonly string[] }>;
+  generatePkceCallCount: number;
+  buildAuthUrlCalls: Array<{
+    state: string;
+    scopes: readonly string[];
+    pkce: PkceChallenge | null;
+  }>;
   handleCallbackCalls: Array<{ code: string; state: string; pkce: PkceInputs | null }>;
   refreshTokenCalls: Array<{ refreshToken: string }>;
   revokeCalls: Array<{ token: string }>;
@@ -33,6 +40,13 @@ export interface CreatePkceMockProviderOptions {
   refreshTokenEncrypted?: string | null;
   providerAccountId?: string;
   scopes?: readonly string[];
+  /**
+   * When provided, the mock implements `generatePkce` and returns this
+   * value (or the value produced by this function) on each call. When
+   * omitted, the mock OMITS the generatePkce method entirely — matches
+   * the Slack-shaped (no-PKCE) provider contract.
+   */
+  generatePkce?: PkceGeneration | (() => PkceGeneration);
   /**
    * Custom refresh implementation. Overrides the default behavior. When
    * unset and `refreshTokenThrows` is also unset, `refreshToken` throws
@@ -52,14 +66,25 @@ export function createPkceMockProvider(
   options: CreatePkceMockProviderOptions = {},
 ): { provider: ProviderOAuth; state: PkceMockState } {
   const state: PkceMockState = {
+    generatePkceCallCount: 0,
     buildAuthUrlCalls: [],
     handleCallbackCalls: [],
     refreshTokenCalls: [],
     revokeCalls: [],
   };
   const provider: ProviderOAuth = {
-    buildAuthUrl(jwtState, scopes) {
-      state.buildAuthUrlCalls.push({ state: jwtState, scopes });
+    ...(options.generatePkce !== undefined
+      ? {
+          generatePkce(): PkceGeneration {
+            state.generatePkceCallCount += 1;
+            return typeof options.generatePkce === "function"
+              ? options.generatePkce()
+              : options.generatePkce!;
+          },
+        }
+      : {}),
+    buildAuthUrl(jwtState, scopes, pkce) {
+      state.buildAuthUrlCalls.push({ state: jwtState, scopes, pkce });
       return `https://mock.example.com/authorize?state=${jwtState}`;
     },
     async handleCallback(code, jwtState, pkce) {

--- a/tests/unit/integrations/gmail/manifest.test.ts
+++ b/tests/unit/integrations/gmail/manifest.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the Gmail provider manifest. Validation against
+ * ProviderManifestSchema happens at module load (it would throw on import
+ * if malformed); these tests assert the specific manifest values that
+ * downstream code depends on.
+ */
+import { gmailManifest } from "@/integrations/gmail/manifest";
+import { getProvider, providerSupports } from "@/integrations/_registry";
+
+describe("gmail manifest", () => {
+  it("is registered in the provider registry under id 'gmail'", () => {
+    expect(getProvider("gmail")).toBe(gmailManifest);
+  });
+
+  it("declares Gmail-required scopes exactly (Slice 2 Q6 narrow set)", () => {
+    expect(gmailManifest.scopes.required).toEqual([
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.send",
+    ]);
+    expect(gmailManifest.scopes.optional).toEqual([]);
+    expect(gmailManifest.scopes.deprecated).toEqual([]);
+  });
+
+  it("is refreshable: true (first refreshable provider in V2)", () => {
+    expect(gmailManifest.refreshable).toBe(true);
+  });
+
+  it("uses tokenScope: user with accountIdField: email (multi-account ready)", () => {
+    expect(gmailManifest.tokenScope).toBe("user");
+    expect(gmailManifest.accountIdField).toBe("email");
+  });
+
+  it("declares honest capabilities — only oauth: true in Slice 2c", () => {
+    // Capabilities flip true in Slice 2d (actions: sendEmail) and Slice 2e
+    // (pollingTrigger: newEmail). Until then, the manifest does not
+    // advertise capabilities that don't ship.
+    expect(gmailManifest.capabilities).toEqual({
+      oauth: true,
+      webhookTrigger: false,
+      pollingTrigger: false,
+      actions: false,
+    });
+    expect(providerSupports("gmail", "oauth")).toBe(true);
+    expect(providerSupports("gmail", "actions")).toBe(false);
+    expect(providerSupports("gmail", "pollingTrigger")).toBe(false);
+    expect(providerSupports("gmail", "webhookTrigger")).toBe(false);
+  });
+
+  it("uses 6h health-check interval matching V1 Google cadence", () => {
+    expect(gmailManifest.healthCheckIntervalMs).toBe(6 * 60 * 60 * 1000);
+  });
+});

--- a/tests/unit/integrations/gmail/oauth.test.ts
+++ b/tests/unit/integrations/gmail/oauth.test.ts
@@ -1,0 +1,404 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for gmailOAuth (services/oauth/dispatcher's gmail entry).
+ *
+ * Strategy: mock the global fetch so token exchange + profile lookup +
+ * refresh hit a captured handler; verify request shape (URL, method,
+ * body params), response handling (encryption round-trip, scope parse,
+ * accountInfo), and the preserve-old refresh-token rotation policy.
+ */
+import { createHash } from "node:crypto";
+import { gmailOAuth } from "@/integrations/gmail/oauth";
+import { decryptToken } from "@/core/encryption/tokens";
+
+const TOKEN_KEY = (() => {
+  // 32 random bytes as base64 — token encryption requires exactly 32 bytes.
+  const bytes = Buffer.alloc(32);
+  for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 7) % 256;
+  return bytes.toString("base64");
+})();
+
+beforeEach(() => {
+  process.env.GOOGLE_CLIENT_ID = "test-google-client-id";
+  process.env.GOOGLE_CLIENT_SECRET = "test-google-client-secret";
+  process.env.NEXT_PUBLIC_APP_URL = "https://app.example.test";
+  process.env.TOKEN_ENCRYPTION_KEY = TOKEN_KEY;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete process.env.GOOGLE_CLIENT_ID;
+  delete process.env.GOOGLE_CLIENT_SECRET;
+  delete process.env.NEXT_PUBLIC_APP_URL;
+  delete process.env.TOKEN_ENCRYPTION_KEY;
+  delete process.env.GOOGLE_AUTHORIZE_BASE;
+  delete process.env.GOOGLE_TOKEN_BASE;
+  delete process.env.GMAIL_API_BASE;
+});
+
+function mockFetchSequence(responses: Array<{ ok: boolean; status?: number; json: unknown }>) {
+  const spy = jest.spyOn(globalThis, "fetch");
+  for (const r of responses) {
+    spy.mockResolvedValueOnce(
+      new Response(JSON.stringify(r.json), {
+        status: r.status ?? (r.ok ? 200 : 500),
+      }),
+    );
+  }
+  return spy;
+}
+
+describe("gmailOAuth.generatePkce", () => {
+  it("returns a verifier + challenge + S256 method", () => {
+    expect(gmailOAuth.generatePkce).toBeDefined();
+    const pkce = gmailOAuth.generatePkce!();
+    expect(pkce.codeChallengeMethod).toBe("S256");
+    expect(typeof pkce.codeVerifier).toBe("string");
+    expect(typeof pkce.codeChallenge).toBe("string");
+  });
+
+  it("produces a 43-char base64url verifier (32 random bytes)", () => {
+    const pkce = gmailOAuth.generatePkce!();
+    // base64url of 32 bytes is 43 chars (no padding).
+    expect(pkce.codeVerifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("challenge equals base64url(SHA256(verifier))", () => {
+    const pkce = gmailOAuth.generatePkce!();
+    const expected = createHash("sha256")
+      .update(pkce.codeVerifier)
+      .digest("base64url");
+    expect(pkce.codeChallenge).toBe(expected);
+  });
+
+  it("each call produces a fresh verifier", () => {
+    const a = gmailOAuth.generatePkce!();
+    const b = gmailOAuth.generatePkce!();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+});
+
+describe("gmailOAuth.buildAuthUrl", () => {
+  const SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+  ];
+  const PKCE_CHALLENGE = {
+    codeChallenge: "fake-challenge-base64url",
+    codeChallengeMethod: "S256",
+  };
+
+  it("includes every required Google v2 OAuth + PKCE param", () => {
+    const url = gmailOAuth.buildAuthUrl("STATE-TOKEN", SCOPES, PKCE_CHALLENGE);
+    const u = new URL(url);
+    expect(u.origin + u.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+    expect(u.searchParams.get("response_type")).toBe("code");
+    expect(u.searchParams.get("client_id")).toBe("test-google-client-id");
+    expect(u.searchParams.get("redirect_uri")).toBe(
+      "https://app.example.test/api/integrations/oauth/gmail/callback",
+    );
+    expect(u.searchParams.get("scope")).toBe(SCOPES.join(" "));
+    expect(u.searchParams.get("state")).toBe("STATE-TOKEN");
+    expect(u.searchParams.get("access_type")).toBe("offline");
+    expect(u.searchParams.get("prompt")).toBe("consent");
+    expect(u.searchParams.get("code_challenge")).toBe("fake-challenge-base64url");
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("throws when pkce is null (Gmail requires PKCE)", () => {
+    expect(() => gmailOAuth.buildAuthUrl("S", SCOPES, null)).toThrow(/PKCE/);
+  });
+
+  it("throws when GOOGLE_CLIENT_ID is unset", () => {
+    delete process.env.GOOGLE_CLIENT_ID;
+    expect(() => gmailOAuth.buildAuthUrl("S", SCOPES, PKCE_CHALLENGE)).toThrow(
+      /GOOGLE_CLIENT_ID/,
+    );
+  });
+
+  it("uses GOOGLE_AUTHORIZE_BASE override when set (e2e mock surface)", () => {
+    process.env.GOOGLE_AUTHORIZE_BASE = "http://127.0.0.1:9877";
+    const url = gmailOAuth.buildAuthUrl("S", SCOPES, PKCE_CHALLENGE);
+    expect(new URL(url).origin).toBe("http://127.0.0.1:9877");
+  });
+});
+
+describe("gmailOAuth.handleCallback", () => {
+  const PKCE_INPUTS = { codeVerifier: "verifier-secret-43chars", codeChallengeMethod: "S256" };
+
+  it("posts form-encoded code + code_verifier + client_id + client_secret to token endpoint", async () => {
+    const fetchSpy = mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.gmail-access",
+          refresh_token: "1//refresh-token-x",
+          expires_in: 3599,
+          scope:
+            "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send",
+        },
+      },
+      {
+        ok: true,
+        json: { emailAddress: "alice@example.com", historyId: "hist-1" },
+      },
+    ]);
+
+    await gmailOAuth.handleCallback("auth-code-xyz", "state-token", PKCE_INPUTS);
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+    );
+    const body = fetchSpy.mock.calls[0]![1]!.body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get("grant_type")).toBe("authorization_code");
+    expect(params.get("code")).toBe("auth-code-xyz");
+    expect(params.get("code_verifier")).toBe("verifier-secret-43chars");
+    expect(params.get("client_id")).toBe("test-google-client-id");
+    expect(params.get("client_secret")).toBe("test-google-client-secret");
+    expect(params.get("redirect_uri")).toBe(
+      "https://app.example.test/api/integrations/oauth/gmail/callback",
+    );
+  });
+
+  it("calls users.getProfile with Bearer access token", async () => {
+    const fetchSpy = mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.access",
+          refresh_token: "1//refresh",
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+      { ok: true, json: { emailAddress: "alice@example.com" } },
+    ]);
+
+    await gmailOAuth.handleCallback("c", "s", PKCE_INPUTS);
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+      expect.objectContaining({
+        method: "GET",
+        headers: { Authorization: "Bearer ya29.access" },
+      }),
+    );
+  });
+
+  it("encrypts both access and refresh tokens; decrypt round-trips", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.real-access",
+          refresh_token: "1//real-refresh",
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+      { ok: true, json: { emailAddress: "alice@example.com" } },
+    ]);
+
+    const result = await gmailOAuth.handleCallback("c", "s", PKCE_INPUTS);
+
+    expect(result.tokens.accessTokenEncrypted).not.toContain("ya29.real-access");
+    expect(result.tokens.refreshTokenEncrypted).not.toContain("1//real-refresh");
+    expect(decryptToken(result.tokens.accessTokenEncrypted)).toBe("ya29.real-access");
+    expect(decryptToken(result.tokens.refreshTokenEncrypted!)).toBe("1//real-refresh");
+  });
+
+  it("populates accountInfo from emailAddress (Decision 2c-1)", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.x",
+          refresh_token: "1//y",
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+      { ok: true, json: { emailAddress: "bob@example.com", historyId: "h-42" } },
+    ]);
+
+    const result = await gmailOAuth.handleCallback("c", "s", PKCE_INPUTS);
+
+    expect(result.account.providerAccountId).toBe("bob@example.com");
+    expect(result.account.displayName).toBe("bob@example.com");
+    expect(result.account.metadata).toEqual({
+      email: "bob@example.com",
+      historyId: "h-42",
+    });
+  });
+
+  it("throws when pkce is null", async () => {
+    await expect(gmailOAuth.handleCallback("c", "s", null)).rejects.toThrow(
+      /PKCE code_verifier is required/,
+    );
+  });
+
+  it("throws when pkce.codeVerifier is empty", async () => {
+    await expect(
+      gmailOAuth.handleCallback("c", "s", { codeVerifier: "", codeChallengeMethod: "S256" }),
+    ).rejects.toThrow(/PKCE code_verifier is required/);
+  });
+
+  it("surfaces Google's error code on token-exchange HTTP error", async () => {
+    mockFetchSequence([
+      { ok: false, status: 400, json: { error: "invalid_grant", error_description: "code expired" } },
+    ]);
+    await expect(gmailOAuth.handleCallback("bad-code", "s", PKCE_INPUTS)).rejects.toThrow(
+      /invalid_grant/,
+    );
+  });
+
+  it("throws when token response is missing refresh_token", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.x",
+          // no refresh_token
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+    ]);
+    await expect(gmailOAuth.handleCallback("c", "s", PKCE_INPUTS)).rejects.toThrow(
+      /missing refresh_token/,
+    );
+  });
+
+  it("throws when profile response is missing emailAddress", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.x",
+          refresh_token: "1//y",
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+      { ok: true, json: {} }, // no emailAddress
+    ]);
+    await expect(gmailOAuth.handleCallback("c", "s", PKCE_INPUTS)).rejects.toThrow(
+      /emailAddress/,
+    );
+  });
+
+  it("uses GOOGLE_TOKEN_BASE + GMAIL_API_BASE overrides when set", async () => {
+    process.env.GOOGLE_TOKEN_BASE = "http://127.0.0.1:9877";
+    process.env.GMAIL_API_BASE = "http://127.0.0.1:9877";
+    const fetchSpy = mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.x",
+          refresh_token: "1//y",
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+      { ok: true, json: { emailAddress: "alice@example.com" } },
+    ]);
+
+    await gmailOAuth.handleCallback("c", "s", PKCE_INPUTS);
+
+    expect(fetchSpy.mock.calls[0]![0]).toBe("http://127.0.0.1:9877/token");
+    expect(fetchSpy.mock.calls[1]![0]).toBe("http://127.0.0.1:9877/gmail/v1/users/me/profile");
+  });
+});
+
+describe("gmailOAuth.refreshToken", () => {
+  it("posts grant_type=refresh_token with the input refresh token", async () => {
+    const fetchSpy = mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.new-access",
+          refresh_token: "1//rotated-refresh", // Google rotated
+          expires_in: 3599,
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+    ]);
+
+    await gmailOAuth.refreshToken("1//old-refresh");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      }),
+    );
+    const body = fetchSpy.mock.calls[0]![1]!.body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get("grant_type")).toBe("refresh_token");
+    expect(params.get("refresh_token")).toBe("1//old-refresh");
+    expect(params.get("client_id")).toBe("test-google-client-id");
+    expect(params.get("client_secret")).toBe("test-google-client-secret");
+  });
+
+  it("when Google returns a new refresh_token, uses the rotated one", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.new",
+          refresh_token: "1//rotated",
+          expires_in: 3599,
+          scope: "",
+        },
+      },
+    ]);
+
+    const result = await gmailOAuth.refreshToken("1//old");
+
+    expect(decryptToken(result.refreshTokenEncrypted!)).toBe("1//rotated");
+    expect(decryptToken(result.accessTokenEncrypted)).toBe("ya29.new");
+  });
+
+  it("when Google omits refresh_token, preserves the input refresh token (Decision 2b-5)", async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        json: {
+          access_token: "ya29.new",
+          // no refresh_token — Google's default Gmail behavior
+          expires_in: 3599,
+          scope: "",
+        },
+      },
+    ]);
+
+    const result = await gmailOAuth.refreshToken("1//original");
+
+    // The encrypted ciphertext bytes WILL change (fresh IV per encryption)
+    // but the underlying plaintext is the same.
+    expect(decryptToken(result.refreshTokenEncrypted!)).toBe("1//original");
+  });
+
+  it("surfaces Google's error code on refresh failure", async () => {
+    mockFetchSequence([
+      { ok: false, status: 400, json: { error: "invalid_grant" } },
+    ]);
+    await expect(gmailOAuth.refreshToken("dead-token")).rejects.toThrow(/invalid_grant/);
+  });
+});
+
+describe("gmailOAuth.revoke", () => {
+  it("is a no-op stub for Slice 2c (matches Slack's pattern; deferred)", async () => {
+    await expect(gmailOAuth.revoke("any-token")).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/integrations/slack/oauth.test.ts
+++ b/tests/unit/integrations/slack/oauth.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 
 describe("slackOAuth.buildAuthUrl", () => {
   it("produces a Slack v2 authorize URL with all required params", () => {
-    const url = slackOAuth.buildAuthUrl("STATE-TOKEN", ["chat:write", "channels:read"]);
+    const url = slackOAuth.buildAuthUrl("STATE-TOKEN", ["chat:write", "channels:read"], null);
     const u = new URL(url);
     expect(u.origin + u.pathname).toBe("https://slack.com/oauth/v2/authorize");
     expect(u.searchParams.get("client_id")).toBe("test-slack-client-id");
@@ -27,7 +27,7 @@ describe("slackOAuth.buildAuthUrl", () => {
 
   it("falls back to localhost redirect_uri when NEXT_PUBLIC_APP_URL is not set", () => {
     delete process.env.NEXT_PUBLIC_APP_URL;
-    const url = slackOAuth.buildAuthUrl("S", ["chat:write"]);
+    const url = slackOAuth.buildAuthUrl("S", ["chat:write"], null);
     expect(new URL(url).searchParams.get("redirect_uri")).toBe(
       "http://localhost:3000/api/integrations/oauth/slack/callback",
     );
@@ -35,12 +35,12 @@ describe("slackOAuth.buildAuthUrl", () => {
 
   it("throws when SLACK_CLIENT_ID is not set", () => {
     delete process.env.SLACK_CLIENT_ID;
-    expect(() => slackOAuth.buildAuthUrl("S", ["chat:write"])).toThrow(/SLACK_CLIENT_ID/);
+    expect(() => slackOAuth.buildAuthUrl("S", ["chat:write"], null)).toThrow(/SLACK_CLIENT_ID/);
   });
 
   it("uses SLACK_AUTHORIZE_BASE override when set (e2e mock surface)", () => {
     process.env.SLACK_AUTHORIZE_BASE = "http://localhost:9876";
-    const url = slackOAuth.buildAuthUrl("S", ["chat:write"]);
+    const url = slackOAuth.buildAuthUrl("S", ["chat:write"], null);
     const u = new URL(url);
     expect(u.origin + u.pathname).toBe(
       "http://localhost:9876/oauth/v2/authorize",
@@ -49,12 +49,12 @@ describe("slackOAuth.buildAuthUrl", () => {
 
   it("defaults to slack.com when SLACK_AUTHORIZE_BASE is unset (production-safe)", () => {
     delete process.env.SLACK_AUTHORIZE_BASE;
-    const url = slackOAuth.buildAuthUrl("S", ["chat:write"]);
+    const url = slackOAuth.buildAuthUrl("S", ["chat:write"], null);
     expect(new URL(url).origin).toBe("https://slack.com");
   });
 
   it("URL-encodes scopes with special characters", () => {
-    const url = slackOAuth.buildAuthUrl("S", ["channels:history", "chat:write.public"]);
+    const url = slackOAuth.buildAuthUrl("S", ["channels:history", "chat:write.public"], null);
     const u = new URL(url);
     expect(u.searchParams.get("scope")).toBe("channels:history,chat:write.public");
   });

--- a/tests/unit/services/oauth/dispatcher.test.ts
+++ b/tests/unit/services/oauth/dispatcher.test.ts
@@ -72,4 +72,61 @@ describe("dispatcher.connect", () => {
       ]),
     );
   });
+
+  it("does NOT pass PKCE for non-PKCE providers (Slack default v2)", async () => {
+    await connect({ userId: "u", provider: "slack" });
+    // No PKCE columns persisted on the oauth_states row
+    const created = mockOAuthStatesCreate.mock.calls[0]![0] as Record<string, unknown>;
+    expect(created.pkceCodeVerifier).toBeUndefined();
+    expect(created.pkceCodeChallengeMethod).toBeUndefined();
+  });
+});
+
+describe("dispatcher.connect — PKCE flow (Slice 2c)", () => {
+  beforeEach(() => {
+    process.env.GOOGLE_CLIENT_ID = "test-google-client-id";
+  });
+  afterEach(() => {
+    delete process.env.GOOGLE_CLIENT_ID;
+  });
+
+  it("calls provider.generatePkce, persists verifier+method on the state row, embeds challenge in URL", async () => {
+    const { redirectUrl } = await connect({ userId: "user-pkce", provider: "gmail" });
+    const u = new URL(redirectUrl);
+    expect(u.origin + u.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+
+    // Verifier + method went to the oauth_states row.
+    expect(mockOAuthStatesCreate).toHaveBeenCalledTimes(1);
+    const created = mockOAuthStatesCreate.mock.calls[0]![0] as Record<string, unknown>;
+    expect(created.pkceCodeChallengeMethod).toBe("S256");
+    expect(typeof created.pkceCodeVerifier).toBe("string");
+    expect((created.pkceCodeVerifier as string).length).toBeGreaterThanOrEqual(43);
+
+    // Challenge ended up in the authorize URL (NOT the verifier — the
+    // verifier is the secret half and never goes in the URL).
+    const challenge = u.searchParams.get("code_challenge");
+    expect(challenge).toBeTruthy();
+    expect(challenge).not.toBe(created.pkceCodeVerifier);
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+
+    // Google-required offline-access params.
+    expect(u.searchParams.get("access_type")).toBe("offline");
+    expect(u.searchParams.get("prompt")).toBe("consent");
+  });
+
+  it("each connect produces a fresh PKCE pair (no verifier reuse)", async () => {
+    const a = await connect({ userId: "u-1", provider: "gmail" });
+    const b = await connect({ userId: "u-2", provider: "gmail" });
+    const aChallenge = new URL(a.redirectUrl).searchParams.get("code_challenge");
+    const bChallenge = new URL(b.redirectUrl).searchParams.get("code_challenge");
+    expect(aChallenge).toBeTruthy();
+    expect(bChallenge).toBeTruthy();
+    expect(aChallenge).not.toBe(bChallenge);
+
+    const aVerifier = (mockOAuthStatesCreate.mock.calls[0]![0] as Record<string, unknown>)
+      .pkceCodeVerifier;
+    const bVerifier = (mockOAuthStatesCreate.mock.calls[1]![0] as Record<string, unknown>)
+      .pkceCodeVerifier;
+    expect(aVerifier).not.toBe(bVerifier);
+  });
 });


### PR DESCRIPTION
## Summary

First refreshable + first PKCE-using provider in V2. Slice 2a's PKCE plumbing and Slice 2b's refresh dispatcher / `refreshAndRetry` / per-user single-flight lock all hook into Gmail's `oauth.ts`. No actions, no trigger, no e2e — those are Slices 2d / 2e / 2f.

This is **Slice 2c** of the Slice 2 plan. Gmail OAuth + manifest only; the slice is intentionally narrow so the contract change to `ProviderOAuth` (PKCE-related additions) ships with one real consumer and reviewable surface area.

Confirmed decisions: account ID via Gmail `users.getProfile.emailAddress` (2c-1, A); 32-byte / 43-char base64url PKCE verifier (2c-2, A); S256 method only (2c-3, A); `prompt=consent` always (2c-4, A); three separate env vars `GOOGLE_AUTHORIZE_BASE` / `GOOGLE_TOKEN_BASE` / `GMAIL_API_BASE` (2c-5, A); `revoke` stub deferred (2c-6, A); provider-owned `generatePkce` (2c-7, Option I).

## What ships

**Source (4 modified, 2 new):**

- `contracts/integration.ts` — extended `ProviderOAuth` contract:
  - new optional `generatePkce?(): PkceGeneration` method (Decision 2c-7 Option I — provider-owned PKCE generation).
  - new exported types `PkceChallenge` (challenge half for the URL) and `PkceGeneration` (verifier + challenge + method, returned from `generatePkce`).
  - `buildAuthUrl` signature widened from `(state, scopes)` to `(state, scopes, pkce: PkceChallenge | null)` — same fewer-params variance pattern as Slice 2a's `handleCallback` widening; Slack's `(state, scopes)` implementation stays valid via TS contextual typing.

- `services/oauth/dispatcher.ts:connect` — calls `oauth.generatePkce?.()` and threads:
  - `codeVerifier` + `codeChallengeMethod` into `createState`'s `pkce` arg (persisted on the `oauth_states` row at connect time).
  - `codeChallenge` + `codeChallengeMethod` into `buildAuthUrl`'s third arg (embedded in the authorize URL).
  Non-PKCE providers (Slack) omit `generatePkce` entirely → optional chaining returns `undefined` → no PKCE metadata flows anywhere.

- `integrations/gmail/manifest.ts` — Gmail provider manifest. Scopes: required `gmail.readonly` + `gmail.send` (Slice 2 Q6 narrow set). `refreshable: true`. `tokenScope: "user"`. `accountIdField: "email"`. `healthCheckIntervalMs: 6h` (V1 Google cadence). Capabilities reflect honest current state — `webhookTrigger` / `pollingTrigger` / `actions` all `false`; flip true in 2d/2e when their handlers ship.

- `integrations/gmail/oauth.ts` — full `ProviderOAuth` implementation:
  - `generatePkce`: 32 random bytes → 43-char base64url verifier; challenge = `base64url(SHA256(verifier))`; method `S256` hardcoded.
  - `buildAuthUrl`: `response_type=code` + `client_id` + `redirect_uri` + `scope` (space-separated per Google) + `state` + `access_type=offline` + `prompt=consent` (always) + `code_challenge` + `code_challenge_method=S256`. Throws if `pkce` is null.
  - `handleCallback`: throws clear error when `pkce` is null (defense-in-depth — should be impossible for Gmail given the dispatcher's `generatePkce` threading). POSTs `code` + `code_verifier` + `client_id` + `client_secret` to `oauth2.googleapis.com/token`. Calls `gmail.googleapis.com/v1/users/me/profile` with the access token, extracts `emailAddress` as `providerAccountId`. Throws explicitly when `refresh_token` is missing — first-connect with `prompt=consent` should always issue one.
  - `refreshToken`: Decision 2b-5 preserve-old policy. When Google's response includes `refresh_token`, encrypts and returns the rotated one. When omitted (Google's default Gmail behavior), re-encrypts the input refresh token plaintext and returns it. Repository's `updateTokens` always writes whatever the provider returned; preserve-old logic lives in the provider per the parent decision.
  - `revoke`: stub deferred to disconnect-UX slice (matches Slack's pattern; parent Slice 2 Decision 4 keeps revoke out of scope).
  - Three env-overridable base URLs (Decision 2c-5): `GOOGLE_AUTHORIZE_BASE`, `GOOGLE_TOKEN_BASE`, `GMAIL_API_BASE` — all default to real Google in production.

- `integrations/_registry.ts` — adds `gmailManifest` to `ALL_MANIFESTS`. Validates against `ProviderManifestSchema` at module load.

- `services/oauth/dispatcher.ts:OAUTH_BY_PROVIDER` — adds `gmail: gmailOAuth`.

- `.env.example` — adds `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` (real values for dev), and commented `GOOGLE_AUTHORIZE_BASE` / `GOOGLE_TOKEN_BASE` / `GMAIL_API_BASE` (e2e-mocking only; production leaves unset).

**Test infrastructure:**
- `tests/__mocks__/integrations/_pkceMockProvider/oauth.ts` — mock provider factory extended with `generatePkce` option (`PkceGeneration | () => PkceGeneration`); when set, mock implements the optional method, when omitted mock OMITS the method (matches Slack-shaped non-PKCE provider contract). `PkceMockState` extended with `generatePkceCallCount` and `buildAuthUrlCalls` now capture `pkce` arg.

## Why Slack source files stay untouched

`integrations/slack/oauth.ts` keeps its 2-arg `buildAuthUrl(state, scopes)` and no `generatePkce` method — TS contextual typing accepts narrower implementations against the widened interface plus optional methods (same Slice 2a precedent). Test file `tests/unit/integrations/slack/oauth.test.ts` updated to pass `null` as `buildAuthUrl`'s 3rd arg at 6 direct call sites; this is mechanical fix-up, no Slack production behavior change.

## Tests (+2 new suites, +32 tests, 649 → 681 total)

- `tests/unit/integrations/gmail/manifest.test.ts` (6 tests) — registry registration, narrow scope set, `refreshable: true`, tokenScope/accountIdField, honest capabilities (only `oauth: true`), 6h health interval.
- `tests/unit/integrations/gmail/oauth.test.ts` (23 tests) — `generatePkce` (verifier shape, challenge derivation, S256, freshness); `buildAuthUrl` (all required params + PKCE, null-pkce throws, missing-env throws, override); `handleCallback` (request shape including `code_verifier`, profile Bearer auth, encryption round-trip on both tokens, accountInfo from emailAddress, pkce-required throws, Google error surface, missing-refresh-token throws, missing-emailAddress throws, env-override paths); `refreshToken` (request shape, rotation, preserve-old, error surface); `revoke` stub.
- `tests/unit/services/oauth/dispatcher.test.ts` (+3 tests) — Slack connect persists no PKCE on the row; Gmail connect calls `generatePkce` and persists verifier + embeds challenge in URL (asserting verifier ≠ challenge); each Gmail connect produces a fresh PKCE pair.

## Backward compatibility

- **No DB migration.** `oauth_states.pkce_code_verifier` + `pkce_code_challenge_method` columns shipped in Slice 1; Gmail is the first real consumer.
- **No production registry change** beyond the Gmail entry. Mock provider extensions live entirely under `tests/__mocks__`.
- **No handler currently wires into `refreshAndRetry`.** Slice 2d adopts it for Gmail's send action.
- **`ProviderOAuth` contract widened** with optional `generatePkce?:` and 3-arg `buildAuthUrl` — both changes safe via TS variance + optional method. Slack source untouched. Slack tests updated mechanically per the Slice 2a precedent.
- **Slice 1 e2e regression smoke green** — `slice-1-slack-walkthrough.spec.ts` passed in 19.5s, matching baseline 19.2–19.5s.

## Out of scope (deferred to later sub-slices)

- Gmail send action handler — Slice 2d.
- Gmail polling trigger + shared polling scheduler infrastructure — Slice 2e.
- Gmail e2e walkthrough (full Playwright flow with mocked Google) — Slice 2f.
- `dispatcher.revoke` and Slack/Gmail revoke implementations — Slice 2.5+ disconnect UX.
- Wiring any handler into `refreshAndRetry` — Slice 2d.
- Health-engine listener for `IntegrationActionRequiredError` — its own future slice.

## Slice 2d readiness

Slice 2d (Gmail send action) can adopt this directly:
- Gmail OAuth + manifest are registered; `getActiveForExecution(userId, "gmail", emailAddress)` returns the integration row.
- `gmailOAuth.refreshToken` works end-to-end via `dispatcher.refresh` + `refreshAndRetry`.
- The send-action handler wraps its `users.messages.send` call in `refreshAndRetry({ userId, provider: "gmail", accountId, apiCall: token => ... })`.
- The Gmail API helper for `users.messages.send` throws `Unauthorized401Error` on HTTP 401.
- Gmail manifest's `actions: false` flips to `true` in 2d when the handler lands.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run lint:structure` — OK
- [x] `npm run lint:migrations` — OK (no migration changes)
- [x] `npx jest tests/unit/integrations/gmail/ tests/unit/services/oauth/ tests/unit/integrations/slack/ tests/unit/integrations/_registry.test.ts` — 16 suites / 152 tests passed
- [x] `npm test` — 75 suites / 681 tests passed in 3.20s
- [x] `npx playwright test tests/e2e/slice-1-slack-walkthrough.spec.ts` — 1 passed in 19.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
