### PR TITLE
ops: wire Gmail polling cron in vercel.json

### DIFF
--- a/docs/ops/cron-wiring.md
+++ b/docs/ops/cron-wiring.md
@@ -1,9 +1,9 @@
 # Cron wiring for `/api/cron/poll-triggers`
 
-**Status:** deferred. `vercel.json` is intentionally **not** committed yet.
-
-This note exists so the wiring is one config-file copy away from being
-applied, the moment the prerequisites (below) are confirmed.
+**Status:** implemented on `slice-2-ops-vercel-cron`. The `vercel.json`
+snippet below is now committed at the repo root. Prerequisites (Vercel
+plan + `CRON_SECRET`) must still be verified in the Vercel dashboard
+before the deploy is healthy.
 
 ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/poll-triggers",
+      "schedule": "* * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add root-level `vercel.json` with the single `/api/cron/poll-triggers` entry at `* * * * *`, matching the snippet documented in `docs/ops/cron-wiring.md`.
- Flip the doc's Status header from "deferred" to "implemented on `slice-2-ops-vercel-cron`"; prerequisites/verification/risks sections are unchanged.
- No route handler / CI / e2e / provider / polling-logic changes. No other V1 cron entries copied over.

## Dashboard side (still manual, not part of this PR)
- Confirm the Vercel project plan supports `* * * * *` cadence (Hobby is daily-only — deploy will fail if the project is on Hobby).
- Confirm `CRON_SECRET` is set in the Vercel project's Production environment (route returns 500 on every tick without it).
- If the plan does not support minute-level cron, follow up by adjusting the schedule (e.g., `*/5 * * * *` documented as the fallback).

## Test plan
- [ ] CI green on this branch.
- [ ] After merge + production deploy: `curl -X POST -H "Authorization: Bearer $CRON_SECRET" https://<vercel-domain>/api/cron/poll-triggers` returns 200 with the expected JSON shape.
- [ ] Vercel Functions logs show no `cron.poll_triggers.fatal` events over the first 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)