### PR TITLE
chore(ops): add CI workflow and document cron wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+# Slice 2-OPS: minimal non-e2e CI gate. Runs on every PR targeting
+# v2-foundation and on every push that lands on v2-foundation.
+#
+# Scope (intentionally non-e2e):
+#   - Type-check (npx tsc --noEmit)
+#   - ESLint (npm run lint)
+#   - Structural lint (npm run lint:structure) — ≤50 files per leaf folder
+#   - Migration lint (npm run lint:migrations) — RLS on user-data tables
+#   - Unit + structural Jest (npm test) — currently 91 suites / 811 tests
+#
+# Playwright e2e is intentionally NOT in this workflow. The e2e specs
+# (slice-1-slack-walkthrough.spec.ts, slice-2f-gmail-walkthrough.spec.ts)
+# require a real Supabase project for createTestUser + DB asserts; pointing
+# CI at production is unsafe, and a dedicated test Supabase project
+# doesn't exist yet. When that project lands, e2e gets its own workflow
+# job with the secrets enumerated in docs/ops/cron-wiring.md (the parent
+# OPS doc) — NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+# SLACK_SIGNING_SECRET, CRON_SECRET, GOOGLE_CLIENT_ID,
+# GOOGLE_CLIENT_SECRET, TOKEN_ENCRYPTION_KEY, OAUTH_STATE_SIGNING_KEY.
+
+on:
+  pull_request:
+    branches:
+      - v2-foundation
+  push:
+    branches:
+      - v2-foundation
+
+concurrency:
+  # One CI run per branch; new pushes cancel in-flight runs to save minutes.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: typecheck + lint + jest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          # Matches local dev (v22.20.0 at time of writing). The repo has
+          # no .nvmrc; pinning to 22.x here keeps CI deterministic without
+          # forcing an .nvmrc on every contributor.
+          node-version: 22.x
+          cache: npm
+
+      - name: Install (npm ci)
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Lint (eslint)
+        run: npm run lint
+
+      - name: Lint structure (≤50 files per leaf folder)
+        run: npm run lint:structure
+
+      - name: Lint migrations (RLS on user-data tables)
+        run: npm run lint:migrations
+
+      - name: Jest (unit + structural)
+        run: npm test

--- a/docs/ops/cron-wiring.md
+++ b/docs/ops/cron-wiring.md
@@ -1,0 +1,164 @@
+# Cron wiring for `/api/cron/poll-triggers`
+
+**Status:** deferred. `vercel.json` is intentionally **not** committed yet.
+
+This note exists so the wiring is one config-file copy away from being
+applied, the moment the prerequisites (below) are confirmed.
+
+---
+
+## Why deferred
+
+Vercel's cron-job cadence support is plan-gated: as of this writing,
+Hobby supports daily-only cron jobs while Pro and Enterprise support
+minute-level cron jobs. Shipping `* * * * *` on Hobby would fail at deploy
+time. Slice 2-OPS could not verify the plan from inside the repo (no
+`.vercel/` linkage; no plan info derivable from `package.json`), so the
+file is staged here as documentation rather than committed as runtime
+config that might break the deploy.
+
+When you confirm the plan supports the chosen cadence, the wiring is a
+two-step manual change:
+
+1. Set `CRON_SECRET` in Vercel (Project → Settings → Environment
+   Variables, scoped to Production at minimum, ideally Production +
+   Preview + Development with the same value used in `.env.local`).
+2. Commit `vercel.json` with the entry below in a follow-up PR.
+
+---
+
+## Prerequisites checklist
+
+- [ ] **Vercel plan supports the chosen cadence.** Pro/Enterprise: every
+      minute is fine. Hobby: every minute is **not** supported — only
+      daily granularity. Confirm the project's plan in the Vercel
+      dashboard.
+- [ ] **`CRON_SECRET` is set in the Vercel project's environment.**
+      `services/cron/auth.ts:requireCronAuth` validates the bearer token
+      against `process.env.CRON_SECRET`; without it set, the route
+      returns 500 ("Server misconfiguration") on every cron tick. Vercel
+      cron sends the project's `CRON_SECRET` automatically as
+      `Authorization: Bearer <CRON_SECRET>` when the variable exists at
+      project scope.
+- [ ] **The value in Vercel matches `.env.local`** so manual `curl`
+      verification against the deploy uses the same secret as Vercel
+      cron does. (Cross-env consistency makes runbook commands portable.)
+
+---
+
+## Recommended cadence
+
+**`* * * * *` (every minute) — for Pro / Enterprise plans.**
+
+Reasoning: the per-trigger interval gate inside
+`services/cron/runPollingTriggers.ts` (`now - lastPolledAt < interval`,
+default 5 minutes from `services/cron/pollingIntervals.ts`) does the
+actual rate-limiting per Gmail trigger. A 1-minute cron tick with the
+5-minute per-trigger interval means each trigger fires once every 5
+minutes (V1 parity). Ticks that find no eligible triggers cost one
+indexed JSONB query plus a per-row state lookup — negligible.
+
+**Fall back to `*/5 * * * *` if the plan supports it.** Same average
+behavior; just no margin for clock skew between the cron and the
+per-trigger interval.
+
+**Do not ship daily-only cron** for the polling route — a 24-hour
+delivery delay defeats the purpose of polling. If Hobby is the only
+available plan and Hobby is locked to daily granularity, the right
+answer is to upgrade the Vercel plan, not to weaken the cadence.
+
+---
+
+## `vercel.json` to commit (after prerequisites are checked)
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/cron/poll-triggers",
+      "schedule": "* * * * *"
+    }
+  ]
+}
+```
+
+**Production-only scoping (recommended):** Vercel cron jobs run on the
+Production deployment only by default in current Vercel cron behavior
+(preview deploys do not get scheduled cron). Confirm in the Vercel docs
+at the time of activation; if preview deploys would also get scheduled
+ticks and that is not desired, the cron entry can be conditionally
+guarded by deployment context inside the route handler.
+
+---
+
+## Manual verification
+
+### Locally
+
+With `CRON_SECRET` set in `.env.local` and the dev server running on
+`http://localhost:3000`:
+
+```sh
+curl -X POST -H "Authorization: Bearer $CRON_SECRET" \
+  http://localhost:3000/api/cron/poll-triggers
+```
+
+Expected: HTTP 200 with `{ "ok": true, "examined": <n>, "processed":
+<n>, "skipped": <n>, "errors": <n>, "startedAt": "<ISO>" }`.
+
+### On the production deploy
+
+After committing `vercel.json` and confirming the deploy succeeded:
+
+```sh
+curl -X POST -H "Authorization: Bearer $CRON_SECRET" \
+  https://<your-vercel-domain>/api/cron/poll-triggers
+```
+
+Expected: same shape as above. Then check Vercel Functions logs for the
+`cron.poll_triggers.fatal` event-tag — it should never appear on a
+healthy deploy. Per-tick logs (`processed`, `skipped`, `errors`) flow
+through Next's default `console.info` output.
+
+---
+
+## Risks and operational notes
+
+**Cost / quota.** Each tick that finds eligible triggers calls Gmail's
+`history.list`, `messages.get`, and (when filters pass) the engine's
+action chain (which for `send_email` calls `messages.send`). With the
+5-minute per-trigger interval, each Gmail trigger uses ≤288 Gmail API
+calls per day — well below the project's per-user quota.
+
+**Concurrency.** The scheduler caps fan-out at 5 parallel triggers and
+25-second per-trigger timeouts (`services/cron/runPollingTriggers.ts`).
+For a small user base this is comfortable. When the count of pollable
+triggers crosses ~50–100, batching by user or sharding by trigger-id
+range is the next move — out of scope for now, flagged here so the cost
+isn't surprising at scale.
+
+**Failure isolation.** A handler throwing or timing out is caught by
+`Promise.allSettled` and recorded as an `errors` count without aborting
+the batch. The route returns 200 even with non-zero `errors` (Vercel
+should not retry cron failures). The next tick is the retry.
+
+**Dedup.** Re-delivery of the same Gmail message id (e.g., from a brief
+DB clock-skew that causes overlapping polls) is blocked at the
+`webhook_event_dedup` table by the unique `(provider, event_id)` index.
+No duplicate runs.
+
+---
+
+## When to revisit
+
+- After the first production deploy with cron active: monitor Vercel
+  Functions logs for the cron route over a 24-hour window. Typical
+  steady-state: most ticks `processed: 0, skipped: <n>, errors: 0` (idle
+  triggers awaiting the next interval); periodic ticks with
+  `processed: 1+` when a Gmail message arrives. Sustained `errors > 0`
+  is the signal to investigate.
+- When polling-trigger row count crosses ~50 per user, revisit the
+  concurrency cap and the query plan for `listForPolling`.
+- When per-tier polling intervals ship (Slice 2 follow-up #2), the
+  scheduler will read `user_profiles.role` to compute the gate; the
+  `vercel.json` cadence does not change.


### PR DESCRIPTION
## Summary

Slice 2-OPS — closes the operational loop on the merged Slack/Gmail foundation. Adds a minimal non-e2e CI gate that runs on every PR + push to \`v2-foundation\`, and ships a runbook for the deferred \`vercel.json\` cron wiring.

## Decision: \`vercel.json\` deferred

Vercel's cron cadence is plan-gated (Hobby: daily-only; Pro/Enterprise: minute-level). Cadence support cannot be verified from inside the repo (no \`.vercel/\` linkage, no plan info in \`package.json\`), so per the OPS plan this PR ships the \`vercel.json\` content as **documentation only** in \`docs/ops/cron-wiring.md\`. When the Vercel plan is confirmed, the doc has the exact \`vercel.json\` to copy-paste in a follow-up PR.

## What shipped

- **\`.github/workflows/ci.yml\`** — single \`ubuntu-latest\` job, Node 22.x, runs on \`pull_request → v2-foundation\` and \`push → v2-foundation\`. Steps: \`actions/checkout@v4\` → \`actions/setup-node@v4\` (with npm cache) → \`npm ci\` → \`npx tsc --noEmit\` → \`npm run lint\` → \`npm run lint:structure\` → \`npm run lint:migrations\` → \`npm test\`. Concurrency-grouped per branch (new pushes cancel in-flight runs to save Actions minutes). 10-min timeout. **No secrets required.**

- **\`docs/ops/cron-wiring.md\`** — runbook covering: why \`vercel.json\` is deferred, the two prerequisites (Vercel plan support + \`CRON_SECRET\` env var in Vercel), the recommended cadence (\`* * * * *\` for Pro/Enterprise; \`*/5 * * * *\` as the safe fallback; explicitly NOT daily-only because polling needs sub-hour latency), the exact \`vercel.json\` content to commit when prerequisites clear, manual \`curl\` verification commands for local + production, and operational notes on cost / concurrency / dedup / when to revisit at scale.

## What's intentionally NOT in this PR

- **No \`vercel.json\`** — deferred per OPS plan until the Vercel plan is confirmed.
- **No Playwright e2e in CI** — deferred until a dedicated test Supabase project exists. The CI workflow's docstring enumerates the seven secrets needed at that point.
- **No branch protection in code** — branch protection lives in GitHub repo settings, not the repo. Defer until the workflow has been green on a few PRs.
- **No third-provider work**, no AI filter, no health-engine work, no per-tier polling.

## Local verification (mirrors CI exactly)

| Step | Result |
|---|---|
| YAML parse (\`js-yaml.load\`) | OK — 1 job, 8 steps |
| \`npx tsc --noEmit\` | clean |
| \`npm run lint\` | clean |
| \`npm run lint:structure\` | leaf folders ≤ 50 files |
| \`npm run lint:migrations\` | RLS gates OK |
| \`npm test\` | 91 suites / 811 tests pass (3.3s) |

The CI workflow itself will be the first run against this PR — that's the validation that the workflow file is correct.

## Manual setup still required

| Step | When | Where |
|---|---|---|
| Verify Vercel plan supports \`* * * * *\` cron cadence | Before the cron-wiring follow-up PR | Vercel dashboard |
| Set \`CRON_SECRET\` env var in Vercel | Before the cron-wiring follow-up PR | Vercel project → Settings → Environment Variables |
| Create dedicated test Supabase project | Before e2e CI ships | Supabase dashboard |
| Add 7 e2e secrets to GitHub Actions | Before e2e CI ships | GitHub repo → Settings → Secrets |
| Enable branch protection on \`v2-foundation\` | After CI is stable on a few PRs | GitHub repo → Settings → Rules |

## Test plan

- [ ] CI workflow runs and passes on this PR (this is the workflow's own first run)
- [ ] Vercel preview deploy passes
- [ ] Reviewer scans diff for scope creep (only the two new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)