### PR TITLE
test(e2e): add Gmail walkthrough with mocked Google boundary

### DIFF
--- a/integrations/gmail/triggers/newEmail/poll.ts
+++ b/integrations/gmail/triggers/newEmail/poll.ts
@@ -1,5 +1,6 @@
 import { refreshAndRetry } from "@/services/oauth/refreshAndRetry";
 import { enqueueRun } from "@/services/execution/enqueue";
+import { getActiveForExecution } from "@/repositories/integrations";
 import * as triggerResourcesRepo from "@/repositories/triggerResources";
 import type { PollingHandler } from "@/services/triggers/pollingRegistry";
 import { DEFAULT_INTERVAL_MS } from "@/services/cron/pollingIntervals";
@@ -67,6 +68,32 @@ async function poll(input: {
     return;
   }
 
+  // Resolve the integration's email up-front. trigger_resources.account_id
+  // is intentionally NULL per services/triggers/lifecycle.ts — the design
+  // is "account_id resolved on-demand" so that account swaps don't leave
+  // stale rows. Webhook dispatchers read it from the inbound payload;
+  // polling reads it here, once per cycle. The resolved email becomes
+  // both TriggerEvent.accountId (so action handlers can target the right
+  // inbox) AND the explicit accountId on refreshAndRetry calls (avoids
+  // the multi-account ambiguity case).
+  const integration = await getActiveForExecution(
+    trigger.userId,
+    "gmail",
+    null,
+  );
+  if (!integration) {
+    console.warn(
+      JSON.stringify({
+        event: "gmail.poll.no_integration",
+        triggerId: trigger.id,
+        workflowId: trigger.workflowId,
+        userId: trigger.userId,
+      }),
+    );
+    return;
+  }
+  const accountId = integration.providerAccountId;
+
   let cursor = config.snapshot.historyId;
 
   // Walk all pages. Page through with nextPageToken until exhausted.
@@ -81,7 +108,7 @@ async function poll(input: {
       page = await refreshAndRetry({
         userId: trigger.userId,
         provider: "gmail",
-        accountId: trigger.accountId,
+        accountId,
         apiCall: async (accessToken) =>
           usersHistoryList({
             accessToken,
@@ -96,7 +123,7 @@ async function poll(input: {
         const profile = await refreshAndRetry({
           userId: trigger.userId,
           provider: "gmail",
-          accountId: trigger.accountId,
+          accountId,
           apiCall: async (accessToken) => usersGetProfile({ accessToken }),
         });
         console.warn(
@@ -131,7 +158,7 @@ async function poll(input: {
   if (!cursorReset) {
     for (const messageId of uniqueIds) {
       try {
-        await processOneMessage({ trigger, messageId });
+        await processOneMessage({ trigger, accountId, messageId });
       } catch (err) {
         console.warn(
           JSON.stringify({
@@ -169,9 +196,10 @@ async function poll(input: {
 
 async function processOneMessage(input: {
   trigger: import("@/repositories/triggerResources").TriggerResourceRecord;
+  accountId: string;
   messageId: string;
 }): Promise<void> {
-  const { trigger, messageId } = input;
+  const { trigger, accountId, messageId } = input;
   const config = GmailNewEmailConfigSchema.parse(trigger.config);
 
   const dedupOutcome = await checkAndMarkSeen(messageId);
@@ -181,14 +209,14 @@ async function processOneMessage(input: {
   const message = await refreshAndRetry({
     userId: trigger.userId,
     provider: "gmail",
-    accountId: trigger.accountId,
+    accountId,
     apiCall: async (accessToken) => usersMessagesGet({ accessToken, messageId }),
   });
 
   if (!matchesFilters(message, config)) return;
 
   const event = buildTriggerEvent({
-    emailAddress: trigger.accountId ?? "",
+    emailAddress: accountId,
     message,
   });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,17 @@ const SLACK_MOCK_PORT = Number(process.env.SLACK_MOCK_PORT ?? "9876");
 const MOCK_BASE = `http://127.0.0.1:${SLACK_MOCK_PORT}`;
 
 /**
+ * Google mock server runs on this port (started by global-setup.ts). The
+ * dev server inherits GMAIL_API_BASE / GOOGLE_AUTHORIZE_BASE /
+ * GOOGLE_TOKEN_BASE pointing here, so all of V2's server-side Google
+ * outbound calls land on the mock — including the OAuth callback's
+ * token exchange + getProfile, the Slice 2e activation hook, and the
+ * polling cycle's history.list / messages.get / messages.send.
+ */
+const GMAIL_MOCK_PORT = Number(process.env.GMAIL_MOCK_PORT ?? "9877");
+const GOOGLE_MOCK_BASE = `http://127.0.0.1:${GMAIL_MOCK_PORT}`;
+
+/**
  * E2e dev server port. Default 3001 — separate from the typical dev port
  * (3000) so a developer keeping a dev server running for manual testing
  * doesn't collide with the e2e dev server, and so the e2e dev server
@@ -55,6 +66,14 @@ export default defineConfig({
       // Production never sets these; the override is e2e-only.
       SLACK_API_BASE: MOCK_BASE,
       SLACK_AUTHORIZE_BASE: MOCK_BASE,
+      // Slice 2f: route Google OAuth + Gmail API calls through the
+      // Google mock. Same e2e-only override pattern. integrations/gmail/
+      // oauth.ts already supports all three env vars (Slice 2c shipped
+      // them); the cron route + activation hook + polling handler all
+      // read GMAIL_API_BASE, so all four code paths land on the mock.
+      GMAIL_API_BASE: GOOGLE_MOCK_BASE,
+      GOOGLE_AUTHORIZE_BASE: GOOGLE_MOCK_BASE,
+      GOOGLE_TOKEN_BASE: GOOGLE_MOCK_BASE,
       // Force the dev server to use the e2e port as its public URL even
       // when .env.local sets NEXT_PUBLIC_APP_URL to something else (e.g.
       // an ngrok tunnel for manual testing). The OAuth dispatcher reads

--- a/services/triggers/lifecycle.ts
+++ b/services/triggers/lifecycle.ts
@@ -2,6 +2,12 @@ import { getActiveForExecution } from "@/repositories/integrations";
 import * as triggerResourcesRepo from "@/repositories/triggerResources";
 import type { WorkflowRecord } from "@/repositories/workflows";
 import { findActivation } from "@/services/triggers/activationRegistry";
+// Side-effect import: forces provider activation/polling-handler
+// registrations at module load. Without this, an activate API request
+// that loads the orchestrator → lifecycle module graph in isolation
+// would see an empty activation registry and skip the snapshot init.
+// (Slice 2f bug — surfaced first by the Gmail e2e walkthrough.)
+import "@/integrations/_registry";
 
 /**
  * Trigger lifecycle service.

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -5,31 +5,45 @@ import {
   startMockSlackServer,
   type MockSlackHandle,
 } from "./helpers/mockSlackServer";
+import {
+  startMockGoogleServer,
+  type MockGoogleHandle,
+} from "./helpers/mockGoogleServer";
 
 /**
  * Playwright global setup.
  *
- * Boots the mock Slack server before any tests run. Writes the resolved
- * base URL to a state file so individual specs can read it without
- * cross-process plumbing (Playwright's globalSetup return value isn't
- * accessible from spec files in the same way).
+ * Boots the mock Slack + Google servers before any tests run. Writes each
+ * resolved base URL to its own state file so individual specs can read
+ * them without cross-process plumbing (Playwright's globalSetup return
+ * value isn't accessible from spec files in the same way).
  *
- * The dev server (started via webServer in playwright.config.ts) already
- * has SLACK_API_BASE / SLACK_AUTHORIZE_BASE env vars set in the config,
- * pointing at this same mock URL — that's what makes V2's server-side
- * Slack calls land on the mock.
+ * The dev server (started via webServer in playwright.config.ts) has
+ * SLACK_API_BASE / SLACK_AUTHORIZE_BASE / GMAIL_API_BASE /
+ * GOOGLE_AUTHORIZE_BASE / GOOGLE_TOKEN_BASE env vars pointing at these
+ * same mock URLs — that's what makes V2's server-side calls land on the
+ * mocks.
  *
- * Module-level handle: held in a module-scoped variable for global-teardown
- * to reach. Playwright invokes both setup + teardown in the same Node
- * process, so module state survives.
+ * Module-level handles: held in module-scoped variables for
+ * global-teardown to reach. Playwright invokes both setup + teardown in
+ * the same Node process, so module state survives.
  */
 
-let handle: MockSlackHandle | null = null;
+let slackHandle: MockSlackHandle | null = null;
+let googleHandle: MockGoogleHandle | null = null;
 
 export const STATE_FILE = resolve(__dirname, ".state/mock-slack.json");
+export const GOOGLE_STATE_FILE = resolve(
+  __dirname,
+  ".state/mock-google.json",
+);
 
 export function getMockHandle(): MockSlackHandle | null {
-  return handle;
+  return slackHandle;
+}
+
+export function getGoogleMockHandle(): MockGoogleHandle | null {
+  return googleHandle;
 }
 
 /**
@@ -57,6 +71,11 @@ const SPEC_PROCESS_ENV_KEYS = [
   "NEXT_PUBLIC_SUPABASE_URL",
   "SUPABASE_SERVICE_ROLE_KEY",
   "SLACK_SIGNING_SECRET",
+  // Slice 2f: the spec POSTs to /api/cron/poll-triggers with
+  // `Authorization: Bearer $CRON_SECRET`. The dev server reads
+  // CRON_SECRET from .env.local automatically; the spec process needs
+  // it lifted explicitly.
+  "CRON_SECRET",
 ];
 
 function loadDotEnvLocal(): void {
@@ -86,21 +105,44 @@ export default async function globalSetup(): Promise<void> {
   // Match playwright.config.ts E2E_PORT default.
   const e2ePort = Number(process.env.E2E_PORT ?? "3001");
   const appBaseUrl = `http://localhost:${e2ePort}`;
-  const port = Number(process.env.SLACK_MOCK_PORT ?? "9876");
-  handle = await startMockSlackServer({ appBaseUrl, port });
+
+  const slackPort = Number(process.env.SLACK_MOCK_PORT ?? "9876");
+  slackHandle = await startMockSlackServer({ appBaseUrl, port: slackPort });
   await mkdir(dirname(STATE_FILE), { recursive: true });
   await writeFile(
     STATE_FILE,
-    JSON.stringify({ port, baseUrl: handle.baseUrl, appBaseUrl }),
+    JSON.stringify({
+      port: slackPort,
+      baseUrl: slackHandle.baseUrl,
+      appBaseUrl,
+    }),
     "utf8",
   );
   console.log(
-    `[e2e] mock Slack listening at ${handle.baseUrl} (V2 callbacks land on ${appBaseUrl})`,
+    `[e2e] mock Slack listening at ${slackHandle.baseUrl} (V2 callbacks land on ${appBaseUrl})`,
+  );
+
+  const googlePort = Number(process.env.GMAIL_MOCK_PORT ?? "9877");
+  googleHandle = await startMockGoogleServer({
+    appBaseUrl,
+    port: googlePort,
+  });
+  await writeFile(
+    GOOGLE_STATE_FILE,
+    JSON.stringify({
+      port: googlePort,
+      baseUrl: googleHandle.baseUrl,
+      appBaseUrl,
+    }),
+    "utf8",
+  );
+  console.log(
+    `[e2e] mock Google listening at ${googleHandle.baseUrl} (V2 callbacks land on ${appBaseUrl})`,
   );
 }
 
 /**
- * Spec-side helper to read the mock URL written by global-setup.
+ * Spec-side helper to read the Slack mock URL written by global-setup.
  * Specs that need to assert on the mock's recorded calls go through the
  * shared `getMockHandle()` import — it's the same module instance because
  * Jest/Playwright isolates per-process, not per-import.
@@ -111,6 +153,19 @@ export async function readMockState(): Promise<{
   appBaseUrl: string;
 }> {
   const raw = await readFile(STATE_FILE, "utf8");
+  return JSON.parse(raw) as {
+    port: number;
+    baseUrl: string;
+    appBaseUrl: string;
+  };
+}
+
+export async function readGoogleMockState(): Promise<{
+  port: number;
+  baseUrl: string;
+  appBaseUrl: string;
+}> {
+  const raw = await readFile(GOOGLE_STATE_FILE, "utf8");
   return JSON.parse(raw) as {
     port: number;
     baseUrl: string;

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,13 +1,23 @@
 import { rm } from "node:fs/promises";
 import { dirname } from "node:path";
-import { getMockHandle, STATE_FILE } from "./global-setup";
+import {
+  getGoogleMockHandle,
+  getMockHandle,
+  STATE_FILE,
+} from "./global-setup";
 
 export default async function globalTeardown(): Promise<void> {
-  const handle = getMockHandle();
-  if (handle) {
-    await handle.stop();
+  const slackHandle = getMockHandle();
+  if (slackHandle) {
+    await slackHandle.stop();
     console.log("[e2e] mock Slack stopped");
   }
-  // Clean up the state directory.
+  const googleHandle = getGoogleMockHandle();
+  if (googleHandle) {
+    await googleHandle.stop();
+    console.log("[e2e] mock Google stopped");
+  }
+  // Clean up the state directory. Both state files live under the same
+  // .state/ folder, so removing the parent dir cleans both.
   await rm(dirname(STATE_FILE), { recursive: true, force: true });
 }

--- a/tests/e2e/helpers/mockGoogleServer.ts
+++ b/tests/e2e/helpers/mockGoogleServer.ts
@@ -1,0 +1,628 @@
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { URL } from "node:url";
+import { Buffer } from "node:buffer";
+
+/**
+ * Standalone mock Google server for the Slice 2f Gmail e2e walkthrough.
+ *
+ * Routes (sized to V2's actual call patterns — nothing more):
+ *   GET  /o/oauth2/v2/auth                       → 302 to V2's
+ *                                                  /api/integrations/oauth/gmail/callback
+ *                                                  with the preserved state +
+ *                                                  a synthetic code.
+ *   POST /token                                  → canned token-exchange
+ *                                                  response with a recognizable
+ *                                                  access + refresh token.
+ *   GET  /gmail/v1/users/me/profile              → emailAddress + currentHistoryId.
+ *                                                  Used by Slice 2c's OAuth
+ *                                                  callback for accountId AND
+ *                                                  by Slice 2e's activation
+ *                                                  hook for the snapshot.
+ *   GET  /gmail/v1/users/me/history              → history.list, returns one
+ *                                                  messageAdded entry per email
+ *                                                  injected since startHistoryId.
+ *   GET  /gmail/v1/users/me/messages/{id}        → format=metadata response for
+ *                                                  the injected email by id.
+ *   POST /gmail/v1/users/me/messages/send        → records the base64url raw
+ *                                                  body decoded into headers +
+ *                                                  body parts; returns a fake
+ *                                                  send id.
+ *
+ * Control plane (test-only):
+ *   POST /__injectEmail   — inject an email into the mock store and bump
+ *                           historyId; the next history.list returns it.
+ *   POST /__replayLastEmail — re-queue the most recently injected email
+ *                           WITHOUT bumping historyId. Used by the dedup
+ *                           probe so the spec proves the same Gmail message
+ *                           id seen twice does not produce two runs.
+ *   POST /__reset         — clear calls + email store + reset historyId.
+ *   GET  /__inspect       — dump calls + store state; cross-process seam.
+ *
+ * Listens on a fixed port (default 9877, override via GMAIL_MOCK_PORT).
+ * Different port from Slack (9876) so both can run simultaneously under
+ * the same global-setup. If the port is busy, fail loud at start.
+ *
+ * Stateful: tracks an in-memory `currentHistoryId` (BigInt) and a queue
+ * of `pendingHistoryEntries` so the spec controls exactly which messages
+ * surface on each history.list call. The `replayLastEmail` knob exists
+ * specifically for the dedup test — re-queues an entry without bumping
+ * the cursor, exactly like a stored-historyId-rewound scenario.
+ */
+
+const SEED_HISTORY_ID = "100000";
+
+export interface RecordedAuthorize {
+  state: string;
+  scope: string;
+  codeChallenge: string | null;
+}
+
+export interface RecordedTokenExchange {
+  body: string;
+  parsedBody: Record<string, string>;
+}
+
+export interface RecordedProfile {
+  authorization: string | undefined;
+  responseHistoryId: string;
+}
+
+export interface RecordedHistoryList {
+  authorization: string | undefined;
+  url: string;
+  startHistoryId: string;
+  pageToken: string | null;
+  historyTypes: string[];
+  responseEntries: number;
+}
+
+export interface RecordedMessagesGet {
+  authorization: string | undefined;
+  url: string;
+  messageId: string;
+  format: string;
+}
+
+export interface RecordedMessagesSend {
+  authorization: string | undefined;
+  raw: string;
+  decoded: string;
+  parsed: ParsedRfc5322;
+}
+
+/**
+ * Minimal RFC 5322 parse — splits headers / body on the first blank line,
+ * extracts header name/value pairs case-insensitively, and pulls the
+ * primary mimeType. For multipart/alternative we also bucket parts by
+ * Content-Type so the spec can grep the plain-text leaf.
+ */
+export interface ParsedRfc5322 {
+  headers: Record<string, string>;
+  mimeType: string;
+  partsByMimeType: Record<string, string>;
+}
+
+export interface InjectedEmail {
+  id: string;
+  threadId: string;
+  labelIds: readonly string[];
+  snippet: string;
+  internalDate: string;
+  sizeEstimate: number;
+  mimeType: string;
+  headers: Array<{ name: string; value: string }>;
+  /** historyId that was current when the email was injected. */
+  historyIdAtInsert: string;
+}
+
+export interface MockGoogleHandle {
+  port: number;
+  baseUrl: string;
+  /** Cumulative call records since last reset. */
+  calls: {
+    authorize: RecordedAuthorize[];
+    tokenExchange: RecordedTokenExchange[];
+    profile: RecordedProfile[];
+    historyList: RecordedHistoryList[];
+    messagesGet: RecordedMessagesGet[];
+    send: RecordedMessagesSend[];
+  };
+  /** Map of injected emails by id. */
+  emails: Map<string, InjectedEmail>;
+  /**
+   * historyId entries pending delivery on the next history.list call.
+   * Each entry pairs a message id with the historyId it was added at.
+   * `replayLastEmail` re-pushes the most recent pending without bumping.
+   */
+  pendingHistoryEntries: Array<{ historyId: string; messageId: string }>;
+  /** Current historyId — returned by getProfile + history.list. */
+  currentHistoryId: string;
+  /** Most recently injected message id (for replay). */
+  lastInjectedMessageId: string | null;
+  reset(): void;
+  stop(): Promise<void>;
+}
+
+const DEFAULT_PORT = Number(process.env.GMAIL_MOCK_PORT ?? "9877");
+
+export async function startMockGoogleServer(opts: {
+  appBaseUrl: string;
+  port?: number;
+}): Promise<MockGoogleHandle> {
+  const port = opts.port ?? DEFAULT_PORT;
+
+  const state: Pick<
+    MockGoogleHandle,
+    "calls" | "emails" | "pendingHistoryEntries" | "currentHistoryId" | "lastInjectedMessageId"
+  > = freshState();
+
+  const server: Server = createServer((req, res) => {
+    handleRequest(req, res, opts.appBaseUrl, state).catch((err) => {
+      console.error("[mock-google] handler crashed", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end("mock-google handler crashed");
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    get calls() {
+      return state.calls;
+    },
+    get emails() {
+      return state.emails;
+    },
+    get pendingHistoryEntries() {
+      return state.pendingHistoryEntries;
+    },
+    get currentHistoryId() {
+      return state.currentHistoryId;
+    },
+    get lastInjectedMessageId() {
+      return state.lastInjectedMessageId;
+    },
+    reset: () => Object.assign(state, freshState()),
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function freshState(): Pick<
+  MockGoogleHandle,
+  "calls" | "emails" | "pendingHistoryEntries" | "currentHistoryId" | "lastInjectedMessageId"
+> {
+  return {
+    calls: {
+      authorize: [],
+      tokenExchange: [],
+      profile: [],
+      historyList: [],
+      messagesGet: [],
+      send: [],
+    },
+    emails: new Map(),
+    pendingHistoryEntries: [],
+    currentHistoryId: SEED_HISTORY_ID,
+    lastInjectedMessageId: null,
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  appBaseUrl: string,
+  state: Pick<
+    MockGoogleHandle,
+    "calls" | "emails" | "pendingHistoryEntries" | "currentHistoryId" | "lastInjectedMessageId"
+  >,
+): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://placeholder");
+
+  // ── Authorize ──
+  if (req.method === "GET" && url.pathname === "/o/oauth2/v2/auth") {
+    const stateParam = url.searchParams.get("state");
+    const scope = url.searchParams.get("scope") ?? "";
+    const codeChallenge = url.searchParams.get("code_challenge");
+    if (!stateParam) {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("missing state");
+      return;
+    }
+    state.calls.authorize.push({ state: stateParam, scope, codeChallenge });
+    const callback = new URL(
+      "/api/integrations/oauth/gmail/callback",
+      appBaseUrl,
+    );
+    callback.searchParams.set("code", `mock-google-code-${Date.now()}`);
+    callback.searchParams.set("state", stateParam);
+    res.writeHead(302, { location: callback.toString() });
+    res.end();
+    return;
+  }
+
+  // ── Token exchange ──
+  if (req.method === "POST" && url.pathname === "/token") {
+    const body = await readBody(req);
+    const params = new URLSearchParams(body);
+    const parsed: Record<string, string> = {};
+    for (const [k, v] of params.entries()) parsed[k] = v;
+    state.calls.tokenExchange.push({ body, parsedBody: parsed });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        access_token: "ya29.mock-e2e-access",
+        refresh_token: "1//mock-e2e-refresh",
+        expires_in: 3600,
+        scope:
+          "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send",
+        token_type: "Bearer",
+      }),
+    );
+    return;
+  }
+
+  // ── users.getProfile ──
+  if (
+    req.method === "GET" &&
+    url.pathname === "/gmail/v1/users/me/profile"
+  ) {
+    state.calls.profile.push({
+      authorization: req.headers.authorization,
+      responseHistoryId: state.currentHistoryId,
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        emailAddress: "alice@e2e.test",
+        messagesTotal: state.emails.size,
+        threadsTotal: state.emails.size,
+        historyId: state.currentHistoryId,
+      }),
+    );
+    return;
+  }
+
+  // ── users.history.list ──
+  if (
+    req.method === "GET" &&
+    url.pathname === "/gmail/v1/users/me/history"
+  ) {
+    const startHistoryId = url.searchParams.get("startHistoryId") ?? "0";
+    const pageToken = url.searchParams.get("pageToken");
+    const historyTypes = url.searchParams.getAll("historyTypes");
+    const startBig = safeBigInt(startHistoryId);
+
+    // Drain pending entries whose historyId is > startHistoryId. The
+    // dedup probe re-queues an entry at its original historyId, so we
+    // include entries with historyId >= startHistoryId when the
+    // requested cursor matches the entry's historyId exactly — this
+    // simulates "stored cursor was rewound and we walk forward again".
+    const out: Array<{ id: string; messagesAdded: Array<{ message: { id: string; threadId: string } }> }> = [];
+    const remaining: typeof state.pendingHistoryEntries = [];
+    for (const entry of state.pendingHistoryEntries) {
+      const entryBig = safeBigInt(entry.historyId);
+      if (startBig === null || entryBig === null) {
+        remaining.push(entry);
+        continue;
+      }
+      // > startHistoryId is the normal case (new message arrived since the
+      // stored cursor). === also delivers — handles dedup probe / rewind.
+      if (entryBig >= startBig) {
+        const email = state.emails.get(entry.messageId);
+        if (email) {
+          out.push({
+            id: entry.historyId,
+            messagesAdded: [
+              { message: { id: email.id, threadId: email.threadId } },
+            ],
+          });
+        }
+        // Once delivered, remove from pending — the spec re-queues
+        // explicitly via /__replayLastEmail when it wants a replay.
+        continue;
+      }
+      remaining.push(entry);
+    }
+    state.pendingHistoryEntries = remaining;
+
+    state.calls.historyList.push({
+      authorization: req.headers.authorization,
+      url: req.url ?? "",
+      startHistoryId,
+      pageToken,
+      historyTypes,
+      responseEntries: out.length,
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        history: out,
+        historyId: state.currentHistoryId,
+      }),
+    );
+    return;
+  }
+
+  // ── users.messages.get ──
+  if (
+    req.method === "GET" &&
+    url.pathname.startsWith("/gmail/v1/users/me/messages/")
+  ) {
+    const messageId = decodeURIComponent(
+      url.pathname.replace("/gmail/v1/users/me/messages/", ""),
+    );
+    const format = url.searchParams.get("format") ?? "";
+    state.calls.messagesGet.push({
+      authorization: req.headers.authorization,
+      url: req.url ?? "",
+      messageId,
+      format,
+    });
+    const email = state.emails.get(messageId);
+    if (!email) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { code: 404, message: "Not Found" } }));
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        id: email.id,
+        threadId: email.threadId,
+        labelIds: email.labelIds,
+        snippet: email.snippet,
+        internalDate: email.internalDate,
+        sizeEstimate: email.sizeEstimate,
+        payload: {
+          mimeType: email.mimeType,
+          headers: email.headers,
+        },
+      }),
+    );
+    return;
+  }
+
+  // ── users.messages.send ──
+  if (
+    req.method === "POST" &&
+    url.pathname === "/gmail/v1/users/me/messages/send"
+  ) {
+    const body = await readBody(req);
+    let raw = "";
+    try {
+      const parsed = JSON.parse(body) as { raw?: string };
+      raw = parsed.raw ?? "";
+    } catch {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("malformed json");
+      return;
+    }
+    const decoded = base64UrlDecodeToString(raw);
+    const parsedMessage = parseRfc5322(decoded);
+    state.calls.send.push({
+      authorization: req.headers.authorization,
+      raw,
+      decoded,
+      parsed: parsedMessage,
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        id: `sent-${Date.now()}`,
+        threadId: "sent-thr",
+        labelIds: ["SENT"],
+      }),
+    );
+    return;
+  }
+
+  // ── Control plane ──
+
+  if (req.method === "POST" && url.pathname === "/__injectEmail") {
+    const body = await readBody(req);
+    let payload: {
+      id: string;
+      headers: Record<string, string>;
+      mimeType?: string;
+      snippet?: string;
+    };
+    try {
+      payload = JSON.parse(body) as typeof payload;
+    } catch {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("malformed json");
+      return;
+    }
+    if (!payload.id || !payload.headers) {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("missing id or headers");
+      return;
+    }
+    // Bump historyId by 1 to simulate "a new message arrived".
+    const nextId = (safeBigInt(state.currentHistoryId) ?? 0n) + 1n;
+    state.currentHistoryId = nextId.toString();
+    const email: InjectedEmail = {
+      id: payload.id,
+      threadId: `thr-${payload.id}`,
+      labelIds: ["INBOX", "UNREAD"],
+      snippet: payload.snippet ?? "",
+      internalDate: String(Date.now()),
+      sizeEstimate: 1024,
+      mimeType: payload.mimeType ?? "multipart/alternative",
+      headers: Object.entries(payload.headers).map(([name, value]) => ({
+        name,
+        value,
+      })),
+      historyIdAtInsert: state.currentHistoryId,
+    };
+    state.emails.set(email.id, email);
+    state.pendingHistoryEntries.push({
+      historyId: state.currentHistoryId,
+      messageId: email.id,
+    });
+    state.lastInjectedMessageId = email.id;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        ok: true,
+        currentHistoryId: state.currentHistoryId,
+        messageId: email.id,
+      }),
+    );
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/__replayLastEmail") {
+    if (!state.lastInjectedMessageId) {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("no email to replay");
+      return;
+    }
+    const email = state.emails.get(state.lastInjectedMessageId);
+    if (!email) {
+      res.writeHead(400, { "content-type": "text/plain" });
+      res.end("last injected email not found in store");
+      return;
+    }
+    // Re-queue at the original historyId — does NOT bump currentHistoryId.
+    // This simulates "the stored cursor was rolled back; the same message
+    // surfaces in history.list again". Dedup must catch it via
+    // webhook_event_dedup keyed on the gmail message id.
+    state.pendingHistoryEntries.push({
+      historyId: email.historyIdAtInsert,
+      messageId: email.id,
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, replayedMessageId: email.id }));
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/__reset") {
+    Object.assign(state, freshState());
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/__inspect") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        calls: state.calls,
+        currentHistoryId: state.currentHistoryId,
+        emailCount: state.emails.size,
+        pendingHistoryEntries: state.pendingHistoryEntries,
+        lastInjectedMessageId: state.lastInjectedMessageId,
+      }),
+    );
+    return;
+  }
+
+  // Anything else is unexpected — fail loud so the test surfaces it.
+  res.writeHead(404, { "content-type": "text/plain" });
+  res.end(`mock-google: no route for ${req.method} ${url.pathname}`);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function safeBigInt(v: string): bigint | null {
+  try {
+    return BigInt(v);
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecodeToString(s: string): string {
+  // base64url → base64. Length-pad with '=' so Buffer.from accepts it.
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4;
+  const padLen = pad === 0 ? 0 : 4 - pad;
+  return Buffer.from(padded + "=".repeat(padLen), "base64").toString("utf8");
+}
+
+function parseRfc5322(text: string): ParsedRfc5322 {
+  // Split headers / body on the first blank line. RFC says CRLF; tolerate
+  // bare LF too (some senders emit that, including our own send action).
+  const headerEnd = text.search(/\r?\n\r?\n/);
+  const headerBlock = headerEnd >= 0 ? text.slice(0, headerEnd) : text;
+  const bodyBlock = headerEnd >= 0 ? text.slice(headerEnd).replace(/^\r?\n\r?\n/, "") : "";
+
+  const headers = parseHeaders(headerBlock);
+  const mimeType = (headers["content-type"] ?? "").split(";")[0]!.trim().toLowerCase();
+  const partsByMimeType: Record<string, string> = {};
+
+  // Multipart parsing — extract boundary and split. We don't need a full
+  // RFC-compliant parser; the spec only asserts the plain-text leaf is
+  // present. For multipart/alternative the structure is:
+  //   --boundary
+  //   Content-Type: text/plain; charset=...
+  //   <blank line>
+  //   <body>
+  //   --boundary
+  //   Content-Type: text/html; charset=...
+  //   <blank line>
+  //   <body>
+  //   --boundary--
+  if (mimeType.startsWith("multipart/")) {
+    const ctRaw = headers["content-type"] ?? "";
+    const m = ctRaw.match(/boundary="?([^";]+)"?/i);
+    if (m) {
+      const boundary = `--${m[1]}`;
+      const segments = bodyBlock.split(boundary);
+      for (const seg of segments) {
+        const trimmed = seg.replace(/^\r?\n/, "").replace(/\r?\n--\s*$/, "");
+        if (!trimmed.trim() || trimmed.startsWith("--")) continue;
+        const partHeaderEnd = trimmed.search(/\r?\n\r?\n/);
+        if (partHeaderEnd < 0) continue;
+        const partHeaders = parseHeaders(trimmed.slice(0, partHeaderEnd));
+        const partBody = trimmed.slice(partHeaderEnd).replace(/^\r?\n\r?\n/, "");
+        const partMime = (partHeaders["content-type"] ?? "").split(";")[0]!.trim().toLowerCase();
+        if (partMime) {
+          // Strip trailing CRLF that's part of the multipart boundary
+          // delimiter rather than the body itself.
+          partsByMimeType[partMime] = partBody.replace(/\r?\n$/, "");
+        }
+      }
+    }
+  } else if (mimeType) {
+    partsByMimeType[mimeType] = bodyBlock;
+  }
+
+  return { headers, mimeType, partsByMimeType };
+}
+
+function parseHeaders(block: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  // Unfold continuation lines (RFC 5322 §2.2.3): a line beginning with
+  // whitespace is part of the previous header.
+  const unfolded = block.replace(/\r?\n[\t ]+/g, " ");
+  for (const line of unfolded.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    const name = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+    out[name] = value;
+  }
+  return out;
+}

--- a/tests/e2e/helpers/supabaseAdmin.ts
+++ b/tests/e2e/helpers/supabaseAdmin.ts
@@ -105,6 +105,81 @@ export async function getNotificationsForUser(
 }
 
 /**
+ * Slice 2f: read trigger_resources rows for the test user. Used to
+ * assert the activation hook populated `config.snapshot.historyId` and
+ * that the polling cycle advanced the cursor + bumped lastPolledAt.
+ */
+export async function getTriggerResourcesForUser(
+  userId: string,
+): Promise<readonly Record<string, unknown>[]> {
+  const { data, error } = await adminClient()
+    .from("trigger_resources")
+    .select("*")
+    .eq("user_id", userId);
+  if (error) throw new Error(`getTriggerResourcesForUser: ${error.message}`);
+  return data ?? [];
+}
+
+/**
+ * Slice 2f: read a single webhook_event_dedup row by (provider, event_id).
+ * Used to assert dedup actually wrote on the first poll AND that the
+ * row is what blocks the duplicate run on the second poll. Returns null
+ * when no row matches. System table — service-role only.
+ */
+export async function getDedupRow(
+  provider: string,
+  eventId: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await adminClient()
+    .from("webhook_event_dedup")
+    .select("*")
+    .eq("provider", provider)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (error) throw new Error(`getDedupRow: ${error.message}`);
+  return data ?? null;
+}
+
+/**
+ * Slice 2f: rewind a trigger_resources row's `config.polling.lastPolledAt`
+ * to a long-past timestamp so the polling scheduler's interval gate
+ * (5-minute default in Slice 2e) doesn't skip the next cron tick.
+ *
+ * Used by the dedup probe — between polls we need to simulate "enough
+ * time has passed to poll again" without sleeping for 5 minutes. The
+ * scheduler reads `config.polling.lastPolledAt` directly, so we just
+ * write a value far enough in the past.
+ *
+ * Service-role: writes a single known row id; the test runner has
+ * already authenticated the user, but the polling cron code path uses
+ * service-role too.
+ */
+export async function rewindTriggerPollingTimestamp(
+  triggerResourceId: string,
+): Promise<void> {
+  const long_ago = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  // Read current config so we update only the polling slice without
+  // accidentally clearing snapshot / other keys.
+  const { data, error: readErr } = await adminClient()
+    .from("trigger_resources")
+    .select("config")
+    .eq("id", triggerResourceId)
+    .single();
+  if (readErr) throw new Error(`rewindTriggerPollingTimestamp read: ${readErr.message}`);
+  const config = (data.config ?? {}) as Record<string, unknown>;
+  const polling = (config.polling ?? {}) as Record<string, unknown>;
+  const newConfig = {
+    ...config,
+    polling: { ...polling, lastPolledAt: long_ago },
+  };
+  const { error } = await adminClient()
+    .from("trigger_resources")
+    .update({ config: newConfig })
+    .eq("id", triggerResourceId);
+  if (error) throw new Error(`rewindTriggerPollingTimestamp write: ${error.message}`);
+}
+
+/**
  * Poll until the predicate returns truthy or timeout. The execution engine
  * runs in a fire-and-forget Promise after the webhook returns 200, so the
  * test must wait for the workflow_runs row to appear.

--- a/tests/e2e/slice-2f-gmail-walkthrough.spec.ts
+++ b/tests/e2e/slice-2f-gmail-walkthrough.spec.ts
@@ -1,0 +1,454 @@
+import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import {
+  createTestUser,
+  deleteTestUser,
+  getDedupRow,
+  getIntegrationsForUser,
+  getNotificationsForUser,
+  getOAuthStateRowCount,
+  getTriggerResourcesForUser,
+  getWorkflowRunsForUser,
+  rewindTriggerPollingTimestamp,
+  waitFor,
+  type TestUser,
+} from "./helpers/supabaseAdmin";
+import { readGoogleMockState } from "./global-setup";
+
+/**
+ * Slice 2f end-to-end walkthrough — Gmail polling trigger.
+ *
+ * Mirrors the shape of Slice 1's Slack walkthrough: real auth, real OAuth
+ * dispatcher (PKCE state row + atomic consume), real integration row with
+ * AES-encrypted tokens, real workflow create + activate, real polling
+ * scheduler, real trigger handler. The Google network boundary is the
+ * only thing mocked (authorize, token, profile, history.list, messages.get,
+ * messages.send).
+ *
+ * Real surfaces exercised:
+ *   - Auth (Supabase admin createUser → UI sign-in)
+ *   - OAuth dispatcher + signed state + atomic consume + PKCE S256
+ *   - Token endpoint POST (form-urlencoded with code_verifier)
+ *   - Service-role integration insert + token encryption (AES-256-GCM)
+ *   - Workflow CRUD + lifecycle preconditions + activate transition
+ *   - Activation hook seam (Slice 2e): registerWorkflowTriggers consults
+ *     activationRegistry, calls Gmail's activate which fetches getProfile
+ *     and snapshots the historyId BEFORE upserting trigger_resources
+ *   - Polling cron auth (CRON_SECRET bearer)
+ *   - Polling scheduler iteration with concurrency/timeout
+ *   - Gmail polling handler: history.list (V1 port), messages.get
+ *     (format=metadata), filter matching (default INBOX), DB-backed
+ *     dedup via webhook_event_dedup, checkpoint advancement
+ *   - Engine + canonical resolver + Gmail send_email handler
+ *   - refreshAndRetry token decryption on the send call
+ *
+ * Mocked surfaces (Google network boundary only):
+ *   - accounts.google.com/o/oauth2/v2/auth → 302 to V2's gmail callback
+ *   - oauth2.googleapis.com/token → canned access + refresh token
+ *   - gmail.googleapis.com/gmail/v1/users/me/profile
+ *   - gmail.googleapis.com/gmail/v1/users/me/history
+ *   - gmail.googleapis.com/gmail/v1/users/me/messages/{id}
+ *   - gmail.googleapis.com/gmail/v1/users/me/messages/send
+ *
+ * UI shortcut: V2's builder UI doesn't have per-node configuration yet
+ * (Slice 1I.2 was minimum picker + list + save). The test patches the
+ * workflow draft via the API at step "configure nodes" so the trigger
+ * + action have valid `type` + `config` for execution. When per-node
+ * configuration UI ships, this step becomes a UI walkthrough — same
+ * comment as the Slice 1 spec.
+ *
+ * Two-run stability: every test run uses a fresh `msg-e2e-${randomUUID()}`
+ * gmail message id, so the `webhook_event_dedup` row written by the first
+ * run never collides with a second run. All other tables are cleaned via
+ * `deleteTestUser`'s FK cascade.
+ */
+
+let testUser: TestUser | null = null;
+
+test.describe("Slice 2f — full Gmail walkthrough", () => {
+  test.beforeEach(async () => {
+    testUser = await createTestUser();
+  });
+
+  test.afterEach(async () => {
+    if (testUser) {
+      await deleteTestUser(testUser.id);
+      testUser = null;
+    }
+  });
+
+  test("sign in → connect Gmail → build + activate → poll cycle → succeeded run → dedup blocks duplicate", async ({
+    page,
+    request,
+  }) => {
+    if (!testUser) throw new Error("test user setup failed");
+    const user = testUser;
+    const mock = await readGoogleMockState();
+    const cronSecret = requireEnv("CRON_SECRET");
+
+    // Per-run unique gmail message id so the webhook_event_dedup row
+    // never collides across consecutive runs (the table is system-wide,
+    // no user FK, so user-delete cascades don't clean it).
+    const messageId = `msg-e2e-${randomUUID()}`;
+
+    // Reset Google mock counters + email store so per-test assertions
+    // are scoped to this run.
+    await page.request.post(`${mock.baseUrl}/__reset`);
+
+    // ── 1. Sign in via UI ──
+    await signIn(page, user);
+
+    // ── 2. Snapshot oauth_states count for the consumed-state assertion ──
+    const oauthStatesBefore = await getOAuthStateRowCount();
+
+    // ── 3. Connect Gmail (UI → mocked authorize → V2 callback → land) ──
+    // The dynamic [provider]/callback route handles all providers; for
+    // gmail it lands at /api/integrations/oauth/gmail/callback. After the
+    // callback redirects, we land on /?integration=connected&provider=gmail.
+    await page.goto("/integrations");
+    await Promise.all([
+      page.waitForURL(/\/\?integration=connected&provider=gmail/),
+      page.getByRole("button", { name: "Connect Gmail" }).click(),
+    ]);
+
+    // After OAuth: navigate to integrations page; Gmail row shows connected.
+    await page.goto("/integrations");
+    await expect(
+      page.locator('ul[aria-label="Integrations"]').getByText(/Connected/),
+    ).toBeVisible();
+
+    // DB assertions: integration row exists with encrypted tokens.
+    const integrations = await getIntegrationsForUser(user.id, "gmail");
+    expect(integrations).toHaveLength(1);
+    const integration = integrations[0]! as Record<string, unknown>;
+    expect(integration.provider_account_id).toBe("alice@e2e.test");
+    expect(integration.access_token_encrypted).toBeTruthy();
+    // Encryption invariant: ciphertext must NOT equal plaintext mock value.
+    expect(integration.access_token_encrypted).not.toBe("ya29.mock-e2e-access");
+    expect(integration.refresh_token_encrypted).toBeTruthy();
+    expect(integration.refresh_token_encrypted).not.toBe("1//mock-e2e-refresh");
+    // Scopes: exactly the manifest's required pair.
+    const scopes = integration.scopes as readonly string[];
+    expect([...scopes].sort()).toEqual([
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.send",
+    ]);
+
+    // OAuth state row was atomically consumed — total count back to baseline.
+    const oauthStatesAfter = await getOAuthStateRowCount();
+    expect(oauthStatesAfter).toBe(oauthStatesBefore);
+
+    // Mock-call assertions: exactly one authorize, one token exchange,
+    // one profile call (the OAuth callback's accountId lookup).
+    const callsAfterOAuth = await fetchMockCalls(request, mock.baseUrl);
+    expect(callsAfterOAuth.calls.authorize).toHaveLength(1);
+    expect(callsAfterOAuth.calls.tokenExchange).toHaveLength(1);
+    expect(callsAfterOAuth.calls.profile).toHaveLength(1);
+    expect(callsAfterOAuth.calls.send).toHaveLength(0);
+    // Token exchange used PKCE: code_verifier was sent.
+    expect(
+      callsAfterOAuth.calls.tokenExchange[0]!.parsedBody.code_verifier,
+    ).toBeTruthy();
+
+    // ── 4. Create workflow via UI ──
+    await page.goto("/workflows");
+    await page.getByRole("button", { name: "Create workflow" }).click();
+    await page.getByLabel(/workflow name/i).fill("E2E Gmail Walkthrough");
+    await Promise.all([
+      page.waitForURL(/\/workflows\/[0-9a-f-]+/),
+      page.getByRole("button", { name: "Create", exact: true }).click(),
+    ]);
+    const workflowId = page.url().match(/\/workflows\/([0-9a-f-]+)/)![1]!;
+
+    // ── 5. Configure trigger + action via API patch ──
+    // V2's builder UI cannot configure node `type` + `config` yet
+    // (Slice 1I.2 was minimum picker + list + save). When per-node
+    // configuration UI ships, replace this with UI interaction.
+    const draftDefinition = {
+      nodes: [
+        {
+          id: "trigger-node",
+          kind: "trigger" as const,
+          provider: "gmail",
+          type: "new_email",
+          // labelIds defaults to ["INBOX"] in the schema; we make it
+          // explicit so the test reads the same way as the V2 schema.
+          config: { labelIds: ["INBOX"] },
+          position: { x: 0, y: 0 },
+        },
+        {
+          id: "action-node",
+          kind: "action" as const,
+          provider: "gmail",
+          type: "send_email",
+          // Hardcoded recipient/subject/body — variable resolution from
+          // trigger event is unit-tested elsewhere; this e2e exercises the
+          // poll → enqueue → handler chain, not variable plumbing.
+          // Both textBody + htmlBody set so the handler sends
+          // `multipart/alternative` (Slice 2d Decision 2d-1, Option C).
+          config: {
+            to: "alice@e2e.test",
+            subject: "Hello back",
+            textBody: "Hello from e2e",
+            htmlBody: "<p>Hello from e2e</p>",
+          },
+          position: { x: 0, y: 100 },
+        },
+      ],
+      edges: [{ id: "e1", from: "trigger-node", to: "action-node" }],
+    };
+    const patch = await page.request.patch(`/api/workflows/${workflowId}`, {
+      data: { draftDefinition },
+    });
+    expect(patch.status(), await patch.text()).toBe(200);
+
+    // Reload so the server-rendered builder picks up the patched definition.
+    await page.reload();
+    const nodeList = page.locator('ol[aria-label="Workflow nodes"]');
+    await expect(nodeList.getByText(/trigger/i).first()).toBeVisible();
+    await expect(nodeList.getByText(/action/i).first()).toBeVisible();
+
+    // ── 6. Activate workflow via UI ──
+    // This triggers the Slice 2e activation hook: registerWorkflowTriggers
+    // consults activationRegistry, calls Gmail's activate function, which
+    // fetches users.getProfile against the mock and stamps
+    // config.snapshot.historyId BEFORE upsert.
+    await page.getByRole("button", { name: "Activate" }).click();
+    await expect(
+      page.locator("[data-status-kind=active]"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // DB: trigger_resources row has the snapshot from the mock's
+    // currentHistoryId (seed = "100000").
+    const triggerRowsAfterActivate = await getTriggerResourcesForUser(user.id);
+    expect(triggerRowsAfterActivate).toHaveLength(1);
+    const triggerAfterActivate = triggerRowsAfterActivate[0]! as Record<
+      string,
+      unknown
+    >;
+    expect(triggerAfterActivate.provider).toBe("gmail");
+    expect(triggerAfterActivate.event_type).toBe("new_email");
+    const configAfterActivate = triggerAfterActivate.config as {
+      pollingEnabled?: boolean;
+      snapshot?: { historyId?: string; capturedAt?: string };
+    };
+    expect(configAfterActivate.pollingEnabled).toBe(true);
+    expect(configAfterActivate.snapshot?.historyId).toBe("100000");
+    expect(configAfterActivate.snapshot?.capturedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T/,
+    );
+
+    // Mock saw a second profile call (one from OAuth callback, one from
+    // activation hook). No history.list / messages.get yet.
+    const callsAfterActivate = await fetchMockCalls(request, mock.baseUrl);
+    expect(callsAfterActivate.calls.profile).toHaveLength(2);
+    expect(callsAfterActivate.calls.historyList).toHaveLength(0);
+    expect(callsAfterActivate.calls.send).toHaveLength(0);
+
+    // ── 7. Inject a new email via the mock control plane ──
+    // Bumps mock currentHistoryId from "100000" to "100001" and queues
+    // a `messageAdded` entry for the next history.list call.
+    const injectResp = await page.request.post(
+      `${mock.baseUrl}/__injectEmail`,
+      {
+        data: {
+          id: messageId,
+          headers: {
+            From: "Bob <bob@e2e.test>",
+            To: "alice@e2e.test",
+            Subject: "Hello",
+            Date: new Date().toUTCString(),
+          },
+          mimeType: "multipart/alternative",
+          snippet: "Test inbound message",
+        },
+      },
+    );
+    expect(injectResp.status()).toBe(200);
+
+    // ── 8. Trigger a poll cycle ──
+    const pollResp = await request.post("/api/cron/poll-triggers", {
+      headers: { authorization: `Bearer ${cronSecret}` },
+    });
+    expect(pollResp.status(), await pollResp.text()).toBe(200);
+
+    // ── 9. Wait for workflow_run → assert succeeded ──
+    const runs = await waitFor(
+      async () => {
+        const rows = await getWorkflowRunsForUser(user.id);
+        return rows.length > 0 ? rows : null;
+      },
+      { description: "workflow_runs row to appear", timeoutMs: 15_000 },
+    );
+    expect(runs).toHaveLength(1);
+    const run = runs[0]! as Record<string, unknown>;
+    expect(run.status).toBe("succeeded");
+    expect(run.error_classification).toBeNull();
+
+    // ── 10. Mock saw exactly the expected Gmail calls ──
+    const callsAfterPoll = await fetchMockCalls(request, mock.baseUrl);
+    // history.list called once with the activation snapshot as start cursor.
+    expect(callsAfterPoll.calls.historyList).toHaveLength(1);
+    const historyCall = callsAfterPoll.calls.historyList[0]!;
+    expect(historyCall.startHistoryId).toBe("100000");
+    // V1-port behavior: BOTH messageAdded and labelAdded queried.
+    expect(historyCall.historyTypes.sort()).toEqual([
+      "labelAdded",
+      "messageAdded",
+    ]);
+    // No labelId param — multi-label is filtered client-side (V1 parity).
+    expect(historyCall.url).not.toMatch(/labelId=/);
+
+    // messages.get called once for the injected message, format=metadata.
+    expect(callsAfterPoll.calls.messagesGet).toHaveLength(1);
+    expect(callsAfterPoll.calls.messagesGet[0]!.messageId).toBe(messageId);
+    expect(callsAfterPoll.calls.messagesGet[0]!.format).toBe("metadata");
+
+    // messages.send called exactly once with the right multipart body.
+    expect(callsAfterPoll.calls.send).toHaveLength(1);
+    const send = callsAfterPoll.calls.send[0]!;
+    expect(send.parsed.mimeType).toBe("multipart/alternative");
+    expect(send.parsed.headers.to).toBe("alice@e2e.test");
+    expect(send.parsed.headers.subject).toBe("Hello back");
+    expect(send.parsed.partsByMimeType["text/plain"] ?? "").toContain(
+      "Hello from e2e",
+    );
+    // Authorization header carries the (decrypted) access token — proves
+    // the encryption round-trip + refreshAndRetry plumbing.
+    expect(send.authorization).toBe("Bearer ya29.mock-e2e-access");
+
+    // ── 11. trigger_resources cursor advanced + dedup row written ──
+    const triggerRowsAfterPoll = await getTriggerResourcesForUser(user.id);
+    expect(triggerRowsAfterPoll).toHaveLength(1);
+    const triggerAfterPoll = triggerRowsAfterPoll[0]! as Record<
+      string,
+      unknown
+    >;
+    const configAfterPoll = triggerAfterPoll.config as {
+      snapshot?: { historyId?: string };
+      polling?: { lastPolledAt?: string };
+    };
+    expect(configAfterPoll.snapshot?.historyId).toBe("100001");
+    expect(configAfterPoll.polling?.lastPolledAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T/,
+    );
+
+    // Dedup row written under (provider='gmail', event_id=messageId).
+    const dedupRow = await getDedupRow("gmail", messageId);
+    expect(dedupRow).not.toBeNull();
+
+    // ── 12. UI: Run history shows the succeeded run ──
+    await page.reload();
+    const runHistory = page.locator('section[aria-label="Run history"]');
+    await expect(runHistory).toBeVisible();
+    await expect(runHistory.getByText(/succeeded/i)).toBeVisible();
+
+    // ── 13. No notification on success path ──
+    expect(await getNotificationsForUser(user.id)).toHaveLength(0);
+
+    // ── 14. Dedup probe — replay same email and re-poll ──
+    // /__replayLastEmail re-queues the same gmail message id at its
+    // original historyId (does NOT bump currentHistoryId). On the next
+    // poll, history.list will surface the same message id; dedup must
+    // catch it via webhook_event_dedup keyed on (gmail, messageId), and
+    // no second workflow_run + no second send must occur.
+    //
+    // Rewind the polling cursor BEFORE the second poll so the
+    // scheduler's 5-min interval gate doesn't skip this trigger. The
+    // gate reads `config.polling.lastPolledAt`; setting it to 24h ago
+    // simulates enough time elapsed.
+    await rewindTriggerPollingTimestamp(triggerAfterPoll.id as string);
+    const replayResp = await page.request.post(
+      `${mock.baseUrl}/__replayLastEmail`,
+    );
+    expect(replayResp.status()).toBe(200);
+
+    const pollResp2 = await request.post("/api/cron/poll-triggers", {
+      headers: { authorization: `Bearer ${cronSecret}` },
+    });
+    expect(pollResp2.status(), await pollResp2.text()).toBe(200);
+
+    // Give the engine a moment to NOT execute a second run. We can't
+    // wait-for-row (the row should not appear), so we busy-poll briefly
+    // then assert the count stayed at 1.
+    await new Promise((r) => setTimeout(r, 1500));
+    const runsAfterReplay = await getWorkflowRunsForUser(user.id);
+    expect(runsAfterReplay).toHaveLength(1);
+
+    const callsAfterReplay = await fetchMockCalls(request, mock.baseUrl);
+    // The second poll DID hit history.list + messages.get (we don't
+    // dedup at the API call boundary — we dedup at the enqueue boundary,
+    // which is correct because the dedup table is the single source of
+    // truth for "did this message already trigger a run").
+    expect(callsAfterReplay.calls.historyList).toHaveLength(2);
+    // messages.get may or may not have been called a second time —
+    // it's called per-history-message before the dedup check in the
+    // current Slice 2e implementation. The send count is the load-
+    // bearing assertion: send must NOT have fired twice.
+    expect(callsAfterReplay.calls.send).toHaveLength(1);
+  });
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+async function signIn(page: Page, user: TestUser): Promise<void> {
+  await page.goto("/auth/sign-in");
+  await page.getByLabel(/email/i).fill(user.email);
+  await page.getByLabel(/password/i).fill(user.password);
+  await Promise.all([
+    page.waitForURL((url) => !/\/auth\/sign-in/.test(url.toString()), {
+      timeout: 15_000,
+    }),
+    page.getByRole("button", { name: "Sign in", exact: true }).click(),
+  ]);
+}
+
+interface MockInspect {
+  calls: {
+    authorize: { state: string; scope: string; codeChallenge: string | null }[];
+    tokenExchange: { body: string; parsedBody: Record<string, string> }[];
+    profile: { authorization: string | undefined; responseHistoryId: string }[];
+    historyList: {
+      authorization: string | undefined;
+      url: string;
+      startHistoryId: string;
+      pageToken: string | null;
+      historyTypes: string[];
+      responseEntries: number;
+    }[];
+    messagesGet: {
+      authorization: string | undefined;
+      url: string;
+      messageId: string;
+      format: string;
+    }[];
+    send: {
+      authorization: string | undefined;
+      raw: string;
+      decoded: string;
+      parsed: {
+        headers: Record<string, string>;
+        mimeType: string;
+        partsByMimeType: Record<string, string>;
+      };
+    }[];
+  };
+  currentHistoryId: string;
+  emailCount: number;
+  pendingHistoryEntries: { historyId: string; messageId: string }[];
+  lastInjectedMessageId: string | null;
+}
+
+async function fetchMockCalls(
+  request: APIRequestContext,
+  mockBaseUrl: string,
+): Promise<MockInspect> {
+  const resp = await request.get(`${mockBaseUrl}/__inspect`);
+  return (await resp.json()) as MockInspect;
+}
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`e2e: ${name} env var is required`);
+  return v;
+}


### PR DESCRIPTION
## Summary

Adds the Slice 2f Gmail e2e walkthrough — same shape as Slice 1's Slack walkthrough, but the trigger source is the polling cron from Slice 2e and the mocked network boundary is Google instead of Slack. Two pre-existing Slice 2e bugs surfaced and are fixed in this commit.

## What shipped

**New** (helpers + spec)
- `tests/e2e/helpers/mockGoogleServer.ts` — stateful mock for Google authorize, token endpoint, Gmail profile/history/messages/send, plus a `__injectEmail` / `__replayLastEmail` / `__reset` / `__inspect` control plane.
- `tests/e2e/slice-2f-gmail-walkthrough.spec.ts` — the single test, full journey + dedup probe.

**Modified** (e2e infra)
- `tests/e2e/global-setup.ts` — boot Google mock alongside Slack; write `mock-google.json`; `CRON_SECRET` added to spec-process env allow-list.
- `tests/e2e/global-teardown.ts` — stop both mocks.
- `playwright.config.ts` — `webServer.env` adds `GMAIL_API_BASE`, `GOOGLE_AUTHORIZE_BASE`, `GOOGLE_TOKEN_BASE` pointing to the mock.
- `tests/e2e/helpers/supabaseAdmin.ts` — three new helpers: `getTriggerResourcesForUser`, `getDedupRow`, `rewindTriggerPollingTimestamp`.

**Bundled bug fixes** (surfaced by the e2e)
- `services/triggers/lifecycle.ts` — side-effect `import "@/integrations/_registry"` so the activation registry is populated when the activate route loads its module graph in isolation. Without it, `registerWorkflowTriggers` found no activation for `("gmail", "new_email")` and silently no-op'd the snapshot init.
- `integrations/gmail/triggers/newEmail/poll.ts` — resolve the user's integration `provider_account_id` once at the top of `poll()` and thread it through `TriggerEvent.accountId` + `refreshAndRetry` calls. Aligns polling with Slice 2e's `lifecycle.ts` "account_id resolved on-demand" design comment. Without this, the send action's `getActiveForExecution` lookup failed because no integration has `provider_account_id=""`.

## Why bundle the bug fixes

The e2e was the first integration test through the real activate-then-poll path. Slice 2e's unit tests populated the activation registry directly and used mocked trigger rows, so the route-level module-graph gap and the empty-accountId propagation were both invisible until the e2e ran. Splitting the fixes into a separate PR would mean shipping a known-broken Slice 2e for the duration of the split — bundling them keeps `v2-foundation` green at every commit.

Both fixes are minimal and surgical. No API changes. No schema changes.

## Bug 1 details — empty activation registry

The activate API route's module graph is:

```
app/api/workflows/[id]/activate/route.ts
  → services/workflows/orchestratorFactory
  → services/triggers/lifecycle.ts
  → services/triggers/activationRegistry  ← empty registry, no providers loaded
```

Slice 2e's poll-triggers cron route had `import "@/integrations/_registry"` for side effects, but that side-effect import lives only in the cron route — the activate path doesn't transitively load `_registry`. So `findActivation("gmail", "new_email")` returned null and the activation hook silently skipped, leaving `trigger_resources.config` without `pollingEnabled` or `snapshot.historyId`.

Fix: side-effect import at the top of `services/triggers/lifecycle.ts`. Any caller of the lifecycle service now loads `_registry` first. Single-line change; covered by the e2e.

## Bug 2 details — empty TriggerEvent.accountId on polling runs

`services/triggers/lifecycle.ts` upserts `trigger_resources` with `account_id: null` per its design comment ("accountId is resolved later via the user's integrations row"). For webhook dispatch, "later" is the inbound payload (e.g., Slack `team_id`). For polling, "later" had not been wired — the poll handler just did `trigger.accountId ?? ""`, propagating empty string into the TriggerEvent.

The downstream Gmail send action then read `triggerEvent.accountId === ""` and called `getActiveForExecution(userId, "gmail", "")`, which filters on `provider_account_id="" AND user_id=... AND provider="gmail"` — no match, returns null, refreshAndRetry throws.

Fix: `poll()` calls `getActiveForExecution(userId, "gmail", null)` once at the top to get the user's active Gmail integration, uses `integration.providerAccountId` as the resolved email, and threads it through both the TriggerEvent and all `refreshAndRetry` calls. One DB query per cron tick, indexed lookup. Multi-account ambiguity is preserved as a future concern (matches Slice 2e's existing scope).

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm run lint` | clean |
| `npm run lint:structure` | OK |
| `npm run lint:migrations` | OK |
| `npm test` | **91 suites / 811 tests** (no unit test count change — the spec is the test) |
| `npx playwright test slice-1-slack-walkthrough.spec.ts` | 1 passed (Slack walkthrough still green with the new mock running alongside) |
| `npx playwright test slice-2f-gmail-walkthrough.spec.ts` (run 1) | 1 passed (~20s) |
| `npx playwright test slice-2f-gmail-walkthrough.spec.ts` (run 2) | 1 passed (~20s) — two-run stability confirmed |

## Out of scope

- No real Google sanity check (mock is the network boundary).
- No CI wiring for e2e.
- No Pub/Sub / `users.watch()`.
- No DB migration.
- No CLAUDE.md (V2 doesn't have one).
- No labels / attachments / AI filter e2e.
- No visual / screenshot testing.
- No stale-cursor recovery e2e.
- No token-refresh e2e.
- No failed-run notification e2e.
- No Slice 3 / post-Slice-2 work.

## Test plan

- [ ] Reviewer scans diff for scope creep
- [ ] CI runs full Jest + both e2e specs
- [ ] Spot-check the two bug fixes in `lifecycle.ts` and `poll.ts`
- [ ] Confirm two-run stability claim by running the new spec twice locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)