### PR TITLE
CONN-SHARE production promotion (scoped, flag-on)

### DIFF
--- a/app/api/accounts/[id]/integrations/[integrationId]/sharing/_shared.ts
+++ b/app/api/accounts/[id]/integrations/[integrationId]/sharing/_shared.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { SetSharingFailureReason } from "@/services/integrations/connectionSharing";
+
+/**
+ * Shared route-layer helper for the connection-sharing route
+ * (Slice 4.CONN-SHARE / CS-2). Underscore-prefixed: not a route.
+ *
+ * Maps the service's typed reason → a generic, no-leak HTTP response:
+ *   - `not_enabled` ⇒ 404 CONNECTION_SHARING_NOT_ENABLED. The feature is behind a
+ *     temporary dev guard; a uniform response to every caller (the service does
+ *     zero I/O when OFF) leaks nothing about the row or membership.
+ *   - `not_found` ⇒ 404 INTEGRATION_NOT_FOUND. Covers cross-account, unknown id,
+ *     non-member, AND disconnected row uniformly — existence/ownership/state
+ *     never leak.
+ *   - `account_frozen` ⇒ 403 ACCOUNT_PENDING_DELETION (mirrors disconnect).
+ *   - `forbidden` ⇒ 403 FORBIDDEN (a member who lacks permission for THIS action —
+ *     e.g. a non-connector trying to share, or a plain member trying to unshare).
+ *   - `account_provider_not_shareable` ⇒ 422 ACCOUNT_PROVIDER_NOT_SHAREABLE
+ *     (account/service providers are already account-shared by classification).
+ *
+ * No raw provider/DB/token detail ever appears here — only typed codes.
+ */
+export function sharingFailureResponse(reason: SetSharingFailureReason): NextResponse {
+  switch (reason) {
+    case "not_enabled":
+      return NextResponse.json(
+        { error: "Connection sharing is not available.", code: "CONNECTION_SHARING_NOT_ENABLED" },
+        { status: 404 },
+      );
+    case "account_frozen":
+      return NextResponse.json(
+        { error: "This account is pending deletion.", code: "ACCOUNT_PENDING_DELETION" },
+        { status: 403 },
+      );
+    case "not_found":
+      return NextResponse.json(
+        { error: "Integration not found.", code: "INTEGRATION_NOT_FOUND" },
+        { status: 404 },
+      );
+    case "forbidden":
+      return NextResponse.json(
+        { error: "Insufficient permissions.", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    case "account_provider_not_shareable":
+      return NextResponse.json(
+        {
+          error: "This provider is already shared with the account and cannot be shared individually.",
+          code: "ACCOUNT_PROVIDER_NOT_SHAREABLE",
+        },
+        { status: 422 },
+      );
+  }
+}

--- a/app/api/accounts/[id]/integrations/[integrationId]/sharing/route.ts
+++ b/app/api/accounts/[id]/integrations/[integrationId]/sharing/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { requireAuthedUserId } from "@/app/api/account/_shared";
+import { setIntegrationSharingScope } from "@/services/integrations/connectionSharing";
+import { INTEGRATION_SHARING_SCOPE_VALUES } from "@/core/integrations/sharingScope";
+import { sharingFailureResponse } from "./_shared";
+
+/**
+ * POST /api/accounts/[id]/integrations/[integrationId]/sharing
+ * (Slice 4.CONN-SHARE / CS-2)
+ *
+ * Sets the explicit sharing scope of ONE personal connection. Thin: authenticate
+ * the session → validate the requested scope → call the service → map typed
+ * failures. The service (`setIntegrationSharingScope`) is the single
+ * authorization chokepoint (flag → frozen → exact (account, id) row scope →
+ * membership → disconnected guard → provider class → connector/admin authz) and
+ * the only writer of `integration_sharing_scope`. The route never touches a
+ * service-role client and never sees a token, provider account id, or raw error.
+ *
+ * Request body: `{ scope: "private_to_connector" | "shared_with_account" }`. The
+ * account id + integration id come from the path; the caller id comes from the
+ * verified session — never from request input — so a caller can only act as
+ * themselves.
+ *
+ * No-leak: not_enabled / not_found / cross-account / non-member / disconnected
+ * all collapse to a generic typed code; the success body is only
+ * `{ scope, shared, changed }` (a safe enum + booleans).
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; integrationId: string }> },
+): Promise<Response> {
+  const auth = await requireAuthedUserId();
+  if (!auth.ok) return auth.response;
+
+  // Validate the requested scope BEFORE any service call — reject anything that
+  // is not one of the two known values with a generic 400 (no enumeration hint).
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = null;
+  }
+  const scope = (body as { scope?: unknown } | null)?.scope;
+  if (
+    typeof scope !== "string" ||
+    !(INTEGRATION_SHARING_SCOPE_VALUES as readonly string[]).includes(scope)
+  ) {
+    return NextResponse.json(
+      { error: "Invalid sharing scope.", code: "INVALID_SHARING_SCOPE" },
+      { status: 400 },
+    );
+  }
+
+  const { id: accountId, integrationId } = await params;
+  const result = await setIntegrationSharingScope({
+    accountId,
+    integrationId,
+    callerUserId: auth.userId,
+    scope: scope as (typeof INTEGRATION_SHARING_SCOPE_VALUES)[number],
+  });
+  if (!result.ok) return sharingFailureResponse(result.reason);
+
+  return NextResponse.json({
+    scope: result.scope,
+    shared: result.scope === "shared_with_account",
+    changed: result.changed,
+  });
+}

--- a/app/api/workflows/[id]/activate/route.ts
+++ b/app/api/workflows/[id]/activate/route.ts
@@ -111,7 +111,7 @@ export async function POST(
     if (!authorized.ok) return authorized.response;
     // WF-RUNPERM — activating arms the workflow to fire under the creator's
     // identity. Only the creator may activate a private-credential workflow.
-    const runEditDenied = assertWorkflowRunEditAllowed(workflow, auth.userId);
+    const runEditDenied = await assertWorkflowRunEditAllowed(workflow, auth.userId);
     if (runEditDenied) return runEditDenied;
   }
   let risk: RiskConfirmationResult | null = null;

--- a/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/_shared.ts
+++ b/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/_shared.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import type { MembershipRole } from "@/contracts/accounts";
+import * as workflowsRepo from "@/repositories/workflows";
+import {
+  requireUser,
+  requireWorkflowAccountMember,
+  workflowNotFoundResponse,
+} from "@/app/api/workflows/_shared";
+import { requireAccountRole } from "@/services/accounts/accountAuthz";
+import type { ConnectorBindingReason } from "@/services/integrations/connectionBinding";
+
+/**
+ * Shared auth + error mapping for the node connector-binding routes
+ * (Slice 4.CONN-SHARE / CS-4a). Mirrors the credential-owner route `_shared.ts`.
+ *
+ * `resolveCaller` authenticates, loads the workflow, and authorizes the caller as
+ * a MEMBER of the workflow's account — a non-member, a missing/deleted workflow,
+ * and an unauthenticated caller all collapse to the SAME 404 (no existence leak).
+ * It also resolves the caller's role for the service's editor gate.
+ *
+ * No response ever carries a token, provider account label, email, scope, or
+ * account metadata — only `{ ok }` / safe display views or a typed error code.
+ */
+
+export interface ResolvedCaller {
+  userId: string;
+  accountId: string;
+  role: MembershipRole;
+}
+
+export async function resolveCaller(
+  workflowId: string,
+): Promise<{ ok: true; caller: ResolvedCaller } | { ok: false; response: NextResponse }> {
+  const auth = await requireUser();
+  if (!auth.ok) return { ok: false, response: auth.response };
+
+  const record = await workflowsRepo.getById(workflowId);
+  if (!record || record.state === "deleted") {
+    return { ok: false, response: workflowNotFoundResponse() };
+  }
+
+  const member = await requireWorkflowAccountMember(auth.userId, record.accountId);
+  if (!member.ok) return { ok: false, response: member.response };
+
+  const role = await requireAccountRole(auth.userId, record.accountId, ["owner", "admin", "member"]);
+  if (!role.ok) return { ok: false, response: workflowNotFoundResponse() };
+
+  return { ok: true, caller: { userId: auth.userId, accountId: record.accountId, role: role.role } };
+}
+
+function json(error: string, code: string, status: number): NextResponse {
+  return NextResponse.json({ error, code }, { status });
+}
+
+export function connectorBindingErrorResponse(reason: ConnectorBindingReason): NextResponse {
+  switch (reason) {
+    case "not_enabled":
+      // Hide the endpoint when the feature is off — same 404 shape as a missing
+      // workflow, so flag state is not an existence oracle.
+      return workflowNotFoundResponse();
+    case "workflow_not_found":
+      return workflowNotFoundResponse();
+    case "node_not_found":
+      return json("That step is not part of this workflow.", "NODE_NOT_FOUND", 404);
+    case "not_applicable":
+      return json(
+        "This step uses a shared team connection — it can't be bound to a connector.",
+        "NOT_APPLICABLE",
+        400,
+      );
+    case "account_frozen":
+      return json("This account is pending deletion.", "ACCOUNT_PENDING_DELETION", 403);
+    case "forbidden":
+      return json("You don't have permission to do that.", "FORBIDDEN", 403);
+    case "connector_not_member":
+      return json("That member is not part of this account.", "CONNECTOR_NOT_MEMBER", 400);
+    case "connector_not_connected":
+      return json("That member hasn't connected this app yet.", "CONNECTOR_NOT_CONNECTED", 400);
+    case "connector_not_shared":
+      return json(
+        "That member hasn't shared this connection with the team.",
+        "CONNECTOR_NOT_SHARED",
+        400,
+      );
+  }
+}

--- a/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/eligible-connectors/route.ts
+++ b/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/eligible-connectors/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { listEligibleSharedConnectors } from "@/services/integrations/connectionBinding";
+import { resolveCaller, connectorBindingErrorResponse } from "../_shared";
+
+/**
+ * GET /api/workflows/[id]/nodes/[nodeId]/connector-binding/eligible-connectors
+ * (Slice 4.CONN-SHARE / CS-4a)
+ *
+ * The safe picker: members whose personal connection for this node's provider is
+ * explicitly `shared_with_account`. Editor-gated (the service applies the
+ * owner/admin-or-creator rule). Returns `{ userId, displayName, role }` ONLY —
+ * never a token, provider account label, email, scope, or account metadata.
+ * Reuses the exact shape of the credential-owner eligible-targets endpoint.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+): Promise<Response> {
+  const { id, nodeId } = await params;
+
+  const resolved = await resolveCaller(id);
+  if (!resolved.ok) return resolved.response;
+
+  const result = await listEligibleSharedConnectors({
+    workflowId: id,
+    nodeId,
+    callerUserId: resolved.caller.userId,
+    callerRole: resolved.caller.role,
+  });
+  if (!result.ok) return connectorBindingErrorResponse(result.reason);
+
+  return NextResponse.json({ connectors: result.connectors });
+}

--- a/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route.ts
+++ b/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import {
+  setNodeConnectorBinding,
+  clearNodeConnectorBinding,
+} from "@/services/integrations/connectionBinding";
+import { resolveCaller, connectorBindingErrorResponse } from "./_shared";
+
+/**
+ * PUT/DELETE /api/workflows/[id]/nodes/[nodeId]/connector-binding
+ * (Slice 4.CONN-SHARE / CS-4a)
+ *
+ * PUT sets the node's connector binding to `{ connectorUserId }`; DELETE clears
+ * it. Thin: authenticate + membership-gate via `resolveCaller` → call the service
+ * → map typed failures. The service is the single authorization chokepoint
+ * (flag → workflow → node → provider class → frozen → editor → connector must be
+ * a member + connected + in the live shared set) and the only writer. The route
+ * never touches a service-role client and never sees a token or raw error.
+ *
+ * BEHAVIOR-INERT: the stored binding is not yet consulted by the resolver or the
+ * run/edit gate (CS-4b). No-leak: not_enabled / workflow_not_found / non-member
+ * all collapse to 404; success bodies carry only booleans.
+ */
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+): Promise<Response> {
+  const { id, nodeId } = await params;
+
+  const resolved = await resolveCaller(id);
+  if (!resolved.ok) return resolved.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = null;
+  }
+  const connectorUserId = (body as { connectorUserId?: unknown } | null)?.connectorUserId;
+  if (typeof connectorUserId !== "string" || connectorUserId.length === 0) {
+    return NextResponse.json(
+      { error: "A connector must be selected.", code: "INVALID_CONNECTOR" },
+      { status: 400 },
+    );
+  }
+
+  const result = await setNodeConnectorBinding({
+    workflowId: id,
+    nodeId,
+    connectorUserId,
+    callerUserId: resolved.caller.userId,
+    callerRole: resolved.caller.role,
+  });
+  if (!result.ok) return connectorBindingErrorResponse(result.reason);
+
+  return NextResponse.json({ bound: true });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+): Promise<Response> {
+  const { id, nodeId } = await params;
+
+  const resolved = await resolveCaller(id);
+  if (!resolved.ok) return resolved.response;
+
+  const result = await clearNodeConnectorBinding({
+    workflowId: id,
+    nodeId,
+    callerUserId: resolved.caller.userId,
+    callerRole: resolved.caller.role,
+  });
+  if (!result.ok) return connectorBindingErrorResponse(result.reason);
+
+  return NextResponse.json({ cleared: result.cleared });
+}

--- a/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route.ts
+++ b/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route.ts
@@ -2,8 +2,40 @@ import { NextResponse } from "next/server";
 import {
   setNodeConnectorBinding,
   clearNodeConnectorBinding,
+  getNodeConnectorBindingState,
 } from "@/services/integrations/connectionBinding";
 import { resolveCaller, connectorBindingErrorResponse } from "./_shared";
+
+/**
+ * GET /api/workflows/[id]/nodes/[nodeId]/connector-binding (Slice 4.CONN-SHARE / CS-5b)
+ *
+ * The builder's per-node binding state: `{ status, connectors, currentConnectorDisplayName }`.
+ * Editor-gated; no-leak (status enum + safe `{userId, displayName, role}` options +
+ * a display name only). not_enabled / non-member collapse to 404.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+): Promise<Response> {
+  const { id, nodeId } = await params;
+
+  const resolved = await resolveCaller(id);
+  if (!resolved.ok) return resolved.response;
+
+  const result = await getNodeConnectorBindingState({
+    workflowId: id,
+    nodeId,
+    callerUserId: resolved.caller.userId,
+    callerRole: resolved.caller.role,
+  });
+  if (!result.ok) return connectorBindingErrorResponse(result.reason);
+
+  return NextResponse.json({
+    status: result.status,
+    connectors: result.connectors,
+    currentConnectorDisplayName: result.currentConnectorDisplayName,
+  });
+}
 
 /**
  * PUT/DELETE /api/workflows/[id]/nodes/[nodeId]/connector-binding

--- a/app/api/workflows/[id]/reactivate/route.ts
+++ b/app/api/workflows/[id]/reactivate/route.ts
@@ -40,7 +40,7 @@ export async function POST(
   // executable; only the creator may do so.
   const record = await workflowsRepo.getById(id);
   if (record && record.state !== "deleted") {
-    const runEditDenied = assertWorkflowRunEditAllowed(record, auth.userId);
+    const runEditDenied = await assertWorkflowRunEditAllowed(record, auth.userId);
     if (runEditDenied) return runEditDenied;
   }
 

--- a/app/api/workflows/[id]/replace-from-template/route.ts
+++ b/app/api/workflows/[id]/replace-from-template/route.ts
@@ -49,5 +49,5 @@ export async function POST(
     }
   }
 
-  return NextResponse.json(toWorkflowDetail(result.workflow, auth.userId));
+  return NextResponse.json(await toWorkflowDetail(result.workflow, auth.userId));
 }

--- a/app/api/workflows/[id]/restore/route.ts
+++ b/app/api/workflows/[id]/restore/route.ts
@@ -38,5 +38,5 @@ export async function POST(
   if (!result.ok) return trashErrorResponse(result);
 
   const restored = await workflowsRepo.getById(id);
-  return NextResponse.json(restored ? toWorkflowDetail(restored, auth.userId) : { ok: true });
+  return NextResponse.json(restored ? await toWorkflowDetail(restored, auth.userId) : { ok: true });
 }

--- a/app/api/workflows/[id]/resume/route.ts
+++ b/app/api/workflows/[id]/resume/route.ts
@@ -25,7 +25,7 @@ export async function POST(
   // identity. Only the creator may resume a private-credential workflow.
   const record = await workflowsRepo.getById(id);
   if (record && record.state !== "deleted") {
-    const runEditDenied = assertWorkflowRunEditAllowed(record, auth.userId);
+    const runEditDenied = await assertWorkflowRunEditAllowed(record, auth.userId);
     if (runEditDenied) return runEditDenied;
   }
 

--- a/app/api/workflows/[id]/route.ts
+++ b/app/api/workflows/[id]/route.ts
@@ -58,7 +58,7 @@ export async function GET(
   const loaded = await loadOrNotFound(id, auth.userId);
   if (!loaded.ok) return loaded.response;
 
-  return NextResponse.json(toWorkflowDetail(loaded.record, auth.userId));
+  return NextResponse.json(await toWorkflowDetail(loaded.record, auth.userId));
 }
 
 export async function PATCH(
@@ -122,7 +122,7 @@ export async function PATCH(
     });
     if (!moved.ok) return folderErrorResponse(moved);
   }
-  return NextResponse.json(toWorkflowDetail(next, auth.userId));
+  return NextResponse.json(await toWorkflowDetail(next, auth.userId));
 }
 
 /**

--- a/app/api/workflows/[id]/run-now/route.ts
+++ b/app/api/workflows/[id]/run-now/route.ts
@@ -129,7 +129,7 @@ export async function POST(
   // OAuth identity (22B creator-pin). Only the creator may run it; non-creators
   // (incl. owner/admin) get a typed 403 and are pointed to Duplicate. Shared/
   // account-only + native-only workflows are unaffected (any member runs).
-  const runEditDenied = assertWorkflowRunEditAllowed(workflow, auth.userId);
+  const runEditDenied = await assertWorkflowRunEditAllowed(workflow, auth.userId);
   if (runEditDenied) return runEditDenied;
   if (!ALLOWED_STATES.has(workflow.state)) {
     return NextResponse.json(

--- a/app/api/workflows/_shared.ts
+++ b/app/api/workflows/_shared.ts
@@ -270,19 +270,45 @@ export function toWorkflowSummary(record: WorkflowRecord): WorkflowSummary {
   };
 }
 
-export function toWorkflowDetail(
+/**
+ * The single async `viewerCanRunEdit` boolean (CS-4b/CS-5a) — the SAME decision
+ * `assertWorkflowRunEditAllowed` enforces, so the DTO hint and the gate can never
+ * drift. Flag OFF → exact `viewerMayRunEdit` (no DB). Flag ON → creator / no-
+ * private short-circuit (no DB), else the shared `buildWorkflowCredentialPlan`
+ * resolvability (`allTeamRunnable`).
+ */
+export async function computeViewerCanRunEdit(
   record: WorkflowRecord,
   callerUserId: string,
-): WorkflowDetail {
+): Promise<boolean> {
+  if (!isConnectionSharingEnabled()) {
+    return viewerMayRunEdit(
+      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
+      callerUserId,
+    );
+  }
+  if (!workflowUsesPrivateCredential(record.draftDefinition)) return true;
+  if (record.createdByUserId === callerUserId) return true;
+  const plan = await buildWorkflowCredentialPlan({
+    workflowId: record.id,
+    accountId: record.accountId,
+    createdByUserId: record.createdByUserId,
+    nodes: record.draftDefinition.nodes,
+  });
+  return plan.allTeamRunnable;
+}
+
+export async function toWorkflowDetail(
+  record: WorkflowRecord,
+  callerUserId: string,
+): Promise<WorkflowDetail> {
   return {
     ...toWorkflowSummary(record),
     activeRevisionId: record.activeRevisionId,
     draftDefinition: record.draftDefinition,
     usesPrivateCredential: workflowUsesPrivateCredential(record.draftDefinition),
-    viewerCanRunEdit: viewerMayRunEdit(
-      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
-      callerUserId,
-    ),
+    // Accurate under the flag — shares the gate's exact computation.
+    viewerCanRunEdit: await computeViewerCanRunEdit(record, callerUserId),
   };
 }
 
@@ -295,6 +321,14 @@ export function toWorkflowDetail(
  * once from the `workflow_run_stats` view. Workflows with no recorded real
  * runs get zeroed stats. Only provider id/label/iconUrl + counts + numeric
  * run stats leave the server — no raw definition, config, or values.
+ *
+ * `viewerCanRunEdit` here stays the CONSERVATIVE sync `viewerMayRunEdit` (creator-
+ * only for private-credential workflows) even with the sharing flag ON: the list
+ * renders N rows and a per-row `buildWorkflowCredentialPlan` (3 DB reads each)
+ * is too costly. This is SAFE — it never over-permits; a non-creator who CAN run a
+ * shared workflow simply sees the conservative chip until they open it (the detail
+ * DTO `toWorkflowDetail` is accurate). Batching list resolvability is a CS-5b
+ * follow-up. The run/edit GATE is the real enforcement regardless.
  */
 export function toWorkflowListItem(
   record: WorkflowRecord,
@@ -359,27 +393,10 @@ export async function assertWorkflowRunEditAllowed(
   record: WorkflowRecord,
   callerUserId: string,
 ): Promise<NextResponse | null> {
-  if (!isConnectionSharingEnabled()) {
-    const allowed = viewerMayRunEdit(
-      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
-      callerUserId,
-    );
-    return allowed ? null : workflowUsesPrivateCredentialResponse();
-  }
-
-  // Flag ON. No private credentials, or the creator → allowed (no DB).
-  if (!workflowUsesPrivateCredential(record.draftDefinition)) return null;
-  if (record.createdByUserId === callerUserId) return null;
-
-  // Non-creator with private providers → resolvable iff every personal node has a
-  // specific shared connector. Fails closed on ambiguous / unshared.
-  const plan = await buildWorkflowCredentialPlan({
-    workflowId: record.id,
-    accountId: record.accountId,
-    createdByUserId: record.createdByUserId,
-    nodes: record.draftDefinition.nodes,
-  });
-  return plan.allTeamRunnable ? null : workflowUsesPrivateCredentialResponse();
+  // Shares `computeViewerCanRunEdit` with the DTO hint — gate and UI can't drift.
+  return (await computeViewerCanRunEdit(record, callerUserId))
+    ? null
+    : workflowUsesPrivateCredentialResponse();
 }
 
 export function toWorkflowRunSummary(

--- a/app/api/workflows/_shared.ts
+++ b/app/api/workflows/_shared.ts
@@ -11,6 +11,8 @@ import {
   workflowUsesPrivateCredential,
   viewerMayRunEdit,
 } from "@/core/integrations/workflowCredentialScope";
+import { isConnectionSharingEnabled } from "@/services/integrations/connectionSharingFlags";
+import { buildWorkflowCredentialPlan } from "@/services/integrations/connectionResolution";
 import { emptyRunStats } from "@/repositories/workflowRunStats";
 import * as workflowsRepo from "@/repositories/workflows";
 import type { WorkflowRecord } from "@/repositories/workflows";
@@ -339,21 +341,45 @@ export function workflowUsesPrivateCredentialResponse(): NextResponse {
 }
 
 /**
- * WF-RUNPERM — run/edit gate, applied AFTER the membership gate, on an already-
- * loaded (non-deleted, membership-authorized) record. Returns the typed 403 when
- * the workflow is private-credential and the caller is not its creator; `null`
- * when run/edit is allowed. Role-agnostic — owner/admin do not pass for a
- * private-credential workflow (management actions are separate routes).
+ * WF-RUNPERM (+ CS-4b sharing) — run/edit gate, applied AFTER the membership gate,
+ * on an already-loaded (non-deleted, membership-authorized) record. Returns the
+ * typed 403 when the workflow is private-credential and the caller may not run/
+ * edit it; `null` when allowed. Role-agnostic.
+ *
+ * `ENABLE_CONNECTION_SHARING` OFF → EXACT WF-RUNPERM (`viewerMayRunEdit`, no DB).
+ *
+ * Flag ON → a non-creator is allowed only when EVERY personal-provider node
+ * resolves to a specific shared connector under the shared
+ * `buildWorkflowCredentialPlan` precedence (accepted grant → valid binding →
+ * single-sharer). Any unshared or ambiguous-no-binding node keeps it creator-only.
+ * The gate consumes the SAME plan the executor resolves owners from, so they can
+ * never drift. Creator + no-private short-circuit with no DB read.
  */
-export function assertWorkflowRunEditAllowed(
+export async function assertWorkflowRunEditAllowed(
   record: WorkflowRecord,
   callerUserId: string,
-): NextResponse | null {
-  const allowed = viewerMayRunEdit(
-    { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
-    callerUserId,
-  );
-  return allowed ? null : workflowUsesPrivateCredentialResponse();
+): Promise<NextResponse | null> {
+  if (!isConnectionSharingEnabled()) {
+    const allowed = viewerMayRunEdit(
+      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
+      callerUserId,
+    );
+    return allowed ? null : workflowUsesPrivateCredentialResponse();
+  }
+
+  // Flag ON. No private credentials, or the creator → allowed (no DB).
+  if (!workflowUsesPrivateCredential(record.draftDefinition)) return null;
+  if (record.createdByUserId === callerUserId) return null;
+
+  // Non-creator with private providers → resolvable iff every personal node has a
+  // specific shared connector. Fails closed on ambiguous / unshared.
+  const plan = await buildWorkflowCredentialPlan({
+    workflowId: record.id,
+    accountId: record.accountId,
+    createdByUserId: record.createdByUserId,
+    nodes: record.draftDefinition.nodes,
+  });
+  return plan.allTeamRunnable ? null : workflowUsesPrivateCredentialResponse();
 }
 
 export function toWorkflowRunSummary(

--- a/app/apps/_shared.ts
+++ b/app/apps/_shared.ts
@@ -2,6 +2,8 @@ import { getProvider, listProviders, providerIconUrl } from "@/integrations/_reg
 import type { IntegrationRecord } from "@/repositories/integrations";
 import { APPS_CATEGORY_ORDER, categoryFor, descriptionFor, type AppsCategory } from "@/lib/apps/providerCategories";
 import { isAccountCredentialProvider } from "@/core/integrations/credentialSharing";
+import { effectiveIntegrationSharingScope } from "@/core/integrations/sharingScope";
+import { isConnectionSharingEnabled } from "@/services/integrations/connectionSharingFlags";
 import type { MembershipRole } from "@/contracts/accounts";
 import type {
   AppAccountSummary,
@@ -39,10 +41,62 @@ interface IntegrationShape {
   createdAt: string;
   /**
    * SERVER-ONLY provenance — the human who connected this row. Used ONLY to
-   * derive the `canDisconnect` boolean below; it is NEVER copied into the
-   * emitted DTO. (The dto-safety test asserts it never appears in the output.)
+   * derive the `canDisconnect` / sharing booleans below; it is NEVER copied into
+   * the emitted DTO. (The dto-safety test asserts it never appears in the output.)
    */
   connectedByUserId: string | null;
+  /**
+   * SERVER-ONLY raw sharing-scope column (CS-1). Used ONLY to derive the
+   * `sharingStatus` / `sharedWithAccount` / `canShare` / `canUnshare` fields; the
+   * raw value is NEVER emitted. Optional — mirrors the optional column on
+   * `IntegrationRecord`; `undefined` reads as `null` (the helper accepts both).
+   */
+  integrationSharingScope?: string | null;
+}
+
+interface SharingDtoFields {
+  sharingStatus: AppAccountSummary["sharingStatus"];
+  sharedWithAccount: boolean;
+  canShare: boolean;
+  canUnshare: boolean;
+}
+
+/**
+ * Server-derived sharing fields for one row (CS-5a), evaluated for UI gating only
+ * (the POST sharing route re-authorizes authoritatively).
+ *
+ * `not_applicable` (no sharing UI) when the feature flag is OFF or the provider is
+ * account/service (already account-shared). For personal providers with the flag
+ * ON: status from the row's effective scope; `canShare` = the CONNECTOR only on a
+ * still-private row (owner/admin can NOT silently share a member's identity);
+ * `canUnshare` = connector OR owner/admin on a shared row (admin-safety removal).
+ * Rows here are always active (the catalog only contains active integrations), so
+ * disconnected rows never expose a toggle.
+ */
+function computeSharingFields(
+  provider: string,
+  connectedByUserId: string | null,
+  rawSharingScope: string | null | undefined,
+  ctx: DisconnectContext | undefined,
+): SharingDtoFields {
+  const off: SharingDtoFields = {
+    sharingStatus: "not_applicable",
+    sharedWithAccount: false,
+    canShare: false,
+    canUnshare: false,
+  };
+  if (!ctx || !isConnectionSharingEnabled()) return off;
+  if (isAccountCredentialProvider(provider)) return off; // already account-shared
+
+  const scope = effectiveIntegrationSharingScope(provider, rawSharingScope);
+  const isConnector = connectedByUserId !== null && connectedByUserId === ctx.callerUserId;
+  const isOwnerAdmin = ctx.callerRole === "owner" || ctx.callerRole === "admin";
+  return {
+    sharingStatus: scope,
+    sharedWithAccount: scope === "shared_with_account",
+    canShare: scope === "private_to_connector" && isConnector,
+    canUnshare: scope === "shared_with_account" && (isConnector || isOwnerAdmin),
+  };
 }
 
 /**
@@ -91,6 +145,12 @@ function toAppAccountSummary(
     connectedAt: record.createdAt,
     canDisconnect: canManageCredential,
     canReconnect: canManageCredential,
+    ...computeSharingFields(
+      record.provider,
+      record.connectedByUserId,
+      record.integrationSharingScope,
+      ctx,
+    ),
   };
 }
 
@@ -204,8 +264,10 @@ export function projectIntegrationForMapper(r: IntegrationRecord): IntegrationSh
     provider: r.provider,
     displayName: r.displayName,
     createdAt: r.createdAt,
-    // Server-only — consumed by computeCanDisconnect, never emitted in the DTO.
+    // Server-only — consumed by computeCanDisconnect + computeSharingFields,
+    // never emitted in the DTO.
     connectedByUserId: r.connectedByUserId,
+    integrationSharingScope: r.integrationSharingScope ?? null,
   };
 }
 

--- a/contracts/apps.ts
+++ b/contracts/apps.ts
@@ -39,6 +39,35 @@ export const AppAccountSummarySchema = z.object({
    * the opaque row id.
    */
   canReconnect: z.boolean(),
+  /**
+   * Explicit connection-sharing status of THIS row (Slice 4.CONN-SHARE / CS-5a):
+   *   - `not_applicable` — account/service provider (already account-shared by
+   *     classification), OR the `ENABLE_CONNECTION_SHARING` feature is OFF. No
+   *     sharing UI renders.
+   *   - `private_to_connector` — a personal connection only its connector can use
+   *     for runnable workflows ("Private to you").
+   *   - `shared_with_account` — the connector opted it in; team members may run
+   *     workflows using it ("Shared with team").
+   * Server-derived from the row's sharing scope + provider class + the flag. The
+   * inputs (`integration_sharing_scope`, `connected_by_user_id`) are NEVER emitted.
+   */
+  sharingStatus: z.enum(["not_applicable", "private_to_connector", "shared_with_account"]),
+  /** Convenience boolean — `sharingStatus === "shared_with_account"`. */
+  sharedWithAccount: z.boolean(),
+  /**
+   * Whether the CURRENT caller may SHARE this private connection (CS-5a). True only
+   * for the CONNECTOR of an active personal connection that is currently private,
+   * with the flag ON. Owner/admin can NOT share another member's personal identity,
+   * so this stays false for them. The POST sharing route re-authorizes — a stale
+   * `true` can't bypass anything. No identity emitted.
+   */
+  canShare: z.boolean(),
+  /**
+   * Whether the CURRENT caller may STOP sharing this connection (CS-5a). True for
+   * the connector OR owner/admin (admin-safety removal) on a currently-shared
+   * active personal connection, flag ON. The route re-authorizes server-side.
+   */
+  canUnshare: z.boolean(),
 });
 export type AppAccountSummary = z.infer<typeof AppAccountSummarySchema>;
 

--- a/core/integrations/sharingEligibility.ts
+++ b/core/integrations/sharingEligibility.ts
@@ -157,3 +157,62 @@ export function computeRunEditEligibility(
   // because workflowUsesPrivateCredential was true).
   return { allowed: true, reason: "all_providers_single_shared", providerStatuses };
 }
+
+// ── CS-4b — per-node effective-owner precedence (gate + executor share this) ──
+
+export type NodeOwnerVia = "grant" | "binding" | "single_sharer" | "creator";
+
+export interface NodeOwnerResolution {
+  /**
+   * The user whose personal connection this node runs under. ALWAYS defined — the
+   * creator is the safe deterministic fallback (their OWN connection, never a
+   * co-member). The gate uses `teamRunnable` to decide non-creator access; the
+   * executor uses `owner` to set the credential-resolution context.
+   */
+  readonly owner: string;
+  readonly via: NodeOwnerVia;
+  /**
+   * True when the node resolves to a SPECIFIC shared connector (grant / valid
+   * binding / single sharer) — i.e. a non-creator may run it. False for the
+   * creator fallback (unshared or ambiguous-no-binding), which keeps a workflow
+   * creator-only.
+   */
+  readonly teamRunnable: boolean;
+}
+
+/**
+ * Resolve the effective credential owner for ONE personal-provider node, by the
+ * locked precedence (plan §15.5):
+ *   1. accepted `workflow_node_credentials` grant — wins.
+ *   2. VALID node connector binding — the bound connector is still in the live
+ *      shared set (an unshared / disconnected / departed connector drops out, so
+ *      an invalid binding is IGNORED — never silently used).
+ *   3. single shared connector — exactly one shared connector for the provider.
+ *   4. creator pin — deterministic, safe fallback (unshared OR ambiguous 2+ with
+ *      no valid binding/grant). FAILS CLOSED for non-creators; NEVER picks an
+ *      arbitrary/earliest co-member row.
+ *
+ * Pure — callers gather the inputs. Only call for PERSONAL providers (account /
+ * native nodes are not credential-owned).
+ */
+export function resolveNodeOwner(input: {
+  creatorUserId: string;
+  acceptedGrantOwner: string | null;
+  bindingConnector: string | null;
+  sharedConnectors: ReadonlySet<string>;
+}): NodeOwnerResolution {
+  const { creatorUserId, acceptedGrantOwner, bindingConnector, sharedConnectors } = input;
+
+  if (acceptedGrantOwner) {
+    return { owner: acceptedGrantOwner, via: "grant", teamRunnable: true };
+  }
+  if (bindingConnector && sharedConnectors.has(bindingConnector)) {
+    return { owner: bindingConnector, via: "binding", teamRunnable: true };
+  }
+  if (sharedConnectors.size === 1) {
+    return { owner: [...sharedConnectors][0]!, via: "single_sharer", teamRunnable: true };
+  }
+  // size 0 (unshared) OR size >= 2 with no valid binding/grant (ambiguous) →
+  // creator pin. Safe + deterministic; non-creator is blocked by the gate.
+  return { owner: creatorUserId, via: "creator", teamRunnable: false };
+}

--- a/core/integrations/sharingEligibility.ts
+++ b/core/integrations/sharingEligibility.ts
@@ -1,0 +1,159 @@
+import type { WorkflowDefinition } from "@/contracts/workflowDefinition";
+import {
+  isPrivateCredentialProvider,
+  workflowUsesPrivateCredential,
+  viewerMayRunEdit,
+} from "./workflowCredentialScope";
+
+/**
+ * Ambiguity-aware run/edit eligibility computation (Slice 4.CONN-SHARE / CS-3a).
+ *
+ * Pure, I/O-free. Decides whether a workflow's PRIVATE-credential requirements
+ * are satisfied by CURRENTLY shared connections — WITHOUT ever resolving which
+ * specific connector would execute (that node-level binding is CS-4).
+ *
+ * The CS-4 audit established that provider-level "Gmail is shared" is NOT enough:
+ * when 2+ members share the same personal provider, a non-creator run would
+ * silently resolve to an arbitrary connector. So this computation FAILS CLOSED on
+ * ambiguity — `single_shared_connector` is the only sharing state that makes a
+ * private provider team-runnable; `unshared` and `ambiguous_shared_connectors`
+ * both block a non-creator.
+ *
+ * BEHAVIOR-INERT: nothing wires this into the live run/edit gate
+ * (`app/api/workflows/_shared.ts`) in CS-3a. While `ENABLE_CONNECTION_SHARING` is
+ * OFF the workflow-level result is byte-identical to WF-RUNPERM's `viewerMayRunEdit`
+ * (it delegates to it). CS-3b will wire it behind the flag.
+ *
+ * No-leak: the result carries provider slugs + status ENUMS only — never a
+ * connector id, count, provider_account_id, email, token, scope, or metadata.
+ */
+
+export type ProviderSharingStatus =
+  | "not_private"
+  | "unshared"
+  | "single_shared_connector"
+  | "ambiguous_shared_connectors";
+
+/**
+ * Per-provider sharing status from a distinct-shared-connector COUNT.
+ *   - non-private (account/service or native) → `not_private`
+ *   - private + 0 shared connectors           → `unshared`
+ *   - private + exactly 1 shared connector     → `single_shared_connector`
+ *   - private + 2+ shared connectors           → `ambiguous_shared_connectors`
+ *
+ * Unknown providers classify `personal` (fail-safe via `isPrivateCredentialProvider`),
+ * so an unrecognized provider with no shared row is `unshared` ⇒ blocks a
+ * non-creator. Native pseudo-providers are `not_private`.
+ */
+export function computeProviderSharingStatus(
+  provider: string,
+  sharedConnectorCount: number,
+): ProviderSharingStatus {
+  if (!isPrivateCredentialProvider(provider)) return "not_private";
+  if (sharedConnectorCount <= 0) return "unshared";
+  if (sharedConnectorCount === 1) return "single_shared_connector";
+  return "ambiguous_shared_connectors";
+}
+
+/** Distinct PRIVATE-credential providers used by a workflow's nodes. */
+export function distinctPrivateProviders(definition: WorkflowDefinition): string[] {
+  if (!definition || !Array.isArray(definition.nodes)) return [];
+  const set = new Set<string>();
+  for (const node of definition.nodes) {
+    const provider = node?.provider;
+    if (provider && isPrivateCredentialProvider(provider)) set.add(provider);
+  }
+  return [...set];
+}
+
+export type RunEditEligibilityReason =
+  | "flag_off_legacy"
+  | "creator"
+  | "no_private_credentials"
+  | "all_providers_single_shared"
+  | "blocked_unshared"
+  | "blocked_ambiguous"
+  | "blocked_malformed";
+
+/** Safe per-private-provider status view (slug + enum only — no ids/counts). */
+export interface ProviderSharingStatusView {
+  readonly provider: string;
+  readonly status: ProviderSharingStatus;
+}
+
+export interface RunEditEligibilityResult {
+  readonly allowed: boolean;
+  readonly reason: RunEditEligibilityReason;
+  readonly providerStatuses: readonly ProviderSharingStatusView[];
+}
+
+export interface RunEditEligibilityInput {
+  readonly definition: WorkflowDefinition;
+  readonly createdByUserId: string | null;
+  readonly callerUserId: string;
+  /**
+   * Distinct shared-connector user COUNT per provider. Only private providers
+   * matter; a missing entry reads as 0 (unshared). The caller derives this from
+   * `listSharedConnectorUserIdsServiceRole(...).size` — ids never reach here.
+   */
+  readonly sharedConnectorCountByProvider: ReadonlyMap<string, number>;
+  readonly flagEnabled: boolean;
+}
+
+/**
+ * Workflow-level run/edit eligibility. See the module doc for the model.
+ *
+ * Precedence when blocking a non-creator: `ambiguous` is reported before
+ * `unshared` (both block; ambiguity is the more specific "needs CS-4 binding"
+ * signal). Fails closed on a malformed definition.
+ */
+export function computeRunEditEligibility(
+  input: RunEditEligibilityInput,
+): RunEditEligibilityResult {
+  const { definition, createdByUserId, callerUserId, sharedConnectorCountByProvider, flagEnabled } =
+    input;
+
+  // Fail closed on a malformed definition — never green-light an unparseable
+  // workflow. (The engine validates upstream; this is defense in depth.)
+  if (!definition || !Array.isArray(definition.nodes)) {
+    return { allowed: false, reason: "blocked_malformed", providerStatuses: [] };
+  }
+
+  // Flag OFF → preserve WF-RUNPERM EXACTLY by delegating to the canonical predicate.
+  if (!flagEnabled) {
+    return {
+      allowed: viewerMayRunEdit({ createdByUserId, definition }, callerUserId),
+      reason: "flag_off_legacy",
+      providerStatuses: [],
+    };
+  }
+
+  // No private credentials → any member (membership-gated upstream).
+  if (!workflowUsesPrivateCredential(definition)) {
+    return { allowed: true, reason: "no_private_credentials", providerStatuses: [] };
+  }
+
+  // Creator always allowed (today's behavior).
+  if (createdByUserId !== null && createdByUserId === callerUserId) {
+    return { allowed: true, reason: "creator", providerStatuses: [] };
+  }
+
+  // Non-creator with private providers: eligible ONLY if EVERY distinct private
+  // provider has exactly one shared connector.
+  const providerStatuses: ProviderSharingStatusView[] = distinctPrivateProviders(definition).map(
+    (provider) => ({
+      provider,
+      status: computeProviderSharingStatus(provider, sharedConnectorCountByProvider.get(provider) ?? 0),
+    }),
+  );
+
+  if (providerStatuses.some((p) => p.status === "ambiguous_shared_connectors")) {
+    return { allowed: false, reason: "blocked_ambiguous", providerStatuses };
+  }
+  if (providerStatuses.some((p) => p.status === "unshared")) {
+    return { allowed: false, reason: "blocked_unshared", providerStatuses };
+  }
+  // Every private provider is single_shared_connector (the list is non-empty here
+  // because workflowUsesPrivateCredential was true).
+  return { allowed: true, reason: "all_providers_single_shared", providerStatuses };
+}

--- a/core/integrations/sharingScope.ts
+++ b/core/integrations/sharingScope.ts
@@ -1,0 +1,87 @@
+import {
+  isAccountCredentialProvider,
+  isPersonalCredentialProvider,
+} from "./credentialSharing";
+
+/**
+ * Explicit per-connection sharing scope (Slice 4.CONN-SHARE / CS-1).
+ *
+ * Pure, I/O-free. The data foundation for "a connector may make their PERSONAL
+ * connection team-usable" (plan:
+ * docs/slices/phase-4/explicit-private-connection-sharing-plan.md).
+ *
+ * BEHAVIOR-INERT in CS-1: nothing reads these helpers at runtime yet — the
+ * run/edit gate, execution resolver, Apps DTO/UI, Disconnect/Reconnect, and
+ * workflow_node_credentials are all untouched. CS-2+ wire them behind the
+ * ENABLE_CONNECTION_SHARING dev guard.
+ *
+ * Scope is meaningful ONLY for PERSONAL providers. Account/service providers
+ * (slack/notion/stripe/…) are shared by classification and IGNORE the column.
+ * Classification is the single source of truth (`./credentialSharing`); this
+ * module never re-declares a provider map.
+ */
+
+export type IntegrationSharingScope = "private_to_connector" | "shared_with_account";
+
+/**
+ * The two values the DB CHECK constraint permits. NULL is also valid at the DB
+ * layer — it is the unset / "derive default from classification" state, which
+ * `effectiveIntegrationSharingScope` resolves to `private_to_connector` for
+ * personal providers.
+ */
+export const INTEGRATION_SHARING_SCOPE_VALUES = [
+  "private_to_connector",
+  "shared_with_account",
+] as const;
+
+/**
+ * The EFFECTIVE sharing scope for a (provider, stored-column-value) pair.
+ *
+ * - Account/service provider → ALWAYS `shared_with_account` (shared by
+ *   classification; the column is ignored).
+ * - Personal provider:
+ *     - NULL / unset                  → `private_to_connector` (derived default)
+ *     - exactly "shared_with_account" → `shared_with_account`
+ *     - "private_to_connector"        → `private_to_connector`
+ *     - ANY other / unknown value     → `private_to_connector` (FAIL SAFE —
+ *       never widen access from unrecognized input; the DB CHECK should make an
+ *       out-of-set value unreachable, but the helper refuses to open up
+ *       regardless of what it is handed).
+ */
+export function effectiveIntegrationSharingScope(
+  provider: string,
+  rawColumnValue: string | null | undefined,
+): IntegrationSharingScope {
+  if (isAccountCredentialProvider(provider)) {
+    return "shared_with_account";
+  }
+  return rawColumnValue === "shared_with_account"
+    ? "shared_with_account"
+    : "private_to_connector";
+}
+
+/**
+ * Whether THIS feature can flip a provider's connection from private to shared.
+ * ONLY personal providers — account/service providers are already account-shared
+ * by classification, so there is nothing for explicit sharing to do. `false`
+ * means "not shareable THROUGH this feature", not "unusable".
+ */
+export function isProviderShareable(provider: string): boolean {
+  return isPersonalCredentialProvider(provider);
+}
+
+/** Minimal row shape the row-level shareability check needs (no token material). */
+export interface ShareableRowInput {
+  readonly provider: string;
+  /** Soft-disconnect marker; null = active. */
+  readonly disconnectedAt: string | null;
+}
+
+/**
+ * Whether a specific integration ROW may be shared: a personal-provider row that
+ * is still ACTIVE. A disconnected row carries no usable credential, so it is
+ * never shareable.
+ */
+export function isRowShareable(row: ShareableRowInput): boolean {
+  return isProviderShareable(row.provider) && row.disconnectedAt === null;
+}

--- a/docs/slices/phase-4/explicit-private-connection-sharing-closeout.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-closeout.md
@@ -1,0 +1,195 @@
+# 4.CONN-SHARE — Explicit Private-Connection Sharing — Verification Closeout
+
+**Type:** Verification + closeout (docs-only). No source/test/migration/UI changed in
+this slice. Nothing pushed. `db:push` NOT run.
+**Date:** 2026-06-12
+**Branch:** `builder-ui-v1-audit-1`
+**Plan:** [explicit-private-connection-sharing-plan.md](./explicit-private-connection-sharing-plan.md)
+(model locked §0; CS-4 audit §14; CS-4a design §15).
+
+---
+
+## 1. Executive summary — GO (flag-on recommended, after the two prerequisites)
+
+The explicit private-connection sharing feature (CS-1 → CS-5b) is **functionally
+complete behind `ENABLE_CONNECTION_SHARING` (default OFF)** and verified end-to-end. The
+implementation matches the locked model: connector-push sharing, ambiguity-aware
+fail-closed run/edit gate, node-level connector binding for the 2+-sharer case, a resolver
+that the gate and the executor **share** (cannot drift), and a no-leak surface throughout.
+
+All five static checks pass and the full unit suite is green except **one pre-existing,
+CONN-SHARE-unrelated** suite (`features/integrations/ConnectButton` — jsdom navigation,
+file untouched by the arc).
+
+**Recommendation: safe to enable `ENABLE_CONNECTION_SHARING`** once two deploy-time
+prerequisites are met (below). Do not flip the flag until Marcus approves and the
+prerequisites are confirmed.
+
+**Flag-on prerequisites (must hold in the target environment):**
+1. Both migrations are applied to the target DB:
+   `20260622000000_add_integration_sharing_scope.sql` (column + CHECK) and
+   `20260623000000_workflow_node_connector_bindings.sql` (table + RLS + GRANTs). *This
+   verification did NOT run `db:push`; application state was not checked against a live DB.*
+2. `ENABLE_OPENAI_*`/billing are irrelevant here — CONN-SHARE has **no** AI/MCP/billing
+   dependency. The only env input is the flag itself.
+
+---
+
+## 2. What shipped (commit chain, all local, in `a66d0d87e` ancestry)
+
+| Slice | Commit | Content |
+|---|---|---|
+| CS-1 | `7dd78d1a4` | `integration_sharing_scope` column + CHECK; `ENABLE_CONNECTION_SHARING` flag; pure `sharingScope` helpers (inert) |
+| CS-2 | `4b79788c4` | connector-push toggle service + route + repo writes (gated, no runtime wiring) |
+| CS-3a | `5479edb02` | ambiguity-aware eligibility computation + shared-connector query (inert, not wired) |
+| CS-4a | `d1613b250` | `workflow_node_connector_bindings` table + repo + binding service + routes (gated, inert) |
+| CS-4b + CS-3b | `3471e4461` | resolver precedence + ambiguity-aware run/edit gate wired in lockstep; offboarding binding cleanup |
+| CS-5a | `5e8bb0a28` | Apps sharing UI + accurate workflow DTO booleans (flag-gated) |
+| CS-5b | `b0056ce91` | builder node connector picker for ambiguous shared connections (flag-gated) |
+
+> **Worktree note (shared-tree hazard, per project memory).** During this verification the
+> branch HEAD advanced from `b0056ce91` → **`a66d0d87e`** (`fix(ai-diag): AI-DIAG-2-pre …`),
+> committed by a **parallel AI chat** sharing this worktree. `a66d0d87e` only re-attributes
+> the deterministic 0-credit diagnose telemetry to the workflow-owning account — it touches
+> **no CONN-SHARE code**. All CS files are byte-identical between `b0056ce91` and the verified
+> tree, so this report is unaffected. The parallel chat also has **in-progress, uncommitted
+> AI-DIAG-2a work** in the tree (`lib/api/ai.ts` + untracked `services/ai/diagnostics/explain*`,
+> `app/api/workflows/[id]/ai/diagnose/explain/`); that is NOT part of CONN-SHARE and was left
+> untouched.
+
+---
+
+## 3. Verification performed
+
+### 3.1 Static checks (all newly run this session — PASS)
+- `npm run typecheck` → **0 source errors** (a concurrent build polluted a first run with
+  spurious `.next/types/**` TS6053 noise; a clean re-run is 0 errors).
+- `npm run lint` → 0 errors (19 pre-existing warnings).
+- `npm run lint:structure` → OK.
+- `npm run lint:migrations` → OK (RLS + policy + explicit GRANTs present on the new table).
+- `npm run build` → Compiled successfully.
+
+### 3.2 Tests (newly run this session)
+- Targeted CONN-SHARE suites (12 files): **176/176 pass** — `sharingScope`,
+  `sharingEligibility`, `connectionSharing`, `connectionSharingEligibility`,
+  `connectionBinding`, `connectionBindingState`, `connectionResolution`,
+  `integrations-sharedConnectors`, `workflowNodeConnectorBindings` (repo + migration),
+  `integration-sharing.route`, `connector-binding.route`, `connection-runedit-gate`.
+- Related suites (Apps DTO/UI, `_shared` gate+DTO, builder, engine, leaveAccount,
+  membership, connectorBindings client lib): **103 suites / 1630 pass**.
+- **Full `jest`: 17,727 passed, 181 skipped, 2 failed** — the 2 failures are both in
+  `tests/unit/features/integrations/ConnectButton.test.tsx`.
+
+### 3.3 The single failing suite is pre-existing and unrelated
+`ConnectButton` fails on `mockStartOAuth` / `window.location.assign` not firing inside a
+`waitFor` — a **jsdom navigation** limitation. `ConnectButton.tsx` and its test were last
+touched at `358f7904a` (an APPS-RECONNECT commit **predating** the CS arc); **no CS commit
+touches `ConnectButton`, `startOAuth`, or any shared helper in its render path.** Classified
+as environmental / pre-existing, **not** a CONN-SHARE regression. *Honesty note:* I could
+not run the clean pre-CS isolation (the shared tree's uncommitted parallel work blocked a
+detached checkout), so this rests on code-level evidence, not a bisect.
+
+---
+
+## 4. Behavior verified (code-level audit, every claim tied to a read file)
+
+### 4.1 Flag-OFF regression (matches WF-RUNPERM exactly)
+- `setIntegrationSharingScope` returns `not_enabled` with **zero I/O** when OFF
+  ([connectionSharing.ts:81](../../../services/integrations/connectionSharing.ts)). Same for
+  every binding service entry ([connectionBinding.ts](../../../services/integrations/connectionBinding.ts)).
+- Apps DTO `computeSharingFields` returns `not_applicable` / all-false when OFF, so
+  `canShare`/`canUnshare`/badge controls never render
+  ([app/apps/_shared.ts:88](../../../app/apps/_shared.ts)); AppCard gates on those booleans.
+- Run/edit gate + DTO hint: `computeViewerCanRunEdit` flag-OFF branch delegates to the exact
+  WF-RUNPERM `viewerMayRunEdit` with **no DB read**
+  ([app/api/workflows/_shared.ts:280](../../../app/api/workflows/_shared.ts)).
+- Engine builds **no** credential plan when OFF (`sharingOn ? buildWorkflowCredentialPlan : …`),
+  preserving the pre-CS `effectiveCredentialOwner` path
+  ([engine.ts:403](../../../services/execution/engine.ts)).
+- Binding/sharing routes 404 (`workflowNotFoundResponse` / `CONNECTION_SHARING_NOT_ENABLED`)
+  when OFF — flag state is not an existence oracle.
+
+### 4.2 Flag-ON behavior (locked model)
+- **Share = connector only**; owner/admin cannot silently share a member's identity
+  (`isConnector` required for `shared_with_account`)
+  ([connectionSharing.ts:115](../../../services/integrations/connectionSharing.ts)).
+- **Unshare = connector OR owner/admin**, with a **distinct audit event**
+  (`admin_unshared` carries `actorRole`, not user/connector id) for the admin-safety path
+  ([connectionSharing.ts:138](../../../services/integrations/connectionSharing.ts)).
+- **Account/service providers** → `account_provider_not_shareable`; **disconnected rows** →
+  collapsed to `not_found` and never mutated (write guards `disconnected_at IS NULL`).
+- **Resolver precedence** (`resolveNodeOwner`): accepted grant → **valid** binding (bound
+  connector still in the live shared set) → single-sharer → **creator fallback / fail-closed**
+  for unshared or ambiguous-no-binding
+  ([sharingEligibility.ts:198](../../../core/integrations/sharingEligibility.ts)). Never picks
+  an arbitrary/earliest co-member row (closes the §14.3 silent-wrong-identity risk).
+- **Ambiguity-aware gate**: a non-creator is team-runnable only when **every** personal node
+  resolves to a specific shared connector (`allTeamRunnable`); the gate consumes the **same**
+  `buildWorkflowCredentialPlan` the executor resolves owners from — they cannot drift
+  ([connectionResolution.ts](../../../services/integrations/connectionResolution.ts) +
+  [engine.ts:562](../../../services/execution/engine.ts)).
+- **Multi-sharer + binding** allows run/edit and executes as the **bound** connector;
+  **single-sharer fallback** auto-resolves; **multi-sharer without binding blocks**
+  (`needs_selection` / fail-closed).
+- **Binding authz is structural no-silent-share**: a binding can only point to a connector
+  already in `listSharedConnectorUserIdsServiceRole` → unshared identities are unbindable
+  (`connector_not_shared`) ([connectionBinding.ts:170](../../../services/integrations/connectionBinding.ts)).
+- **Lifecycle / invalidation**: unshare/disconnect/leave drop the connector from the live
+  shared set → binding becomes invalid at resolve time (fail-closed, never silent-switch).
+  Offboarding additionally **hard-deletes** bindings on member-leave and member-remove
+  ([leaveAccount.ts:72](../../../services/accounts/leaveAccount.ts),
+  [membership.ts:122](../../../services/accounts/membership.ts)).
+
+### 4.3 No-leak audit (all surfaces)
+- **Apps DTO** ([contracts/apps.ts](../../../contracts/apps.ts)): only `sharingStatus` enum +
+  `sharedWithAccount`/`canShare`/`canUnshare` booleans + opaque row id + display name. Raw
+  `integration_sharing_scope` and `connected_by_user_id` are server-only, never emitted.
+- **Workflow DTO**: exposes only `usesPrivateCredential` + `viewerCanRunEdit` booleans; the
+  internal owner-by-node map is never serialized.
+- **Binding routes + picker**: options are the existing safe `{ userId, displayName, role }`
+  shape (display name via the member-identity RPC) — never email / `provider_account_id` /
+  token / scope / account metadata.
+- **Errors/banners**: all typed codes; `not_enabled`/`not_found`/cross-account/non-member/
+  disconnected collapse uniformly (no existence/ownership/state oracle).
+- **Audit payloads**: `account.integration.sharing.{shared,unshared,admin_unshared}` and the
+  offboarding `*connector_bindings_deleted` events carry ids + provider slug (+ `actorRole`)
+  only — no user/connector id, token, label, or raw error.
+- **Bounded reads**: `listSharedConnectorUserIdsServiceRole` selects only
+  `connected_by_user_id`, filtered `(account, provider, shared, active)`. No token/scope read
+  on any CONN-SHARE path.
+
+### 4.4 Performance / DB sanity
+- **Workflow list DTO is intentionally conservative**: `toWorkflowListItem` keeps the sync
+  `viewerMayRunEdit` (creator-only) even with the flag ON — it never over-permits; a
+  non-creator who *can* run a shared workflow sees the conservative chip until they open the
+  detail (which is accurate). Per-row `buildWorkflowCredentialPlan` is deliberately avoided
+  on the N-row list ([app/api/workflows/_shared.ts:315](../../../app/api/workflows/_shared.ts)).
+- **Detail/run/edit reads are bounded**: `buildWorkflowCredentialPlan` runs at most one
+  accepted-owners read + one bindings read + one shared-set read **per distinct provider**
+  (via `Promise.all`), short-circuiting on creator / no-private with **no DB read**.
+- **Flag-OFF avoids all sharing reads** (engine, gate, DTO, Apps) by design.
+
+---
+
+## 5. Known limitations / follow-ups (non-blocking)
+
+- **List-row resolvability batching** (CS-5b follow-up): the list chip is conservative by
+  design; a batched resolvability pass would let non-creator-runnable shared workflows show an
+  enabled chip without opening detail. Safe to defer — the gate is the real enforcement.
+- **Migration application is a deploy prerequisite**, not verified here (no `db:push`).
+- **OQ-4a residuals** (plan §15.11): stale-binding rows are left inert (resolve-time recheck
+  makes them harmless); multi-node same-provider different-connector is permitted and covered
+  by engine parity tests.
+- **ConnectButton jsdom failure** is pre-existing and worth a separate fix (mock
+  `window.location` / navigation), independent of this arc.
+
+---
+
+## 6. Result
+
+- **Verification:** PASS (static checks + 17,727 unit tests; the only failures are a
+  pre-existing, CONN-SHARE-unrelated jsdom suite).
+- **Bugs found/fixed:** none in CONN-SHARE.
+- **Flag-on:** **recommended**, gated on (1) both migrations applied to the target DB and
+  (2) Marcus's approval. Flag remains **OFF** in code; not flipped.
+- **No push / no deploy / no `db:push`. No AI/MCP/billing code changed by this verification.**

--- a/docs/slices/phase-4/explicit-private-connection-sharing-closeout.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-closeout.md
@@ -1,29 +1,32 @@
 # 4.CONN-SHARE — Explicit Private-Connection Sharing — Verification Closeout
 
-**Type:** Verification + closeout (docs-only). No source/test/migration/UI changed in
-this slice. Nothing pushed. `db:push` NOT run.
-**Date:** 2026-06-12
+**Type:** Verification + closeout (docs-only). Nothing pushed. `db:push` NOT run.
+**Date:** 2026-06-12 (flag-on landed 2026-06-12 — see §7)
 **Branch:** `builder-ui-v1-audit-1`
 **Plan:** [explicit-private-connection-sharing-plan.md](./explicit-private-connection-sharing-plan.md)
 (model locked §0; CS-4 audit §14; CS-4a design §15).
 
+> **STATUS: FLAG-ON — `ENABLE_CONNECTION_SHARING` enabled (local runtime via `.env.local`).**
+> Migrations confirmed applied; full check set re-run green with the flag live. Code stays
+> opt-in (`=== "true"`); production go-live = set the same env var at deploy. See §7. **Not
+> pushed/deployed — awaiting Marcus's deploy approval.**
+
 ---
 
-## 1. Executive summary — GO (flag-on recommended, after the two prerequisites)
+## 1. Executive summary — GO (flag enabled; ready for deploy pending approval)
 
-The explicit private-connection sharing feature (CS-1 → CS-5b) is **functionally
-complete behind `ENABLE_CONNECTION_SHARING` (default OFF)** and verified end-to-end. The
-implementation matches the locked model: connector-push sharing, ambiguity-aware
-fail-closed run/edit gate, node-level connector binding for the 2+-sharer case, a resolver
-that the gate and the executor **share** (cannot drift), and a no-leak surface throughout.
+The explicit private-connection sharing feature (CS-1 → CS-5b) is **complete and now
+ENABLED** via `ENABLE_CONNECTION_SHARING` (env-var convention). The implementation matches
+the locked model: connector-push sharing, ambiguity-aware fail-closed run/edit gate,
+node-level connector binding for the 2+-sharer case, a resolver that the gate and the
+executor **share** (cannot drift), and a no-leak surface throughout.
 
-All five static checks pass and the full unit suite is green except **one pre-existing,
-CONN-SHARE-unrelated** suite (`features/integrations/ConnectButton` — jsdom navigation,
-file untouched by the arc).
+All five static checks pass and the **full unit suite is fully green** (17,766 passed / 0
+failed). The earlier `features/integrations/ConnectButton` failures were **stale test
+assertions** (not jsdom, not CONN-SHARE) and are fixed (`d4a349c36`).
 
-**Recommendation: safe to enable `ENABLE_CONNECTION_SHARING`** once two deploy-time
-prerequisites are met (below). Do not flip the flag until Marcus approves and the
-prerequisites are confirmed.
+**Recommendation: ready to deploy with the feature live.** Set `ENABLE_CONNECTION_SHARING=true`
+in the production environment at deploy. Kill-switch: remove the var / set `=false`.
 
 **Flag-on prerequisites (must hold in the target environment):**
 1. Both migrations are applied to the target DB:
@@ -176,20 +179,66 @@ detached checkout), so this rests on code-level evidence, not a bisect.
 - **List-row resolvability batching** (CS-5b follow-up): the list chip is conservative by
   design; a batched resolvability pass would let non-creator-runnable shared workflows show an
   enabled chip without opening detail. Safe to defer — the gate is the real enforcement.
-- **Migration application is a deploy prerequisite**, not verified here (no `db:push`).
+- **Migrations applied** to the V2 dev DB — confirmed 2026-06-12 (see §7.2). Production
+  go-live still requires the same two migrations applied to the prod DB.
 - **OQ-4a residuals** (plan §15.11): stale-binding rows are left inert (resolve-time recheck
   makes them harmless); multi-node same-provider different-connector is permitted and covered
   by engine parity tests.
-- **ConnectButton jsdom failure** is pre-existing and worth a separate fix (mock
-  `window.location` / navigation), independent of this arc.
+- **List-row resolvability batching** (CS-5b follow-up) remains the one deferred polish; the
+  run/edit gate is the real enforcement, so the conservative list chip never over-permits.
 
 ---
 
 ## 6. Result
 
-- **Verification:** PASS (static checks + 17,727 unit tests; the only failures are a
-  pre-existing, CONN-SHARE-unrelated jsdom suite).
-- **Bugs found/fixed:** none in CONN-SHARE.
-- **Flag-on:** **recommended**, gated on (1) both migrations applied to the target DB and
-  (2) Marcus's approval. Flag remains **OFF** in code; not flipped.
-- **No push / no deploy / no `db:push`. No AI/MCP/billing code changed by this verification.**
+- **Verification:** PASS (all static checks + 17,766 unit tests green; 0 failures).
+- **Bugs found/fixed:** none in CONN-SHARE. The unrelated `ConnectButton` failures were stale
+  test assertions (APPS-RECONNECT added a second `startOAuth` arg) — fixed in `d4a349c36`.
+- **Flag-on:** **DONE** — `ENABLE_CONNECTION_SHARING` enabled via `.env.local` (env-var
+  convention); code stays opt-in; full check set re-run green with the flag live (§7).
+- **No push / no deploy / no `db:push`. No AI/MCP/billing/AI-DIAG code changed.**
+
+---
+
+## 7. Flag-on (go-live) — 2026-06-12
+
+### 7.1 Exact flag change
+- **Mechanism: env-var enablement** (the dominant convention for these rollout guards —
+  `ENABLE_NODE_CREDENTIAL_REASSIGNMENT`, `ENABLE_ACCOUNT_PURGE_CRON`, etc., all
+  `process.env[FLAG] === "true"`). Chosen over a code-default opt-out because the CONN-SHARE
+  suite encodes **"env unset = OFF / WF-RUNPERM"** as its baseline; an opt-out flip would have
+  required rewriting those OFF-path tests. Code stays **unchanged** (`isConnectionSharingEnabled`
+  remains `=== "true"`), so the per-test flag contract holds and the suite stays green.
+- **Local runtime:** added to **`.env.local`** (gitignored — not committed):
+  ```
+  ENABLE_CONNECTION_SHARING=true
+  ```
+- **Kill-switch:** remove that line (or set `=false`) → every path reverts to WF-RUNPERM
+  creator-only behavior (the flag is read at call time, so no redeploy needed to flip).
+- **Jest is unaffected** by `.env.local` — Jest does not load dotenv (verified: no `dotenv`
+  in `jest.config.mjs` / `jest.setup.ts`), and each suite sets the flag per-test.
+
+### 7.2 Migrations (confirmed applied on the V2 dev DB)
+Queried `supabase_migrations.schema_migrations` (Session pooler `aws-1-us-east-1.pooler…`):
+- `20260622000000_add_integration_sharing_scope.sql` → **APPLIED** (column + CHECK present).
+- `20260623000000_workflow_node_connector_bindings.sql` → **APPLIED** (table + RLS policy present).
+
+### 7.3 Checks re-run with the flag live (HEAD at run time `8e090b2f6`)
+| Check | Result |
+|---|---|
+| Targeted: CONN-SHARE + Apps sharing + builder picker + run/edit route + engine cred-resolution + offboarding (19 suites) | ✅ 380/380 |
+| `typecheck` | ✅ 0 source errors |
+| `lint` | ✅ 0 errors (21 warnings, pre-existing/AI-DIAG) |
+| `lint:structure` | ✅ OK |
+| `lint:migrations` | ✅ OK |
+| `build` | ✅ Compiled successfully, 75/75 static pages |
+| full `jest` | ✅ 17,766 passed / 181 skipped / 0 failed |
+
+### 7.4 Push / deploy recommendation
+- **Ready to deploy with the feature live.** At deploy, set
+  `ENABLE_CONNECTION_SHARING=true` in the **production** environment (host/Vercel env), and
+  confirm both migrations §7.2 are applied to the **prod** DB before/with the deploy.
+- **Not pushed/deployed** — awaiting Marcus's explicit approval (standing push/deploy policy).
+- Post-deploy smoke: share a personal connection from Apps; confirm a non-creator teammate can
+  run a single-sharer shared workflow; confirm a 2+-sharer workflow blocks until a connector is
+  bound; confirm unshare reverts to creator-only. Kill-switch (`=false`) reverts instantly.

--- a/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
@@ -26,6 +26,48 @@ deferring a row-level approach) · [workflow-run-edit-permission-closeout.md](./
 
 ---
 
+## 0. Decision status — LOCKED (2026-06-12, Marcus)
+
+**The model is decided. This remains design-only — do NOT start an implementation slice until
+Marcus explicitly says so.** Marcus confirmed **Option A (row-level connector-push)** and resolved
+every open question. The locked model:
+
+1. **Account ownership unchanged.** `integrations.account_id` owns the row; `connected_by_user_id`
+   stays provenance/audit/display. The row still belongs to the team account.
+2. **Sharing controls usage, not ownership.** `private_to_connector` = only the connector/creator
+   can run/edit private-credential workflows; `shared_with_account` = members with workflow
+   permissions can run/edit workflows using that connection. Account/shared-service providers remain
+   shared by classification and **ignore** this field.
+3. **Row-level, not per-node.** This is per **integration row**, not per workflow node. The existing
+   per-node reassignment/grant system (`workflow_node_credentials`, flag-gated) stays **separate** and
+   remains a future/advanced path. **Do not merge the two concepts.** (Resolves OQ-1 = A; OQ-5 = keep B
+   separate.)
+4. **Who can share: connector only.** Owner/admin may **not** silently share another member's
+   personal external identity. Owner/admin may still manage/audit/disable/delete/disconnect per
+   existing admin rules. (Resolves OQ-2 = connector-only; no silent admin share. The optional
+   "admin-request" flow from the old OQ-2 is **not** adopted.)
+5. **Who can unshare:** connector can unshare. Owner/admin **may** perform a safety/admin removal —
+   but if implemented it must be **framed as an admin safety action and audit-logged**, and must never
+   silently toggle a member's private identity *into* shared.
+6. **Unshare behavior:** do **not** auto-disable workflows. Revert affected workflows to **creator-only
+   run/edit**. Non-creators who could previously run now get the **existing private-credential blocked
+   state + Duplicate CTA**. No silent auto-resume or hidden permission continuation. (Resolves OQ-4.)
+7. **Execution behavior:** a shared personal connection still executes as the **connector's** external
+   OAuth identity (never the runner's/author's). The UI must make this explicit **before** sharing:
+   *"Team members will be able to run workflows using this connection."* (Resolves OQ-3 direction.)
+8. **Data model:** add nullable `integration_sharing_scope` on `integrations` when implementing.
+   Values `private_to_connector | shared_with_account`. `NULL` derives the default from provider
+   credential classification (personal → `private_to_connector`; account → shared by classification).
+   **No backfill.** Add a **CHECK** constraint. **No RLS model change.**
+9. **Feature-flag posture:** this is **not** a permanent hidden feature. A temporary implementation
+   guard during development is fine, but the goal is to **build, verify, and make it live once
+   complete** — not ship it dark indefinitely.
+
+Sections 4–10 below are the design rationale that produced this model; where they describe an option
+as "recommended" or "open," treat §0 as authoritative.
+
+---
+
 ## 1. Context
 
 WF-RUNPERM made "team-visible ≠ team-runnable" real: a workflow with ≥1 private/member-connected
@@ -128,8 +170,10 @@ Three touch-points, each extending an existing seam (no new subsystem):
    `sharedWithAccount` (no identity); the workflow run/edit DTO booleans already exist and just need
    the shared-set folded into their computation.
 
-Ships behind `ENABLE_CONNECTION_SHARING` (default OFF). While off, the column is inert and every
-path behaves exactly as WF-RUNPERM ships today.
+May ship behind a temporary `ENABLE_CONNECTION_SHARING` dev guard so partial slices stay inert
+while in flight (while off, the column is inert and every path behaves exactly as WF-RUNPERM ships
+today) — **but per §0.9 this is not a permanently-hidden feature**; the guard exists to land the work
+safely, and is flipped on (or removed) once the arc is complete and verified.
 
 ---
 
@@ -177,16 +221,18 @@ not applicable (always shared). So the column is **only writable/meaningful for 
   resolve to it server-side (the 22D-2 redaction / `toOwnerControlledView` posture is untouched).
 - The unshare/disconnect error surfaces are typed + generic (no identity).
 
-**Authorization (CS-2):**
-- **Connector** (`connected_by_user_id === caller`) may share / unshare **their own** personal
-  connection. ✅
-- **Owner/admin** may **NOT silently share** a member's personal external identity (Option D
-  rejected — impersonation risk). They may *request* a share (reuse the consent-request notion) or
-  manage account-class shared service integrations (already account-shared, no change). **Default:
-  connector-only for the share toggle.** (OQ-2: optional admin-request flow.)
-- **Normal member** cannot share another member's connection. ✅
-- **Unshare:** connector or owner/admin (owner/admin CAN unshare — that's a restriction, not
-  impersonation). ✅
+**Authorization (CS-2) — per §0.4/§0.5 + §10 (DECIDED 2026-06-12):**
+- **Share — connector only.** The **connector** (`connected_by_user_id === caller`) may share **their
+  own** personal connection. ✅
+- **Owner/admin may NOT silently share** a member's personal external identity (Option D rejected —
+  impersonation risk). The optional admin-*request* flow is **not** adopted. Owner/admin retain
+  manage/audit/disable/delete/disconnect on the row per existing admin rules — but **never** a silent
+  share or any toggle of a member's identity *into* shared. ✅
+- **Normal member** cannot **share or unshare** another member's connection. ✅
+- **Unshare:** the **connector** may unshare their own personal connection. **Owner/admin** may
+  perform an unshare **only as a framed admin safety/removal action, and it must be audit-logged**.
+  Owner/admin unshare is a restriction/removal action — **never** permission to share or to silently
+  toggle a member's identity into shared. ✅
 
 ---
 
@@ -255,25 +301,30 @@ not applicable (always shared). So the column is **only writable/meaningful for 
 
 ---
 
-## 10. Risks / open decisions (each with a recommendation)
+## 10. Decisions (was: open questions) — RESOLVED 2026-06-12
 
-- **OQ-1 — Row-level (A) vs reuse per-node (B).** *Recommendation:* **A** for the connector-push
-  "share my connection" product; keep **B** flag-gated for targeted per-node reassignment. They are
-  different shapes; don't force one to do the other. **Marcus's to confirm** (it partially revisits the
-  2026-06-05 Option-B-only decision).
-- **OQ-2 — Owner/admin share of a member's personal connection.** *Recommendation:* **not silently**
-  (impersonation). Allow owner/admin to *request* via the existing consent notion if demand appears;
-  default connector-only.
-- **OQ-3 — Non-creator author of a workflow on a shared connection.** Execution must resolve to the
-  **connector**, not the author. *Recommendation:* resolve shared personal providers to the row's
-  `connected_by_user_id`; if multiple members share the same provider, the workflow must bind a
-  specific connector (reuse the node-owner override) — mark **unverified** until CS-4 design.
-- **OQ-4 — Unshare effect on dependent workflows.** *Recommendation:* **revert to creator-only**, do
-  not auto-disable (least destructive; matches WF-RUNPERM). Surface a one-time notice to affected
-  workflow owners.
-- **OQ-5 — Interaction with the shipped per-node system.** Both can set an effective owner.
-  *Recommendation:* precedence = an explicit **accepted node-credential grant** (B) wins over the
-  coarse **connection share** (A) for that node; document it; cover with a precedence test.
+All five are now **decided** per §0. Retained here with the resolution + any residual implementation
+nuance to verify during the slice.
+
+- **OQ-1 — Row-level (A) vs reuse per-node (B).** **DECIDED: A** (row-level connector-push). **B stays
+  separate** and flag-gated for targeted per-node reassignment — the two concepts are **not** merged.
+- **OQ-2 — Owner/admin share of a member's personal connection.** **DECIDED: connector-only for share;
+  no silent admin share** (impersonation). The optional admin-*request* flow is **not** adopted.
+  Owner/admin retain manage/audit/disable/delete/disconnect per existing admin rules.
+- **OQ-3 — Non-creator author of a workflow on a shared connection.** **DECIDED: execution resolves to
+  the connector**, never the author/runner. *Residual to verify in CS-4:* if multiple members share the
+  same provider on one account, the workflow must bind a **specific** connector (reuse the node-owner
+  override) — **unverified until CS-4 design.**
+- **OQ-4 — Unshare effect on dependent workflows.** **DECIDED: revert to creator-only; do NOT
+  auto-disable.** Non-creators fall back to the existing private-credential blocked state + Duplicate
+  CTA. No silent auto-resume. Surface a one-time notice to affected workflow owners.
+- **OQ-5 — Interaction with the shipped per-node system.** **DECIDED: keep separate.** *Residual to
+  verify in CS-4:* when both could set an effective owner for a node, an explicit **accepted
+  node-credential grant** (B) wins over the coarse **connection share** (A); document + cover with a
+  precedence test.
+- **Unshare authz nuance (new, from §0.5):** if owner/admin unshare is implemented, it must be a
+  framed **admin safety action** and **audit-logged** — never a silent re-toggle of a member's
+  identity into shared.
 
 ---
 
@@ -302,16 +353,16 @@ Reconnect, and AI/MCP code are all untouched. The model, schema, authz, and slic
 
 ## 13. Recommended next step
 
-Get Marcus's call on **OQ-1** (row-level A as the connector-push model, with per-node B kept separate).
-On confirmation, pick up **CS-1** — the additive nullable `integration_sharing_scope` column + the
-`ENABLE_CONNECTION_SHARING` flag + the pure scope helpers (tested in isolation), `db:push` only with
-explicit approval. Do not start CS-3/CS-4 (gate + execution) until CS-1/CS-2 land and the model is
-confirmed.
+**Model is locked (§0); implementation is NOT authorized yet.** When Marcus explicitly says to start
+the slice, pick up **CS-1** — the additive nullable `integration_sharing_scope` column (+CHECK) + the
+temporary `ENABLE_CONNECTION_SHARING` guard + the pure scope helpers (tested in isolation), `db:push`
+only with explicit approval. Do not start CS-3/CS-4 (gate + execution) until CS-1/CS-2 land. No push,
+no migration, no `db:push`, no AI/MCP changes, no Disconnect changes until then.
 
 ## Build now or defer?
 
-**Design now (this doc); build deferred.** The feature needs a migration + changes to the run/edit
-gate and the execution resolver (both sensitive, both shipped), so it should not be built until Marcus
-confirms the model (OQ-1) and approves the migration. The smallest first step (CS-1) is a single
-additive nullable column behind a default-OFF flag — low risk, reversible — but still gated on explicit
-approval per the standing push/migrate policy.
+**Decision locked now (§0); build deferred until Marcus says go.** The feature needs a migration +
+changes to the run/edit gate and the execution resolver (both sensitive, both shipped). The model is
+no longer in question — only the go-ahead to implement is pending. The smallest first step (CS-1) is a
+single additive nullable column behind a temporary guard — low risk, reversible — but still gated on
+explicit start + migration approval per the standing push/migrate policy.

--- a/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
@@ -165,7 +165,9 @@ Three touch-points, each extending an existing seam (no new subsystem):
 2. **Execution resolution.** For a shared personal provider, the engine resolves
    `connected_by_user_id = <the connector who shared>` instead of the creator-pin. Cleanest reuse:
    the resolver already supports an explicit owner override (the 22B context + the node-credential
-   override path) — sharing supplies that owner from the shared row.
+   override path) — sharing supplies that owner from the shared row. **Refined by the §14 audit:** when
+   **2+** members share the same provider this must resolve to a **node-bound specific connector**, never
+   by `(account, provider)` alone (which would silently pick the earliest-connected row) — see §14.3–14.5.
 3. **Apps surface + workflow badge.** Connector toggles share/unshare; DTO exposes a boolean
    `sharedWithAccount` (no identity); the workflow run/edit DTO booleans already exist and just need
    the shared-set folded into their computation.
@@ -292,9 +294,13 @@ not applicable (always shared). So the column is **only writable/meaningful for 
    typed errors; no-leak. Mirrors the disconnect service/route.
 3. **CS-3 (run/edit gate).** Thread the account's shared-provider set into `viewerMayRunEdit` /
    `assertWorkflowRunEditAllowed` + the DTO booleans. Behind the flag.
-4. **CS-4 (execution resolution).** Resolve shared personal providers to the connector via the
-   existing owner-override seam. Behind the flag. Heaviest correctness surface → its own slice + parity
-   tests.
+4. **CS-4 (execution resolution).** Resolve shared personal providers to a **specific connector user
+   id** via the existing `effectiveCredentialOwner` → context → pin seam — **never by `(account,
+   provider)` alone** (§14.3 silent-wrong-identity risk). Per the §14 audit this **splits**:
+   **CS-4a** = node-level connector binding (storage + safe `{userId, displayName, role}` builder picker
+   DTO) for the 2+-sharer case; **CS-4b** = resolver precedence (accepted grant → node binding →
+   single-sharer → creator) + the **ambiguity-aware gate** + parity tests. Behind the flag. Heaviest
+   correctness surface.
 5. **CS-5 (Apps UI + workflow badge).** Share/Stop-sharing per-row action, badges, confirmation copy.
 6. **CS-6 (disconnect/offboarding interaction).** Unshare-on-disconnect; connector-offboard reverts
    dependent workflows to creator-only.
@@ -312,16 +318,18 @@ nuance to verify during the slice.
   no silent admin share** (impersonation). The optional admin-*request* flow is **not** adopted.
   Owner/admin retain manage/audit/disable/delete/disconnect per existing admin rules.
 - **OQ-3 — Non-creator author of a workflow on a shared connection.** **DECIDED: execution resolves to
-  the connector**, never the author/runner. *Residual to verify in CS-4:* if multiple members share the
-  same provider on one account, the workflow must bind a **specific** connector (reuse the node-owner
-  override) — **unverified until CS-4 design.**
+  the connector**, never the author/runner. *Residual now RESOLVED by the §14 audit:* if multiple members
+  share the same provider, the node must bind a **specific connector user id** (new CS-4 binding), and an
+  unbound 2+-sharer case **fails closed** to creator-only — never an arbitrary/earliest-row pick. See
+  §14.3–14.5.
 - **OQ-4 — Unshare effect on dependent workflows.** **DECIDED: revert to creator-only; do NOT
   auto-disable.** Non-creators fall back to the existing private-credential blocked state + Duplicate
   CTA. No silent auto-resume. Surface a one-time notice to affected workflow owners.
-- **OQ-5 — Interaction with the shipped per-node system.** **DECIDED: keep separate.** *Residual to
-  verify in CS-4:* when both could set an effective owner for a node, an explicit **accepted
-  node-credential grant** (B) wins over the coarse **connection share** (A); document + cover with a
-  precedence test.
+- **OQ-5 — Interaction with the shipped per-node system.** **DECIDED: keep separate.** *Residual now
+  RESOLVED by the §14 audit:* precedence is **accepted node-credential grant (B) → node connector
+  binding (A) → single-sharer → creator**, implemented by extending the existing
+  `effectiveCredentialOwner` seam (no new precedence machine). See §14.4 + §14.5; cover with a
+  precedence test in CS-4b.
 - **Unshare authz nuance (new, from §0.5):** if owner/admin unshare is implemented, it must be a
   framed **admin safety action** and **audit-logged** — never a silent re-toggle of a member's
   identity into shared.
@@ -366,3 +374,139 @@ changes to the run/edit gate and the execution resolver (both sensitive, both sh
 no longer in question — only the go-ahead to implement is pending. The smallest first step (CS-1) is a
 single additive nullable column behind a temporary guard — low risk, reversible — but still gated on
 explicit start + migration approval per the standing push/migrate policy.
+
+---
+
+## 14. CS-4 pre-implementation audit — shared-connection execution binding (2026-06-12)
+
+**Audit only. No source/test/migration/UI changed; this is docs-only findings.** Resolves the
+"unverified until CS-4 design" residuals on OQ-3/OQ-5 and the CS-4 slice. Every claim below ties to a
+file read for this audit.
+
+### 14.1 Files inspected
+[contracts/workflowDefinition.ts](../../../contracts/workflowDefinition.ts) (node shape) ·
+[repositories/integrations.ts](../../../repositories/integrations.ts) (`getActiveForExecution`,
+`listActiveConnectedUserIdsServiceRole`, ownership model) ·
+[supabase/migrations/20260505000002_integrations.sql](../../../supabase/migrations/20260505000002_integrations.sql)
+(base schema — note `account_id`/`connected_by_user_id` were added by the later 22-x account cutover;
+the repo doc-comment is authoritative for the current columns) ·
+[services/oauth/refreshAndRetry.ts](../../../services/oauth/refreshAndRetry.ts) (pin + no-fallback) ·
+[services/oauth/credentialResolutionContext.ts](../../../services/oauth/credentialResolutionContext.ts)
+(ALS context) · [services/execution/engine.ts](../../../services/execution/engine.ts) (per-node owner
+set, ~543-551) · [services/teamCredentials/nodeCredentialOwners.ts](../../../services/teamCredentials/nodeCredentialOwners.ts)
+(`effectiveCredentialOwner`) · [repositories/workflowNodeCredentials.ts](../../../repositories/workflowNodeCredentials.ts)
+(per-node grant table) · [services/teamCredentials/credentialOwnerMetadata.ts](../../../services/teamCredentials/credentialOwnerMetadata.ts)
+(safe display label + eligible targets) · [services/ai/tools/workflowContext.ts](../../../services/ai/tools/workflowContext.ts)
+(availability-by-effective-owner precedent).
+
+### 14.2 Current execution binding model (verified)
+**A workflow node carries NO connection identity.** `WorkflowNodeSchema` stores `id`, `kind`,
+`provider`, `type`, `config` (opaque), `position`, `displayName` — **no integration id, no
+`providerAccountId`, no credential-owner field** ([workflowDefinition.ts:28-54](../../../contracts/workflowDefinition.ts)).
+A node names a **provider string only**.
+
+The integration row is resolved entirely **at execution time** by *user*, not by any node-stored ref:
+
+1. The engine computes a per-node **effective owner** = `effectiveCredentialOwner(provider, nodeId,
+   creatorUserId, acceptedOwners)` = accepted per-node owner (flag ON) **else the workflow creator**,
+   personal providers only ([engine.ts:543-551](../../../services/execution/engine.ts),
+   [nodeCredentialOwners.ts:61-71](../../../services/teamCredentials/nodeCredentialOwners.ts)).
+2. It wraps the handler in `runWithCredentialResolutionContext({ createdByUserId: effectiveOwner })`.
+3. Inside, for **personal** providers, `refreshAndRetry` pins the lookup to
+   `connected_by_user_id = effectiveOwner` ([refreshAndRetry.ts:166-170](../../../services/oauth/refreshAndRetry.ts)).
+4. `getActiveForExecution(accountId, provider, providerAccountId=null, { connectedByUserId })` filters
+   exact on the pin; with the pin present it returns that user's earliest active row; **a missing
+   pinned row throws "owner has no active <provider> connection" — there is NO silent fallback to a
+   co-member** ([integrations.ts:219-250](../../../repositories/integrations.ts),
+   [refreshAndRetry.ts:179-193](../../../services/oauth/refreshAndRetry.ts)).
+
+So **binding today is by USER (`connected_by_user_id`), not by row id and not by `providerAccountId`**.
+`providerAccountId` is `null` on the engine path (it disambiguates multi-workspace rows for the *same*
+user, e.g. two Slack teams; it is not a cross-member selector). The integrations active-unique index is
+`(account_id, provider, provider_account_id) WHERE disconnected_at IS NULL` — so **two different members
+can each have an active row for the same provider** (Alice's Gmail + Bob's Gmail are distinct rows,
+distinct `connected_by_user_id`).
+
+**Answers to Q1/Q2:** (Q1) a node stores **only provider/type** — not integration id, not
+`providerAccountId`, and it relies on **creator-pinning** (or an accepted node-owner) resolved at run
+time. (Q2) `workflow_node_credentials` binds `(workflow, node, provider) → credential_owner_user_id`
+(**a USER**, consent-gated `pending→accepted`, ≤1 live grant/node) and feeds resolution through the SAME
+`effectiveCredentialOwner` → context → pin seam. That seam can bind a shared connection cleanly **because
+it already binds by user id** — which is exactly what a shared connector is. **Node-level binding IS
+required for row-level sharing to be safe whenever the account has >1 sharer of the same provider** (see
+14.3).
+
+### 14.3 Exact risk with multiple shared connectors
+Provider-level "Gmail is shared" is **not** enough — confirmed. The resolver must pin to a **user**. If
+CS-4 naively drops the creator-pin for a shared provider and lets `getActiveForExecution` run with **no
+`connectedByUserId`**, then when Alice **and** Bob have both shared Gmail, the query matches two active
+rows and the **earliest-connected row wins** (`created_at ASC … limit(1)`,
+[integrations.ts:240-243](../../../repositories/integrations.ts)). That is deterministic but
+**product-wrong**: the run silently executes as "whoever connected first," not the intended connector —
+a **silent wrong-identity / cross-member impersonation** outcome, the exact class the personal/account
+model exists to prevent. **Therefore CS-4 must never resolve a shared personal provider by
+`(account, provider)` alone.** It must resolve to a **specific connector user id**, and when the choice
+is ambiguous it must **fail closed**, not pick.
+
+### 14.4 Recommended binding model
+**Bind at the node level to a CONNECTOR USER ID, reusing the existing `effectiveCredentialOwner` →
+context → pin seam.** Do not bind by integration **row id** — a disconnect+reconnect mints a *new* row
+id (upsertActive inserts a fresh row, preserving `connected_by_user_id`), so a row-id binding would break
+on reconnect while a **user-id binding survives** it. This matches every existing pin in the codebase.
+
+Resolution precedence for a personal-provider node (CS-4):
+
+1. **Accepted `workflow_node_credentials` grant** (Option B) — explicit, consent-gated → **wins**
+   (answers Q4; this is just extending today's `effectiveCredentialOwner`, no new precedence machine).
+2. Else **the node's shared-connection connector binding** (the new CS-4 field, see 14.5) if present.
+3. Else, if **exactly one** account member has `shared_with_account` for that provider → **that
+   connector** (the unambiguous case needs no node binding).
+4. Else (provider shared by **2+** members and no node binding) → **ambiguous → not team-runnable**;
+   fall back to creator-only (the run/edit gate blocks non-creators; matches OQ-4's revert posture).
+5. Else (creator) → today's behavior.
+
+**This means CS-3's gate must be ambiguity-aware:** "team-runnable" requires every private provider to
+be not just shared but **unambiguously resolvable** (single sharer, or an explicit node binding, or an
+accepted Option-B grant) — the plan's §4.1 gate wording ("every private-provider node is account-class
+or a shared personal provider") is **necessary but not sufficient** and must add the resolvability test.
+
+### 14.5 Minimum implementation impact (answers Q6)
+- **CS-1 / CS-2 stand as planned** — the `integration_sharing_scope` column + connector-only toggle are
+  unchanged by this audit.
+- **CS-3 (gate)** grows slightly: fold in the **ambiguity test** (14.4 step 4), not just "is shared."
+- **CS-4 (execution)** needs a **node-level connector binding** when >1 member shares a provider. This is
+  the new finding versus the plan's original CS-4 sketch (which assumed "resolve to the connector"
+  singular). Two ways to store it:
+  - **(B-reuse)** Write the chosen connector into `workflow_node_credentials` as an `accepted` grant.
+    *Cons:* its semantics are **requester-pull + target-consent**; a share is **connector-push, already
+    consented**, so we'd be minting auto-accepted grants and conflating two models §0.3 says to keep
+    separate. Also its provider guard + ≤1-live-grant index would need re-reading. **Not recommended as-is.**
+  - **(small row-reference — recommended)** A minimal per-node `connector_user_id` binding (either a
+    narrow new side table `workflow_node_shared_connection` keyed `(workflow_id, node_id)`, or — only if
+    schema review approves — a single opaque field threaded through node config write). It records **just
+    a user id**, set when a builder picks a connector for an ambiguous shared provider; resolution reads
+    it at 14.4 step 2. Smaller surface than the consent machine, and it composes with B via the
+    precedence in 14.4. **Decide the table-vs-field shape in CS-4 design; lean table** (keeps node config
+    free of identity and keeps it server-authoritative / RLS-gated like the other side tables).
+- Net: **CS-1 → CS-2 → CS-3 → CS-4 ordering still holds.** CS-4 splits into **CS-4a (node connector
+  binding: storage + safe builder picker DTO)** and **CS-4b (resolver precedence + ambiguity gate +
+  parity tests)**.
+
+### 14.6 UX implication (answers Q5)
+The safe display primitive **already exists**: members are surfaced by **`displayName` only** (never
+email / `provider_account_id`) via [credentialOwnerMetadata.ts](../../../services/teamCredentials/credentialOwnerMetadata.ts)
+(`ownerDisplayName`) and `listEligibleReassignmentTargets` (returns `{ userId, displayName, role }`),
+backed by `listActiveConnectedUserIdsServiceRole` which selects **only `connected_by_user_id`**
+([integrations.ts:334-355](../../../repositories/integrations.ts)) and is owner/admin/creator-gated.
+A teammate picks **"Alice" vs "Bob"** (member display names), **not** "alice@gmail.com" — so the picker
+leaks no email/provider account id. **Apps DTO stays identity-free** (boolean `sharedWithAccount`); the
+**builder option DTO** for an ambiguous shared provider exposes only the same safe `{ userId, displayName,
+role }` shape the eligible-targets endpoint already returns. No new label primitive is needed; CS-4a
+reuses it.
+
+### 14.7 Does the plan need updating?
+**Yes — two substantive corrections, both folded in above:** (1) CS-3's gate must be **resolvability/
+ambiguity-aware**, not just "is shared"; (2) CS-4 must add a **node-level connector binding** (recommended:
+a small per-node `connector_user_id` reference, **not** a reuse of the consent-gated per-node table) and
+splits into CS-4a/CS-4b. OQ-3 and OQ-5 residuals are now **resolved** by 14.3/14.4. CS-1/CS-2 are
+unaffected. **No implementation authorized — CS-4 design is documented, not built.**

--- a/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
@@ -510,3 +510,215 @@ ambiguity-aware**, not just "is shared"; (2) CS-4 must add a **node-level connec
 a small per-node `connector_user_id` reference, **not** a reuse of the consent-gated per-node table) and
 splits into CS-4a/CS-4b. OQ-3 and OQ-5 residuals are now **resolved** by 14.3/14.4. CS-1/CS-2 are
 unaffected. **No implementation authorized — CS-4 design is documented, not built.**
+
+---
+
+## 15. CS-4a design — node connector binding (storage + service model) — 2026-06-12
+
+**Type: Planning / design only. No source, migrations, tests, UI, execution, or run/edit
+behavior changed in this section. Nothing pushed. No migration created.** Decides the exact
+storage + service model so CS-4a implementation is mechanical. Locks the answers to the seven
+CS-4a questions.
+
+**Arc shipped so far (verified by commit):** CS-1 `7dd78d1a4` (column + flag + pure helpers) →
+CS-2 `4b79788c4` (connector-push toggle service/route) → CS-3a `5479edb02` (ambiguity-aware
+eligibility computation, **not wired**). CS-4a is the storage layer the eligibility result needs to
+become *resolvable* for the 2+-sharer case.
+
+**Source of truth (every file read for this design):**
+[supabase/migrations/20260606000000_workflow_node_credentials.sql](../../../supabase/migrations/20260606000000_workflow_node_credentials.sql)
+(the side-table shape CS-4a parallels — FKs, partial-unique, RLS, GRANT) ·
+[repositories/workflowNodeCredentials.ts](../../../repositories/workflowNodeCredentials.ts)
+(consent-grant repo CS-4a deliberately does NOT reuse) ·
+[services/teamCredentials/nodeCredentialOwners.ts](../../../services/teamCredentials/nodeCredentialOwners.ts)
+(`effectiveCredentialOwner` — the resolver seam CS-4b extends) ·
+[services/teamCredentials/credentialOwnerMetadata.ts](../../../services/teamCredentials/credentialOwnerMetadata.ts)
+(`listEligibleReassignmentTargets` → `{userId, displayName, role}` — the safe picker shape to reuse) ·
+[app/api/workflows/[id]/nodes/[nodeId]/credential-owner/eligible-targets/route.ts](../../../app/api/workflows/[id]/nodes/[nodeId]/credential-owner/eligible-targets/route.ts)
+(the `{ members }` DTO + owner/admin/creator gate) ·
+[app/api/workflows/[id]/nodes/[nodeId]/credential-owner/_shared.ts](../../../app/api/workflows/[id]/nodes/[nodeId]/credential-owner/_shared.ts)
+(`resolveCaller` — membership-gated 404-no-leak auth seam) ·
+[services/accounts/membership.ts](../../../services/accounts/membership.ts)
+(`listMembers` → display name via the `get_account_member_identities` SECURITY DEFINER RPC) ·
+[repositories/integrations.ts](../../../repositories/integrations.ts)
+(`listSharedConnectorUserIdsServiceRole` from CS-3a — the shared-set source) ·
+[core/integrations/sharingEligibility.ts](../../../core/integrations/sharingEligibility.ts) (CS-3a status model).
+
+### 15.1 Q1 — Storage: **new small side table `workflow_node_connector_bindings`** (recommended)
+Rejected alternatives, with reasons grounded in the read files:
+- **Extend `workflow_node_credentials`** — its semantics are **consent-grant**: `status pending →
+  accepted`, a partial-unique `one_live_per_node`, `requested_by_user_id`, and a consent inbox
+  ([repositories/workflowNodeCredentials.ts](../../../repositories/workflowNodeCredentials.ts) +
+  the CS-1…CS-8 consent routes). A connection **share** is *connector-push, already-consented* — there
+  is no target to ask. Reusing it means minting **auto-`accepted`** rows and overloading a state
+  machine the locked model (§0.3) says to keep **separate**. Rejected.
+- **Store in `draftDefinition` node `config`** — the definition is **user- AND AI-editable** and
+  republished; the AI-patch path already strips identity-bearing fields it must not own
+  (`materializeAiPatchNodeIds` strips `displayName`, [contracts/workflowDefinition.ts](../../../contracts/workflowDefinition.ts)
+  L42-53). Putting a `connector_user_id` in config invites an AI patch or an import/export to carry or
+  rewrite an identity binding, and it would not be RLS-gated. Rejected — identity binding must be
+  **server-authoritative**, like `workflow_node_credentials`.
+- **New side table (recommended)** — parallels the proven `workflow_node_credentials` shape but with
+  **direct-binding** (no consent machine), RLS-gated, service-role-written. Smallest surface that keeps
+  the two concepts separate.
+
+### 15.2 Q2 — Binding key + columns (reconnect-stable)
+Keyed `(workflow_id, node_id)`; stores `connector_user_id` (the **stable** key — `connected_by_user_id`
+survives reconnect, whereas the integration **row id** changes on a fresh connect, per
+[repositories/integrations.ts](../../../repositories/integrations.ts) `upsertActive`). `provider` is
+stored for validation/precedence (mirrors `workflow_node_credentials.provider`). **No `account_id`
+column** — derive via the `workflow_id → workflows` FK exactly as `workflow_node_credentials` does (one
+fewer denormalized field to keep in sync; the RLS join already needs `workflows`).
+
+```sql
+CREATE TABLE public.workflow_node_connector_bindings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workflow_id uuid NOT NULL REFERENCES public.workflows(id) ON DELETE CASCADE,
+  node_id text NOT NULL,
+  provider text NOT NULL,                          -- personal-only; enforced in code, not SQL
+  connector_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,  -- who set it (provenance)
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+-- One binding per node (full unique — no status, so no partial predicate needed).
+CREATE UNIQUE INDEX workflow_node_connector_bindings_one_per_node
+  ON public.workflow_node_connector_bindings (workflow_id, node_id);
+CREATE INDEX workflow_node_connector_bindings_workflow_idx
+  ON public.workflow_node_connector_bindings (workflow_id);            -- per-workflow read
+CREATE INDEX workflow_node_connector_bindings_connector_idx
+  ON public.workflow_node_connector_bindings (connector_user_id);      -- offboarding cleanup
+CREATE TRIGGER workflow_node_connector_bindings_set_updated_at
+  BEFORE UPDATE ON public.workflow_node_connector_bindings
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+```
+**No `status` column** — a binding is a direct pointer, not a consent flow. Its *validity* is recomputed
+at resolve time against the live shared set (§15.6), never trusted from storage alone.
+
+### 15.3 Q3 — Authorization to set a binding
+A binding may point ONLY to a `connector_user_id` that, **at set-time**, is in
+`listSharedConnectorUserIdsServiceRole(workflow.accountId, provider)` — i.e. has an **active**,
+`integration_sharing_scope = 'shared_with_account'` personal row for that provider in the workflow's
+account (CS-3a repo). This single check makes "**no silent share of an unshared identity**" *structural*:
+you cannot bind to a connector who has not themselves shared (rejected typed reason
+`connector_not_shared`).
+- **Who may set:** a caller with **edit rights on the workflow** (today: creator, or owner/admin per
+  existing rules — CS-4a does NOT widen edit rights; CS-3b is where non-creators gain them, and only
+  *after* a binding makes the workflow resolvable). The connector may bind their own shared connection;
+  owner/admin may pick among shared connectors — but never an unshared one (the shared-set check blocks
+  it). Reuse the `resolveCaller` membership gate
+  ([credential-owner/_shared.ts](../../../app/api/workflows/[id]/nodes/[nodeId]/credential-owner/_shared.ts)).
+- **Non-member / missing workflow / unknown node** → the same **404 no-leak** the existing credential-
+  owner routes already return.
+- Account/service providers and native nodes → `not_applicable` (only personal providers are bindable),
+  mirroring `ACCOUNT_PROVIDER_NOT_NODE_OWNABLE`.
+
+### 15.4 Q4 — No-leak display model (reuse, don't invent)
+The safe picker already exists. CS-4a adds **one analogous read**: "shared connectors for this provider"
+= map `listSharedConnectorUserIdsServiceRole(account, provider)` → member `displayName` via
+[listMembers](../../../services/accounts/membership.ts) (which sources identity from the
+`get_account_member_identities` **SECURITY DEFINER** RPC — display name only, never the OAuth account
+email/label). The picker DTO is the **exact existing shape**
+`{ userId, displayName, role }` returned by
+[listEligibleReassignmentTargets](../../../services/teamCredentials/credentialOwnerMetadata.ts) /
+[eligible-targets route](../../../app/api/workflows/[id]/nodes/[nodeId]/credential-owner/eligible-targets/route.ts).
+A teammate picks **"Alice (Owner)"**, not `alice@gmail.com`.
+- **No new label primitive needed.** `provider_account_id`, email, token, scope, scope-count, and account
+  metadata never appear — same fence the Apps DTO and eligible-targets already hold.
+- **Apps DTO stays identity-free** (boolean `sharedWithAccount` only; CS-5).
+- The stored binding's *human-facing read* (builder badge) shows the bound connector's `displayName`
+  only; the `userId` is an opaque uuid carried in the set request (the eligible-targets DTO already
+  exposes `userId`, so this is consistent, not a new exposure).
+
+### 15.5 Q5 — Resolver precedence (CS-4b wires this; documented here)
+Extend [`effectiveCredentialOwner`](../../../services/teamCredentials/nodeCredentialOwners.ts) so a
+personal-provider node resolves its credential owner in this order:
+1. **accepted `workflow_node_credentials` grant** (Option B, consent) — **wins** (unchanged today).
+2. else **node connector binding** (CS-4a) — *only if the bound connector is still in the live shared
+   set* (§15.6 validity recheck).
+3. else **single-sharer** — exactly one shared connector for the provider in the account → that connector.
+4. else **creator pin** (today's 22B default).
+5. **2+ shared, no valid binding → fail closed** (no owner ⇒ the run/edit gate blocks the non-creator and
+   the engine never silently picks an arbitrary connector — the §14.3 risk).
+
+### 15.6 Q6 — Lifecycle (fail-closed, never silently-someone-else)
+Validity is **computed at resolve time**, not trusted from the row:
+- **Connector unshares** (`integration_sharing_scope → NULL`, CS-2): the binding row persists but the
+  connector drops out of `listSharedConnectorUserIdsServiceRole` → binding **invalid** → precedence falls
+  through to single-sharer/creator → if now ambiguous/unshared, the non-creator is blocked (CS-3b gate).
+- **Connector disconnects** (`disconnected_at` set): excluded from the shared set by the CS-3a query's
+  `disconnected_at IS NULL` filter → binding invalid → same fail-closed.
+- **Connector leaves the account:** offboarding already soft-disconnects their personal rows
+  ([softDisconnectPersonalForMember](../../../repositories/integrations.ts), 22C) ⇒ binding invalid at
+  resolve. **Plus** a proactive hygiene delete — `deleteBindingsForMemberInAccountServiceRole(accountId,
+  connectorUserId)` from the member-removal/leave path, mirroring
+  [`revokeLiveForMemberServiceRole`](../../../repositories/workflowNodeCredentials.ts). (Resolve-time
+  recheck is the correctness guarantee; the delete is cleanup.)
+- A binding **never** causes a different connector to execute: the resolve-time shared-set recheck is the
+  invariant. `ON DELETE CASCADE` on `connector_user_id` covers hard user deletion.
+
+### 15.7 Q7 — Migration / RLS / GRANT (outline — NOT created in this slice)
+A new table ⇒ a migration is required for CS-4a **implementation**. This design does **not** author it
+(per the "design first" instruction). When authored it must — per
+[migration RLS lint](../../../scripts/check-migration-rls.mjs) + database-security rules — include, in
+the same file, RLS + a policy + explicit GRANTs (mirror `workflow_node_credentials`):
+```sql
+ALTER TABLE public.workflow_node_connector_bindings ENABLE ROW LEVEL SECURITY;
+GRANT SELECT ON public.workflow_node_connector_bindings TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.workflow_node_connector_bindings TO service_role;
+CREATE POLICY workflow_node_connector_bindings_select_account_member
+  ON public.workflow_node_connector_bindings FOR SELECT
+  USING (EXISTS (SELECT 1 FROM public.workflows w
+    JOIN public.account_memberships am ON am.account_id = w.account_id
+    JOIN public.accounts a ON a.id = w.account_id
+    WHERE w.id = workflow_node_connector_bindings.workflow_id
+      AND am.user_id = auth.uid() AND a.deletion_status = 'active'));
+```
+- **No client write policy** — every write is service-role (the binding service authorizes). Default-deny
+  prevents a member self-binding a node by writing the table directly (the same fence
+  `workflow_node_credentials` uses).
+- **No SQL provider list** — personal-only is enforced in code (the single classifier), never duplicated
+  in SQL (same rule the node-credentials migration states).
+
+### 15.8 Does CS-4a implementation need a migration? **Yes** — but not now
+CS-4a ships behind `ENABLE_CONNECTION_SHARING` (already exists, default OFF). The table can be created +
+`db:push`ed when CS-4a implementation is explicitly authorized; this design slice creates nothing.
+
+### 15.9 CS-4a / CS-4b slice split (locked)
+- **CS-4a (implementation, next, gated):** the migration above + a repo
+  (`repositories/workflowNodeConnectorBindings.ts`: get-for-node / set / clear / list-for-workflow /
+  delete-for-member, all service-role) + a binding service (set/clear authz = editor + target-in-shared-
+  set; typed no-leak reasons) + the picker read (shared connectors → `{userId, displayName, role}`) +
+  route(s) under `app/api/workflows/[id]/nodes/[nodeId]/connector-binding/` + tests. **Behavior-inert:**
+  the binding is **stored and displayed but NOT yet consulted** by the resolver or the run/edit gate.
+- **CS-4b (after CS-4a):** wire §15.5 precedence into `effectiveCredentialOwner` (resolver) **and** the
+  §14.4 ambiguity-aware gate into `assertWorkflowRunEditAllowed` (= **CS-3b**), behind the flag, **in
+  lockstep** + execution parity tests + the offboarding binding-cleanup hook.
+
+**Ordering invariant (Marcus's constraint):** **CS-3b (let non-creators run/edit) must NOT ship ahead of
+CS-4b (execution resolves to the bound connector).** They land together in CS-4b so run/edit permission
+never gets ahead of execution binding — a workflow only becomes team-runnable at the exact moment its
+private providers resolve to a specific connector.
+
+### 15.10 Tests CS-4a implementation must prove (by area)
+- **Repo/migration:** table shape + one-per-node unique + RLS membership-gated SELECT + service-role-only
+  writes + GRANTs; offboarding delete scoped to `(accountId, connectorUserId)`.
+- **Binding service authz:** editor binds to a shared connector ✓; binding to a **non-shared** connector
+  → `connector_not_shared` (the no-silent-share fence); non-member → 404 no-leak; account/native →
+  `not_applicable`; cross-account workflow/node → 404.
+- **Picker no-leak:** options are `{userId, displayName, role}` only — no email/`provider_account_id`/
+  token/scope/metadata; non-eligible viewer gated.
+- **Inertness:** with the binding stored, the CS-3a eligibility result and execution are **unchanged**
+  until CS-4b (assert the resolver/gate still ignore bindings in CS-4a).
+
+### 15.11 Open questions (recommendation each)
+- **OQ-4a-1 — does an *unshared-then-rebound* node keep a stale binding row?** *Rec:* yes, leave it
+  inert (resolve-time recheck makes it harmless); CS-4b's offboarding hook + an optional "clear invalid
+  bindings" sweep handle hygiene. Don't add a trigger.
+- **OQ-4a-2 — multiple nodes, same provider, different bound connectors in one workflow?** Allowed (the
+  key is per-node). *Rec:* permit it; each node resolves independently. Mark **unverified** against the
+  execution engine's per-node owner context until CS-4b parity tests (the 22B context is already per-node,
+  [engine.ts:543-551](../../../services/execution/engine.ts), so this is expected to hold).
+- **OQ-4a-3 — should setting a binding require the workflow to currently *use* that provider on that
+  node?** *Rec:* yes — validate `node.provider === provider` against the draft definition at set-time
+  (reuse the `node_not_found`/`not_applicable` checks from `listEligibleReassignmentTargets`).

--- a/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
+++ b/docs/slices/phase-4/explicit-private-connection-sharing-plan.md
@@ -1,0 +1,317 @@
+# 4.CONN-SHARE-1 — Explicit Private-Connection Sharing Plan
+
+**Type:** Planning / design only. **No source, migrations, tests, UI, execution, or
+credential-sharing behavior changes in this slice. Nothing pushed.**
+**Date:** 2026-06-12
+**Branch:** `builder-ui-v1-audit-1`
+**Arc:** WF-RUNPERM (team-visible ≠ team-runnable, shipped `6a02131ed`/`42fe1ce29`) →
+**this plan** → CONN-SHARE CS-1…CS-N (future, gated, migration-bearing).
+
+**Source of truth (verified current state — every file below was read for this plan):**
+[core/integrations/credentialSharing.ts](../../../core/integrations/credentialSharing.ts) (`personal | account` classifier + `POLICY`) ·
+[core/integrations/workflowCredentialScope.ts](../../../core/integrations/workflowCredentialScope.ts) (`workflowUsesPrivateCredential`, `viewerMayRunEdit` — creator-only when private) ·
+[app/api/workflows/_shared.ts](../../../app/api/workflows/_shared.ts) (`assertWorkflowRunEditAllowed` ~348, DTO booleans `usesPrivateCredential`/`viewerCanRunEdit` ~280/316, typed `WORKFLOW_USES_PRIVATE_CREDENTIAL` 335) ·
+[services/oauth/credentialResolutionContext.ts](../../../services/oauth/credentialResolutionContext.ts) (22B AsyncLocalStorage creator-pin) + [services/oauth/refreshAndRetry.ts](../../../services/oauth/refreshAndRetry.ts) (pins `connected_by_user_id = createdByUserId` for personal providers, 166-219) ·
+[repositories/workflowNodeCredentials.ts](../../../repositories/workflowNodeCredentials.ts) (**existing** per-node grant table + consent state machine) ·
+[services/teamCredentials/flags.ts](../../../services/teamCredentials/flags.ts) (`ENABLE_NODE_CREDENTIAL_REASSIGNMENT`, default OFF) + [reassignmentService.ts](../../../services/teamCredentials/reassignmentService.ts) / [credentialRequestsInbox.ts](../../../services/teamCredentials/credentialRequestsInbox.ts) / [nodeCredentialOwners.ts](../../../services/teamCredentials/nodeCredentialOwners.ts) / [credentialOwnerMetadata.ts](../../../services/teamCredentials/credentialOwnerMetadata.ts) ·
+[supabase/migrations/20260505000002_integrations.sql](../../../supabase/migrations/20260505000002_integrations.sql) (`integrations` schema — no sharing column) ·
+[app/apps/_shared.ts](../../../app/apps/_shared.ts) + [contracts/apps.ts](../../../contracts/apps.ts) (Apps DTO; `canDisconnect`/`canReconnect`; NO `provider_account_id`) ·
+[services/integrations/disconnect.ts](../../../services/integrations/disconnect.ts) (disconnect gate + cascade).
+
+**Prior decisions this revisits:**
+[team-workflows-credential-sharing-plan.md](./team-workflows-credential-sharing-plan.md)
+(2026-06-05 — chose **Option B: per-node consent-gated reassignment**, explicitly weighing and
+deferring a row-level approach) · [workflow-run-edit-permission-closeout.md](./workflow-run-edit-permission-closeout.md)
+(WF-RUNPERM creator-only run/edit for private-credential workflows).
+
+---
+
+## 1. Context
+
+WF-RUNPERM made "team-visible ≠ team-runnable" real: a workflow with ≥1 private/member-connected
+credential is **creator-only** to run/edit; teammates can see + duplicate. The remaining gap is
+the **escape hatch the closeout named**: a connector should be able to *explicitly* make their
+private connection team-usable so those workflows become team-runnable by role. This plan designs
+that — **smallest safe path only** — and reconciles it with two already-shipped systems it touches.
+
+---
+
+## 2. Current codebase findings (verified)
+
+### 2.1 Credential classification is centralized and authoritative
+[credentialSharing.ts](../../../core/integrations/credentialSharing.ts) classifies every provider
+`personal | account` (`POLICY`, default `personal`, coverage-tested). **Account** providers
+(slack/notion/stripe/shopify/hubspot/mailchimp) are already account-shared by nature; **personal**
+providers (gmail, outlook, calendars, drive, dropbox, …) act AS the connecting human and must not
+auto-share. **Sharing scope is only ever meaningful for `personal` providers** — account providers
+are inherently shared today.
+
+### 2.2 The run/edit gate is creator-only for private — and does NOT consult any sharing state
+[`viewerMayRunEdit`](../../../core/integrations/workflowCredentialScope.ts) returns: not-private →
+any member; private → `createdByUserId === caller` only. Role-agnostic. Enforced at
+[`assertWorkflowRunEditAllowed`](../../../app/api/workflows/_shared.ts) (run-now / PATCH
+draftDefinition / activate / resume / reactivate) and surfaced as DTO booleans + the typed
+`403 WORKFLOW_USES_PRIVATE_CREDENTIAL`. **This is the single chokepoint a sharing feature must teach
+about "shared" connections.**
+
+### 2.3 Execution pins personal providers to the workflow CREATOR (22B)
+[credentialResolutionContext.ts](../../../services/oauth/credentialResolutionContext.ts) +
+[refreshAndRetry.ts](../../../services/oauth/refreshAndRetry.ts) (166-219): for personal providers,
+the engine pins `connected_by_user_id = createdByUserId`. So a private-credential workflow already
+runs as its creator's identity. **Consequence for sharing:** "shared with team" must NOT change
+*whose* token executes — it stays the **connector's**. Sharing changes **who may trigger** the run,
+not which credential resolves. (If a non-creator authors a workflow against a shared connection,
+execution must resolve to the **connector**, not the author — see OQ-3.)
+
+### 2.4 A per-node, consent-gated reassignment system ALREADY EXISTS (flag OFF)
+[`workflow_node_credentials`](../../../repositories/workflowNodeCredentials.ts) is a shipped side
+table: per `(workflow, node)`, an optional `credential_owner_user_id` + a `pending → accepted →
+declined|revoked` consent machine, with offboarding revoke + a consent inbox
+([reassignmentService.ts](../../../services/teamCredentials/reassignmentService.ts),
+[credentialRequestsInbox.ts](../../../services/teamCredentials/credentialRequestsInbox.ts)). The
+whole CS-1…CS-8 arc landed but is **gated OFF** by `ENABLE_NODE_CREDENTIAL_REASSIGNMENT`
+([flags.ts](../../../services/teamCredentials/flags.ts)); while off, nodes resolve to the creator
+exactly as today. **Shape: requester-pull, per-node, target-consent** — "member B asks to use A's
+credential on one node; A consents."
+
+### 2.5 The `integrations` table has no sharing column
+[20260505000002_integrations.sql](../../../supabase/migrations/20260505000002_integrations.sql):
+columns include `connected_by_user_id`, `provider_account_id`, `disconnected_at`, `account_metadata`
+— **no `sharing_scope`**. The Apps DTO ([app/apps/_shared.ts](../../../app/apps/_shared.ts)) emits
+`id`, `displayName`, `connectedAt`, `canDisconnect`, `canReconnect` — deliberately **no
+`provider_account_id`/email** (pinned by the DTO-safety test).
+
+---
+
+## 3. Product / model decision — what this is, and is NOT
+
+**Is:** a **connector-push, per-connection** opt-in — Person A (the connector of a personal
+integration row) flips it from `private_to_connector` to `shared_with_account`, after which
+workflows using that provider become **team-runnable by role**, while still executing under **A's**
+credential. A coarse, deliberate "I'm letting my team run things as me with this connection" switch.
+
+**Is NOT:** the existing **per-node, requester-pull, consent-gated reassignment**
+(`workflow_node_credentials`, §2.4). That is a *different, finer* mechanism for "use a specific
+person's credential on a specific node." This plan does **not** delete or replace it — it stays
+flag-gated and complementary (targeted reassignment vs broad connection-sharing).
+
+**Is NOT:** a general permission system, a per-workflow ACL, or owner/admin power to silently share
+a member's external identity (see §5).
+
+Anchored to the V2 account model: sharing is **account-scoped** (a connection is shared *with its
+owning account*), role still governs run/edit downstream, and a non-member can never observe or
+infer a shared connection.
+
+---
+
+## 4. Recommended approach — row-level `integration_sharing_scope`
+
+Add an **additive, nullable** `integration_sharing_scope` to `integrations`, consulted **only for
+personal providers**:
+
+- `NULL` / `private_to_connector` → today's behavior (creator-only run/edit; engine creator-pin).
+- `shared_with_account` → the provider stops counting as "private" **for the run/edit gate** on that
+  account; workflows whose only private providers are all shared become team-runnable by role.
+  Execution still resolves to the **connector** (the row's `connected_by_user_id`).
+
+Three touch-points, each extending an existing seam (no new subsystem):
+
+1. **Run/edit gate.** Extend `viewerMayRunEdit` to accept the set of providers the account has
+   `shared_with_account`. A workflow is team-runnable when every private-provider node it uses is
+   either account-class OR a shared personal provider on this account. The chokepoint
+   (`assertWorkflowRunEditAllowed`) resolves that set server-side and passes it in.
+2. **Execution resolution.** For a shared personal provider, the engine resolves
+   `connected_by_user_id = <the connector who shared>` instead of the creator-pin. Cleanest reuse:
+   the resolver already supports an explicit owner override (the 22B context + the node-credential
+   override path) — sharing supplies that owner from the shared row.
+3. **Apps surface + workflow badge.** Connector toggles share/unshare; DTO exposes a boolean
+   `sharedWithAccount` (no identity); the workflow run/edit DTO booleans already exist and just need
+   the shared-set folded into their computation.
+
+Ships behind `ENABLE_CONNECTION_SHARING` (default OFF). While off, the column is inert and every
+path behaves exactly as WF-RUNPERM ships today.
+
+---
+
+## 5. Alternatives considered
+
+| Option | Mechanism | Security / no-leak | Migration | Builder/UI | Execution consistency | Offboarding | Fit to "share my connection" |
+|---|---|---|---|---|---|---|---|
+| **A. Row-level `integration_sharing_scope` (recommended)** | nullable column on `integrations`; only personal providers | ✅ connector-push only; no identity exposed (boolean) | ⚠ **1 additive nullable column** | ✅ one Apps toggle + badge | ✅ resolve to connector via existing owner-override seam | ✅ reuse disconnect/offboarding revoke = unshare | ✅✅ exactly the product ask |
+| **B. Reuse `workflow_node_credentials` (already built)** | model "share" as standing accepted grants | ✅ consent-gated, identity-hidden | ✅ none (table exists) | ❌ per-node, requester-pull — wrong shape for "share whole connection" | ✅ already wired | ✅ already wired (revoke) | ❌ awkward: would need an inverted, connection-wide grant generator |
+| **C. Per-node connection picker** | node references a chosen integration row | ⚠ surfaces co-member rows → leak risk | ⚠ node-ref | ❌ biggest builder change | ✅ | ⚠ | ⚠ overkill for launch |
+| **D. Owner/admin can share any member's connection** | role-based broad share | ❌ silently shares a user's external identity — the thing the personal/account model prevents | — | — | — | — | ❌ rejected (see §6 authz) |
+
+**Recommendation: A**, with **B kept separate** (flag-gated, complementary). A matches the user's
+explicit framing (`private_to_connector` / `shared_with_account`), is the smallest path that makes
+private-credential workflows team-runnable, and reuses the WF-RUNPERM gate + the 22B owner-override
+seam rather than inventing a permission system. The 2026-06-05 plan chose B for *targeted* sharing;
+A is the *broad connector opt-in* that plan's per-node model doesn't ergonomically express — they
+coexist.
+
+---
+
+## 6. Security / data model
+
+**Schema (CS-1, migration-bearing — deferred until approved):**
+```sql
+ALTER TABLE public.integrations
+  ADD COLUMN integration_sharing_scope text;        -- NULL = private_to_connector (derived)
+-- CHECK (integration_sharing_scope IN ('private_to_connector','shared_with_account'))
+-- No backfill: NULL is read as private_to_connector for personal providers; account providers
+-- ignore the column entirely (already account-shared).
+```
+Existing table → **grandfathered grants** (no new GRANT needed; it's an existing table). RLS already
+gates `integrations` rows; the column adds no new row visibility.
+
+**Default-from-classification:** when `NULL`, derive: personal → `private_to_connector`; account →
+not applicable (always shared). So the column is **only writable/meaningful for personal providers**
+— enforce in the toggle service (mirror `workflowNodeCredentials.createPendingRequest`'s
+`ACCOUNT_PROVIDER_NOT_NODE_OWNABLE` guard).
+
+**No-leak invariants (carry from WF-RUNPERM + Apps DTO):**
+- The Apps/workflow DTOs expose only a **boolean** `sharedWithAccount` — never
+  `provider_account_id`, email, token, scope, or connector identity.
+- A non-member never learns a shared connection exists (membership-gated; 404/no-leak).
+- Sharing never lets a co-member **see** the credential or its tokens — only run workflows that
+  resolve to it server-side (the 22D-2 redaction / `toOwnerControlledView` posture is untouched).
+- The unshare/disconnect error surfaces are typed + generic (no identity).
+
+**Authorization (CS-2):**
+- **Connector** (`connected_by_user_id === caller`) may share / unshare **their own** personal
+  connection. ✅
+- **Owner/admin** may **NOT silently share** a member's personal external identity (Option D
+  rejected — impersonation risk). They may *request* a share (reuse the consent-request notion) or
+  manage account-class shared service integrations (already account-shared, no change). **Default:
+  connector-only for the share toggle.** (OQ-2: optional admin-request flow.)
+- **Normal member** cannot share another member's connection. ✅
+- **Unshare:** connector or owner/admin (owner/admin CAN unshare — that's a restriction, not
+  impersonation). ✅
+
+---
+
+## 7. API / service / UI expectations (described, not built)
+
+- **Toggle service** `services/integrations/connectionSharing.ts` —
+  `setSharingScope({ accountId, integrationId, callerUserId, scope })`, authorized exactly like
+  [disconnect's `resolveAndAuthorize`](../../../services/integrations/disconnect.ts) but
+  **connector-only for share** (personal-provider guard). Returns typed reasons
+  (`not_found`/`forbidden`/`account_frozen`/`account_provider_not_shareable`).
+- **Route** `POST /api/accounts/[id]/integrations/[integrationId]/sharing` (mirrors the disconnect
+  route's auth + typed-error mapping). Client sends only the opaque ids + the target scope.
+- **Apps DTO** gains `sharedWithAccount: boolean` (server-derived, personal providers only).
+- **Apps UI** (extends [AppCard](../../../features/apps/AppCard.tsx) per-account row, next to
+  Reconnect/Disconnect): action **"Share with team" / "Stop sharing"**; badge **"Private to you" /
+  "Shared with team"**; a confirmation warning *"Teammates will be able to run workflows that use
+  this connection, acting as you."* Shown only when `acc.canShare` (connector + personal provider).
+- **Workflow surface:** the existing run/edit DTO booleans (`usesPrivateCredential`,
+  `viewerCanRunEdit`) recompute with the shared set → the builder's disabled-Run state + the
+  list-row "Private connection" badge automatically reflect a now-shared connection. A small
+  "Shared connection — team-runnable" badge is an optional polish.
+- **Unshare workflow behavior (decision, §10 OQ-4):** **recommended — unshare reverts affected
+  workflows to creator-only** (they do NOT disable; they simply stop being team-runnable, matching
+  WF-RUNPERM's default). Active workflows owned by the connector keep running (they always could).
+  Do **not** silently leave them broadly runnable, and do **not** auto-disable (less destructive).
+
+---
+
+## 8. Tests required (by area)
+
+- **Classifier/scope unit:** account provider → not shareable; personal → shareable; `NULL` reads as
+  `private_to_connector`; only personal providers consult the column.
+- **Run/edit gate:** workflow with a shared personal provider → team-runnable by role; same workflow
+  unshared → creator-only again; mixed (one shared + one still-private provider) → still creator-only;
+  account-only/native-only unaffected (regression).
+- **Authz (route + service):** connector shares ✓; non-connector member → forbidden; owner/admin share
+  of a member's personal → forbidden (Option D guard) but unshare allowed; non-member → 404 no-leak;
+  account provider → `account_provider_not_shareable`.
+- **Execution:** a shared-connection workflow run by a non-creator member resolves to the
+  **connector's** credential (not the runner's), pinned via the owner-override seam; unshared → reverts
+  to creator-pin.
+- **No-leak:** DTO exposes only the `sharedWithAccount` boolean; no `provider_account_id`/email/token/
+  scope/connector id in any response, badge, or error.
+- **Disconnect interaction:** disconnecting a shared connection still cascades per existing rules AND
+  clears the shared scope; offboarding revoke of the connector unshs / reverts dependent workflows.
+- **Flag:** with `ENABLE_CONNECTION_SHARING` off, the column is inert and every path matches
+  WF-RUNPERM today.
+
+---
+
+## 9. Implementation slice breakdown (all future, gated, smallest-first)
+
+1. **CS-1 (migration + pure scope helpers + flag).** Additive nullable column (+CHECK); flag
+   `ENABLE_CONNECTION_SHARING` (default OFF); pure `effectiveSharingScope(provider, column)` +
+   `accountSharedProviderSet(rows)` helpers. No behavior wired. **Needs `db:push` — Marcus-approved.**
+2. **CS-2 (toggle service + route + authz).** Connector-only share / connector-or-admin unshare;
+   typed errors; no-leak. Mirrors the disconnect service/route.
+3. **CS-3 (run/edit gate).** Thread the account's shared-provider set into `viewerMayRunEdit` /
+   `assertWorkflowRunEditAllowed` + the DTO booleans. Behind the flag.
+4. **CS-4 (execution resolution).** Resolve shared personal providers to the connector via the
+   existing owner-override seam. Behind the flag. Heaviest correctness surface → its own slice + parity
+   tests.
+5. **CS-5 (Apps UI + workflow badge).** Share/Stop-sharing per-row action, badges, confirmation copy.
+6. **CS-6 (disconnect/offboarding interaction).** Unshare-on-disconnect; connector-offboard reverts
+   dependent workflows to creator-only.
+
+---
+
+## 10. Risks / open decisions (each with a recommendation)
+
+- **OQ-1 — Row-level (A) vs reuse per-node (B).** *Recommendation:* **A** for the connector-push
+  "share my connection" product; keep **B** flag-gated for targeted per-node reassignment. They are
+  different shapes; don't force one to do the other. **Marcus's to confirm** (it partially revisits the
+  2026-06-05 Option-B-only decision).
+- **OQ-2 — Owner/admin share of a member's personal connection.** *Recommendation:* **not silently**
+  (impersonation). Allow owner/admin to *request* via the existing consent notion if demand appears;
+  default connector-only.
+- **OQ-3 — Non-creator author of a workflow on a shared connection.** Execution must resolve to the
+  **connector**, not the author. *Recommendation:* resolve shared personal providers to the row's
+  `connected_by_user_id`; if multiple members share the same provider, the workflow must bind a
+  specific connector (reuse the node-owner override) — mark **unverified** until CS-4 design.
+- **OQ-4 — Unshare effect on dependent workflows.** *Recommendation:* **revert to creator-only**, do
+  not auto-disable (least destructive; matches WF-RUNPERM). Surface a one-time notice to affected
+  workflow owners.
+- **OQ-5 — Interaction with the shipped per-node system.** Both can set an effective owner.
+  *Recommendation:* precedence = an explicit **accepted node-credential grant** (B) wins over the
+  coarse **connection share** (A) for that node; document it; cover with a precedence test.
+
+---
+
+## 11. Acceptance criteria
+
+**This planning slice:** the doc exists under `docs/slices/phase-4/`, every current-state claim ties
+to a file that was read, no source/test/migration/UI changed, nothing pushed.
+
+**The implementation must later meet:** additive nullable column only; flag default OFF; connector-push
+authz (no silent admin share of personal identity); run/edit gate + execution both consult the shared
+set; execution still runs as the **connector**; unshare reverts (not broadly-runnable, not auto-disabled);
+no `provider_account_id`/email/token/scope/identity leak; non-members get 404/no-leak; Disconnect
+behavior unchanged except the additive unshare-on-disconnect; the per-node reassignment system stays
+intact and flag-gated.
+
+---
+
+## 12. Hard boundaries (what this slice did NOT change)
+
+No source, tests, migrations, schema, UI, execution, or credential-sharing behavior changed. No column
+added. The `workflow_node_credentials` system, the WF-RUNPERM gate, the 22B creator-pin, Disconnect,
+Reconnect, and AI/MCP code are all untouched. The model, schema, authz, and slice ordering are
+**proposals**. Nothing pushed.
+
+---
+
+## 13. Recommended next step
+
+Get Marcus's call on **OQ-1** (row-level A as the connector-push model, with per-node B kept separate).
+On confirmation, pick up **CS-1** — the additive nullable `integration_sharing_scope` column + the
+`ENABLE_CONNECTION_SHARING` flag + the pure scope helpers (tested in isolation), `db:push` only with
+explicit approval. Do not start CS-3/CS-4 (gate + execution) until CS-1/CS-2 land and the model is
+confirmed.
+
+## Build now or defer?
+
+**Design now (this doc); build deferred.** The feature needs a migration + changes to the run/edit
+gate and the execution resolver (both sensitive, both shipped), so it should not be built until Marcus
+confirms the model (OQ-1) and approves the migration. The smallest first step (CS-1) is a single
+additive nullable column behind a default-OFF flag — low risk, reversible — but still gated on explicit
+approval per the standing push/migrate policy.

--- a/features/apps/AppCard.tsx
+++ b/features/apps/AppCard.tsx
@@ -6,6 +6,7 @@ import { ConnectButton } from "@/features/integrations/ConnectButton";
 import type { AppCatalogItem } from "@/contracts/apps";
 import { AppStatusPill } from "./AppStatusPill";
 import { DisconnectDialog } from "./DisconnectDialog";
+import { ShareConnectionDialog } from "./ShareConnectionDialog";
 import { formatConnectedOn } from "./relativeDate";
 
 /**
@@ -62,6 +63,10 @@ export function AppCard({ app, accountId }: Props) {
   >(null);
   // Transient success line after a disconnect (cleared on next interaction).
   const [disconnectedNotice, setDisconnectedNotice] = useState<string | null>(null);
+  // The account row whose share/unshare dialog is open (null = closed).
+  const [shareTarget, setShareTarget] = useState<
+    { id: string; label: string; mode: "share" | "unshare" } | null
+  >(null);
   const canExpand = app.isConnected;
   const accountCount = app.accounts.length;
 
@@ -173,14 +178,67 @@ export function AppCard({ app, accountId }: Props) {
                   className="flex items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2"
                 >
                   <span className="flex min-w-0 flex-col gap-0.5">
-                    <span className="truncate text-xs font-medium text-foreground">
-                      {label}
+                    <span className="flex items-center gap-2">
+                      <span className="truncate text-xs font-medium text-foreground">
+                        {label}
+                      </span>
+                      {/* Sharing status pill — renders only for personal connections
+                          with the feature ON (sharingStatus !== "not_applicable").
+                          Account/shared-service providers + flag-off rows are
+                          not_applicable and show nothing. No identity in the copy. */}
+                      {acc.sharingStatus !== "not_applicable" && (
+                        <span
+                          data-testid="app-card-sharing-pill"
+                          data-shared={acc.sharedWithAccount ? "true" : "false"}
+                          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${
+                            acc.sharedWithAccount
+                              ? "border-emerald-300 bg-emerald-100 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/15 dark:text-emerald-300"
+                              : "border-border bg-muted/40 text-muted-foreground"
+                          }`}
+                        >
+                          {acc.sharedWithAccount ? "Shared with team" : "Private to you"}
+                        </span>
+                      )}
                     </span>
                     <span className="text-[11px] text-muted-foreground">
                       Connected on {formatConnectedOn(acc.connectedAt)}
                     </span>
                   </span>
                   <span className="flex shrink-0 items-center gap-2">
+                    {/* Share / Stop sharing — per-account, personal connections only.
+                        canShare = the connector on a private row; canUnshare =
+                        connector or owner/admin on a shared row. Both fold in the
+                        feature flag server-side; the route re-authorizes. */}
+                    {acc.canShare && (
+                      <button
+                        type="button"
+                        data-testid="app-card-share"
+                        data-account-id={acc.id}
+                        title="Let your team run workflows with this connection"
+                        onClick={() => {
+                          setDisconnectedNotice(null);
+                          setShareTarget({ id: acc.id, label, mode: "share" });
+                        }}
+                        className="shrink-0 rounded border border-border bg-transparent px-2.5 py-1 text-xs font-medium text-muted-foreground hover:border-foreground/30 hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        Share with team
+                      </button>
+                    )}
+                    {acc.canUnshare && (
+                      <button
+                        type="button"
+                        data-testid="app-card-unshare"
+                        data-account-id={acc.id}
+                        title="Stop letting your team use this connection"
+                        onClick={() => {
+                          setDisconnectedNotice(null);
+                          setShareTarget({ id: acc.id, label, mode: "unshare" });
+                        }}
+                        className="shrink-0 rounded border border-border bg-transparent px-2.5 py-1 text-xs font-medium text-muted-foreground hover:border-foreground/30 hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      >
+                        Stop sharing
+                      </button>
+                    )}
                     {/* Reconnect: per-account (Slice 4.APPS-RECONNECT). Targets
                         THIS specific row — the server steers the provider sign-in
                         to it and refuses to refresh a different account. Renders
@@ -235,6 +293,28 @@ export function AppCard({ app, accountId }: Props) {
             setDisconnectedNotice(`Disconnected ${app.name}.`);
             // Re-fetch the server component so the connection list reflects the
             // soft-disconnect (the row drops out of the active set).
+            router.refresh();
+          }}
+        />
+      )}
+
+      {shareTarget && (
+        <ShareConnectionDialog
+          accountId={accountId}
+          integrationId={shareTarget.id}
+          appName={app.name}
+          accountLabel={shareTarget.label}
+          mode={shareTarget.mode}
+          onClose={() => setShareTarget(null)}
+          onDone={() => {
+            setDisconnectedNotice(
+              shareTarget.mode === "share"
+                ? `Shared ${app.name} with your team.`
+                : `Stopped sharing ${app.name}.`,
+            );
+            // Re-fetch the server component so the sharing status pill + controls
+            // reflect the new scope (no optimistic state — the disconnect pattern
+            // refetches; sharing follows the same model).
             router.refresh();
           }}
         />

--- a/features/apps/ShareConnectionDialog.tsx
+++ b/features/apps/ShareConnectionDialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { setIntegrationSharing } from "@/lib/api/integrations";
+
+/**
+ * Share / Stop-sharing confirmation dialog (Slice 4.CONN-SHARE / CS-5a).
+ *
+ * `mode: "share"` calls the sharing route with `shared_with_account`; `mode:
+ * "unshare"` with `private_to_connector`. On success it calls `onDone()` (the
+ * card refreshes the server component so the new status renders). All failures —
+ * including the flag-off `not_enabled` (which the route hides behind a typed
+ * code) — surface a SAFE generic message; never a raw provider/DB error, token,
+ * or identity. Modeled on DisconnectDialog (plain overlay modal).
+ */
+interface Props {
+  accountId: string;
+  integrationId: string;
+  appName: string;
+  accountLabel: string;
+  mode: "share" | "unshare";
+  onClose: () => void;
+  onDone: () => void;
+}
+
+export function ShareConnectionDialog({
+  accountId,
+  integrationId,
+  appName,
+  accountLabel,
+  mode,
+  onClose,
+  onDone,
+}: Props) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sharing = mode === "share";
+
+  async function confirm() {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      await setIntegrationSharing(
+        accountId,
+        integrationId,
+        sharing ? "shared_with_account" : "private_to_connector",
+      );
+      onDone();
+      onClose();
+    } catch {
+      setError(
+        sharing
+          ? "Couldn't share this connection. Please try again."
+          : "Couldn't stop sharing this connection. Please try again.",
+      );
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+      data-testid="share-overlay"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${sharing ? "Share" : "Stop sharing"} ${appName}`}
+        data-testid="share-dialog"
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md rounded-lg border border-border bg-card p-5 shadow-xl"
+      >
+        <h2 className="text-sm font-semibold text-foreground">
+          {sharing ? `Share ${appName} with your team?` : `Stop sharing ${appName}?`}
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">{accountLabel}</p>
+
+        <p className="mt-3 text-xs text-muted-foreground" data-testid="share-warning">
+          {sharing
+            ? "Team members will be able to run workflows using this connection."
+            : "Team workflows using this connection may become creator-only again."}
+        </p>
+
+        {error && (
+          <p role="alert" data-testid="share-error" className="mt-2 text-xs text-destructive">
+            {error}
+          </p>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={sharing ? "default" : "destructive"}
+            disabled={pending}
+            onClick={confirm}
+            data-testid="share-confirm"
+          >
+            {pending
+              ? sharing
+                ? "Sharing…"
+                : "Stopping…"
+              : sharing
+                ? "Share with team"
+                : "Stop sharing"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/workflow-builder/config-modal/NodeConnectorBindingControl.tsx
+++ b/features/workflow-builder/config-modal/NodeConnectorBindingControl.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  fetchNodeConnectorBindingState,
+  setNodeConnectorBinding,
+  clearNodeConnectorBinding,
+  type NodeConnectorBindingStateDTO,
+} from "@/lib/api/connectorBindings";
+
+/**
+ * Node connector-binding picker for the config-modal (Slice 4.CONN-SHARE / CS-5b).
+ *
+ * Resolves the ambiguous multi-sharer case: when a personal-provider node has 2+
+ * shared connectors and no valid binding, the editor picks WHICH shared connection
+ * the node runs under. Saving calls the CS-4a binding route; the CS-4b plan then
+ * resolves execution + the run/edit gate to that connector.
+ *
+ * States (from the server `status`):
+ *   - not_applicable / single_sharer→(silent or info) — no picker needed.
+ *   - needs_selection — "Multiple team members shared this connection…" + picker.
+ *   - bound — "Using shared connection from {name}." + Change / Stop using.
+ *   - unavailable — "This shared connection is no longer available…" + re-pick.
+ *
+ * No-leak: shows member display names only — never a token / email /
+ * provider_account_id / scope. Best-effort load (degrades to inert on failure).
+ */
+export function NodeConnectorBindingControl({
+  workflowId,
+  nodeId,
+}: {
+  workflowId: string;
+  nodeId: string;
+}) {
+  const [state, setState] = useState<NodeConnectorBindingStateDTO | null>(null);
+  const [tick, setTick] = useState(0);
+  const [selected, setSelected] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchNodeConnectorBindingState(workflowId, nodeId, { signal: controller.signal })
+      .then((s) => {
+        if (!controller.signal.aborted) setState(s);
+      })
+      .catch(() => {
+        /* AbortError / transport — keep prior state */
+      });
+    return () => controller.abort();
+  }, [workflowId, nodeId, tick]);
+
+  const refetch = useCallback(() => {
+    setSelected("");
+    setError(null);
+    setTick((t) => t + 1);
+  }, []);
+
+  async function save() {
+    if (!selected || busy) return;
+    setBusy(true);
+    setError(null);
+    const res = await setNodeConnectorBinding(workflowId, nodeId, selected);
+    setBusy(false);
+    if (res.ok) refetch();
+    else setError("Couldn't save the connection. Please try again.");
+  }
+
+  async function clear() {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    const res = await clearNodeConnectorBinding(workflowId, nodeId);
+    setBusy(false);
+    if (res.ok) refetch();
+    else setError("Couldn't update the connection. Please try again.");
+  }
+
+  // Nothing to show: not loaded yet, account/native, accepted grant owns it, or
+  // single-sharer (auto-resolved — kept silent to avoid noise).
+  if (!state || state.status === "not_applicable" || state.status === "single_sharer") {
+    return null;
+  }
+
+  const picker = (prompt: string) => (
+    <div data-testid="connector-binding-picker" className="flex flex-col gap-1.5">
+      <span className="text-[11px] text-muted-foreground">{prompt}</span>
+      {state.connectors.length === 0 ? (
+        <span data-testid="connector-binding-empty" className="text-[11px] text-muted-foreground">
+          No team member is sharing this connection yet.
+        </span>
+      ) : (
+        <>
+          <select
+            data-testid="connector-binding-select"
+            aria-label="Choose a shared connection"
+            className="rounded border border-input bg-background px-2 py-1 text-xs"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            <option value="">Choose a connection…</option>
+            {state.connectors.map((c) => (
+              <option key={c.userId} value={c.userId}>
+                {c.displayName ?? "Member"}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            data-testid="connector-binding-save"
+            className="w-fit text-[11px] font-medium text-primary hover:underline disabled:opacity-50"
+            disabled={!selected || busy}
+            onClick={save}
+          >
+            Use this connection
+          </button>
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <div data-testid="connector-binding-control" data-status={state.status} className="flex flex-col gap-1.5">
+      {state.status === "needs_selection" &&
+        picker("Multiple team members shared this connection. Choose which one this node should use.")}
+
+      {state.status === "unavailable" &&
+        picker("This shared connection is no longer available. Choose another connection.")}
+
+      {state.status === "bound" && (
+        <div className="flex flex-col gap-1">
+          <span data-testid="connector-binding-bound" className="text-[11px] text-muted-foreground">
+            Using shared connection from {state.currentConnectorDisplayName ?? "a team member"}.
+          </span>
+          <button
+            type="button"
+            data-testid="connector-binding-clear"
+            className="w-fit text-[11px] text-muted-foreground hover:underline disabled:opacity-50"
+            disabled={busy}
+            onClick={clear}
+          >
+            Stop using this connection
+          </button>
+        </div>
+      )}
+
+      {error ? (
+        <span role="alert" data-testid="connector-binding-error" className="text-[11px] text-destructive">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/features/workflow-builder/config-modal/NodeCredentialOwnerSection.tsx
+++ b/features/workflow-builder/config-modal/NodeCredentialOwnerSection.tsx
@@ -5,6 +5,7 @@ import { useBuilderTeamContext } from "../context/builderTeamContext";
 import { useNodeCredentialOwners } from "../hooks/useNodeCredentialOwners";
 import { CredentialOwnershipBadge } from "./CredentialOwnershipBadge";
 import { CredentialReassignControl } from "./CredentialReassignControl";
+import { NodeConnectorBindingControl } from "./NodeConnectorBindingControl";
 
 /**
  * Credential-owner section for the active config-modal node (CS-4b).
@@ -60,6 +61,13 @@ export function NodeCredentialOwnerSection({
           nodeId={nodeId}
           onRequested={refetch}
         />
+      ) : null}
+
+      {/* CS-5b — connector binding picker for ambiguous shared personal connections.
+          Self-hides (not_applicable) when an accepted grant owns the node, the
+          provider is account/native, the flag is OFF, or there's no ambiguity. */}
+      {team?.isTeamWorkflow && isPersonal && workflowId && !accepted && !pending ? (
+        <NodeConnectorBindingControl workflowId={workflowId} nodeId={nodeId} />
       ) : null}
     </div>
   );

--- a/lib/api/connectorBindings.ts
+++ b/lib/api/connectorBindings.ts
@@ -1,0 +1,106 @@
+/**
+ * Typed client wrappers for the per-node connector-binding endpoints
+ * (Slice 4.CONN-SHARE / CS-5b). Client-safe (no server imports).
+ *
+ * The server never returns a token / provider account id / email / scope /
+ * account metadata — these DTOs carry the status enum, safe member display names,
+ * and opaque user ids only (same shape the credential-owner eligible-targets
+ * endpoint already exposes).
+ */
+
+export type NodeBindingStatus =
+  | "not_applicable"
+  | "single_sharer"
+  | "needs_selection"
+  | "bound"
+  | "unavailable";
+
+export interface SharedConnectorOptionDTO {
+  readonly userId: string;
+  readonly displayName: string | null;
+  readonly role: "owner" | "admin" | "member";
+}
+
+export interface NodeConnectorBindingStateDTO {
+  readonly status: NodeBindingStatus;
+  readonly connectors: readonly SharedConnectorOptionDTO[];
+  readonly currentConnectorDisplayName: string | null;
+}
+
+/** A safe "nothing to show" state — used on flag-off / error / non-team. */
+function inertState(): NodeConnectorBindingStateDTO {
+  return { status: "not_applicable", connectors: [], currentConnectorDisplayName: null };
+}
+
+/**
+ * Load the builder's per-node binding state. Degrades to the inert
+ * `not_applicable` state on any non-200 / parse failure (incl. the flag-off 404),
+ * so the builder never breaks on this best-effort read. Re-throws AbortError so the
+ * caller's AbortController can detect cancellation.
+ */
+export async function fetchNodeConnectorBindingState(
+  workflowId: string,
+  nodeId: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<NodeConnectorBindingStateDTO> {
+  try {
+    const res = await fetch(bindingPath(workflowId, nodeId), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      ...(opts.signal !== undefined && { signal: opts.signal }),
+    });
+    if (!res.ok) return inertState();
+    const body = (await res.json()) as NodeConnectorBindingStateDTO;
+    if (typeof body !== "object" || body === null || !Array.isArray(body.connectors)) {
+      return inertState();
+    }
+    return body;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    return inertState();
+  }
+}
+
+export type BindingActionResponse = { ok: true } | { ok: false; code: string };
+
+/** Bind the node to `connectorUserId` (PUT). */
+export async function setNodeConnectorBinding(
+  workflowId: string,
+  nodeId: string,
+  connectorUserId: string,
+): Promise<BindingActionResponse> {
+  return mutate(bindingPath(workflowId, nodeId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ connectorUserId }),
+  });
+}
+
+/** Clear the node's binding (DELETE). */
+export async function clearNodeConnectorBinding(
+  workflowId: string,
+  nodeId: string,
+): Promise<BindingActionResponse> {
+  return mutate(bindingPath(workflowId, nodeId), { method: "DELETE", headers: { Accept: "application/json" } });
+}
+
+function bindingPath(workflowId: string, nodeId: string): string {
+  return `/api/workflows/${encodeURIComponent(workflowId)}/nodes/${encodeURIComponent(
+    nodeId,
+  )}/connector-binding`;
+}
+
+async function mutate(
+  url: string,
+  init: { method: string; headers?: Record<string, string>; body?: string },
+): Promise<BindingActionResponse> {
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch {
+    return { ok: false, code: "UNKNOWN" };
+  }
+  if (res.ok) return { ok: true };
+  const body = (await res.json().catch(() => ({}))) as { code?: string };
+  return { ok: false, code: body.code ?? "UNKNOWN" };
+}

--- a/lib/api/integrations.ts
+++ b/lib/api/integrations.ts
@@ -127,3 +127,34 @@ export async function disconnectIntegration(
   }
   return (await res.json()) as DisconnectIntegrationResult;
 }
+
+export type IntegrationSharingScope = "private_to_connector" | "shared_with_account";
+
+export interface SetIntegrationSharingResult {
+  scope: IntegrationSharingScope;
+  shared: boolean;
+  changed: boolean;
+}
+
+/**
+ * POST the explicit sharing scope of a personal connection (Slice 4.CONN-SHARE /
+ * CS-2 route). `shared_with_account` shares it with the team; `private_to_connector`
+ * stops sharing. The route re-authorizes (connector-only share; connector-or-admin
+ * unshare) and returns only the safe `{ scope, shared, changed }` DTO. Any failure
+ * (incl. flag-off `not_enabled`) surfaces a SAFE, typed message via `safeError`.
+ */
+export async function setIntegrationSharing(
+  accountId: string,
+  integrationId: string,
+  scope: IntegrationSharingScope,
+): Promise<SetIntegrationSharingResult> {
+  const res = await fetch(`${integrationBasePath(accountId, integrationId)}/sharing`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ scope }),
+  });
+  if (!res.ok) {
+    throw await safeError(res, "Couldn't update sharing for this connection. Please try again.");
+  }
+  return (await res.json()) as SetIntegrationSharingResult;
+}

--- a/repositories/integrations.ts
+++ b/repositories/integrations.ts
@@ -369,6 +369,42 @@ export async function listActiveConnectedUserIdsServiceRole(
 }
 
 /**
+ * Service-role: the set of distinct user ids that have an ACTIVE, EXPLICITLY
+ * SHARED (`integration_sharing_scope = 'shared_with_account'`) connection for
+ * `provider` in `accountId` (Slice 4.CONN-SHARE / CS-3a).
+ *
+ * Used to compute per-provider sharing status (0 = unshared, 1 = single
+ * connector, 2+ = ambiguous) for the ambiguity-aware run/edit eligibility. The
+ * CALLER (`computeWorkflowSharingEligibility`) consumes only the SIZE of this set
+ * — the ids never leave the service. Selects ONLY `connected_by_user_id`; no
+ * token, scope, provider_account_id, label, or metadata is read. The
+ * `disconnected_at IS NULL` filter means disconnected shared rows are ignored.
+ */
+export async function listSharedConnectorUserIdsServiceRole(
+  accountId: string,
+  provider: string,
+): Promise<ReadonlySet<string>> {
+  const supabase = getServiceRoleClient(
+    `integrations: listSharedConnectorUserIds for account ${accountId} / ${provider}`,
+  );
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("connected_by_user_id")
+    .eq("account_id", accountId)
+    .eq("provider", provider)
+    .eq("integration_sharing_scope", "shared_with_account")
+    .is("disconnected_at", null);
+  if (error) {
+    throw new Error(`integrations.listSharedConnectorUserIdsServiceRole failed: ${error.message}`);
+  }
+  const ids = new Set<string>();
+  for (const r of (data ?? []) as Array<{ connected_by_user_id: string | null }>) {
+    if (r.connected_by_user_id) ids.add(r.connected_by_user_id);
+  }
+  return ids;
+}
+
+/**
  * Offboarding soft-disconnect (Slice 4.ACCOUNT-MODEL-22C).
  *
  * When a member is removed from a Team, the PERSONAL credentials they connected

--- a/repositories/integrations.ts
+++ b/repositories/integrations.ts
@@ -38,6 +38,18 @@ export interface IntegrationRecord {
   scopes: readonly string[];
   accountMetadata: Readonly<Record<string, unknown>>;
   disconnectedAt: string | null;
+  /**
+   * Explicit connection-sharing scope (Slice 4.CONN-SHARE / CS-1). NULL = unset
+   * = the derived `private_to_connector` default (see
+   * `core/integrations/sharingScope.ts`). Additive + inert: no execution / DTO
+   * path reads it yet; CS-2 is the first writer (the sharing toggle service).
+   *
+   * OPTIONAL on purpose: `rowToRecord` always populates it from the column, but
+   * the many test fixtures that build an `IntegrationRecord` literal pre-date the
+   * column and must keep compiling without it. Readers treat `undefined` exactly
+   * like `null` (the helper `effectiveIntegrationSharingScope` accepts both).
+   */
+  integrationSharingScope?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -70,6 +82,7 @@ interface IntegrationsRow {
   scopes: string[];
   account_metadata: Record<string, unknown>;
   disconnected_at: string | null;
+  integration_sharing_scope: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -88,6 +101,7 @@ function rowToRecord(row: IntegrationsRow): IntegrationRecord {
     scopes: row.scopes,
     accountMetadata: row.account_metadata,
     disconnectedAt: row.disconnected_at,
+    integrationSharingScope: row.integration_sharing_scope ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -458,6 +472,41 @@ export async function getByIdForAccountServiceRole(
     throw new Error(`integrations.getByIdForAccountServiceRole failed: ${error.message}`);
   }
   return data ? rowToRecord(data) : null;
+}
+
+/**
+ * Service-role: set `integration_sharing_scope` on ONE active integration row
+ * (Slice 4.CONN-SHARE / CS-2).
+ *
+ * `scope = 'shared_with_account'` opts the connection in; `scope = null` clears
+ * it back to the unset / derived `private_to_connector` default (we never write
+ * the literal `'private_to_connector'` — the column means "explicitly shared?"
+ * and NULL is the unshared default).
+ *
+ * Guarded `disconnected_at IS NULL` — a disconnected row is NEVER mutated. If the
+ * row was disconnected between the caller's resolve and this write (race), zero
+ * rows match and `updated:false` is returned; the service maps that to a safe
+ * `not_found`. Service-role: the sharing service has already authorized the
+ * caller (connector-only share / connector-or-admin unshare) and operates by
+ * account, not session. Touches no token columns.
+ */
+export async function setSharingScopeByIdServiceRole(input: {
+  integrationId: string;
+  scope: "shared_with_account" | null;
+}): Promise<{ updated: boolean }> {
+  const supabase = getServiceRoleClient(
+    `connection sharing: setSharingScope ${input.integrationId}`,
+  );
+  const { data, error } = await supabase
+    .from("integrations")
+    .update({ integration_sharing_scope: input.scope })
+    .eq("id", input.integrationId)
+    .is("disconnected_at", null)
+    .select("id");
+  if (error) {
+    throw new Error(`integrations.setSharingScopeByIdServiceRole failed: ${error.message}`);
+  }
+  return { updated: (data ?? []).length > 0 };
 }
 
 /**

--- a/repositories/workflowNodeConnectorBindings.ts
+++ b/repositories/workflowNodeConnectorBindings.ts
@@ -132,6 +132,48 @@ export async function setForNodeServiceRole(input: {
   return rowToRecord(data);
 }
 
+/**
+ * Delete EVERY binding pointing at `connectorUserId` across the workflows in
+ * `accountId` — offboarding hygiene (CS-4b: member remove / leave). The resolver
+ * already fails closed on an invalid binding (the connector drops out of the live
+ * shared set once their personal rows are disconnected), so this is data hygiene,
+ * not the correctness guarantee. The table has no `account_id`, so scope is
+ * resolved through the `workflow_id → workflows` FK embed first, then deleted by
+ * id. Always safe to call (0-row no-op). Returns the count removed. Service-role.
+ */
+export async function deleteForMemberInAccountServiceRole(input: {
+  accountId: string;
+  connectorUserId: string;
+}): Promise<{ deletedCount: number }> {
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: deleteForMember ${input.accountId}/${input.connectorUserId}`,
+  );
+  const { data: rows, error: selectError } = await supabase
+    .from("workflow_node_connector_bindings")
+    .select("id, workflows!inner(account_id)")
+    .eq("workflows.account_id", input.accountId)
+    .eq("connector_user_id", input.connectorUserId);
+  if (selectError) {
+    throw new Error(
+      `workflow_node_connector_bindings.deleteForMemberInAccountServiceRole select failed: ${selectError.message}`,
+    );
+  }
+  const ids = (rows ?? []).map((r) => (r as { id: string }).id);
+  if (ids.length === 0) return { deletedCount: 0 };
+
+  const { data: deleted, error: deleteError } = await supabase
+    .from("workflow_node_connector_bindings")
+    .delete()
+    .in("id", ids)
+    .select("id");
+  if (deleteError) {
+    throw new Error(
+      `workflow_node_connector_bindings.deleteForMemberInAccountServiceRole delete failed: ${deleteError.message}`,
+    );
+  }
+  return { deletedCount: (deleted ?? []).length };
+}
+
 /** Delete the binding for one node. Idempotent — returns whether a row was removed. Service-role. */
 export async function deleteForNodeServiceRole(
   workflowId: string,

--- a/repositories/workflowNodeConnectorBindings.ts
+++ b/repositories/workflowNodeConnectorBindings.ts
@@ -1,0 +1,153 @@
+import { getServiceRoleClient } from "./supabase/serviceRoleClient";
+import { isPersonalCredentialProvider } from "@/core/integrations/credentialSharing";
+
+/**
+ * Repository for `workflow_node_connector_bindings` (Slice 4.CONN-SHARE / CS-4a).
+ *
+ * Direct per-node connector binding (NOT the consent-gated
+ * `workflow_node_credentials` — see the migration header / plan §15.1). Holds,
+ * per (workflow, node), the connector user whose explicitly-shared personal
+ * connection that node should run under. CS-4a ships storage + these helpers; NO
+ * resolver/gate reads them yet (behavior-inert until CS-4b).
+ *
+ * All writes are service-role (the binding service authorizes connector/editor +
+ * shared-set membership). Reads here are service-role too; account members read
+ * through RLS (`workflow_node_connector_bindings_select_account_member`) at the
+ * route layer. Provider rule: only PERSONAL-credential providers are bindable —
+ * enforced here via the single classifier, NOT a duplicated SQL map.
+ */
+
+export const ACCOUNT_PROVIDER_NOT_BINDABLE = "ACCOUNT_PROVIDER_NOT_BINDABLE" as const;
+
+export interface WorkflowNodeConnectorBindingRecord {
+  id: string;
+  workflowId: string;
+  nodeId: string;
+  provider: string;
+  connectorUserId: string;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface WorkflowNodeConnectorBindingsRow {
+  id: string;
+  workflow_id: string;
+  node_id: string;
+  provider: string;
+  connector_user_id: string;
+  created_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToRecord(row: WorkflowNodeConnectorBindingsRow): WorkflowNodeConnectorBindingRecord {
+  return {
+    id: row.id,
+    workflowId: row.workflow_id,
+    nodeId: row.node_id,
+    provider: row.provider,
+    connectorUserId: row.connector_user_id,
+    createdByUserId: row.created_by_user_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** All bindings for a workflow (builder/resolution read path). Service-role. */
+export async function listByWorkflowServiceRole(
+  workflowId: string,
+): Promise<readonly WorkflowNodeConnectorBindingRecord[]> {
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: listByWorkflow ${workflowId}`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_connector_bindings")
+    .select("*")
+    .eq("workflow_id", workflowId)
+    .order("created_at", { ascending: true });
+  if (error) {
+    throw new Error(`workflow_node_connector_bindings.listByWorkflowServiceRole failed: ${error.message}`);
+  }
+  return (data ?? []).map((r) => rowToRecord(r as WorkflowNodeConnectorBindingsRow));
+}
+
+/** The binding for one node, or null. The unique index guarantees at most one. Service-role. */
+export async function getForNodeServiceRole(
+  workflowId: string,
+  nodeId: string,
+): Promise<WorkflowNodeConnectorBindingRecord | null> {
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: getForNode ${workflowId}/${nodeId}`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_connector_bindings")
+    .select("*")
+    .eq("workflow_id", workflowId)
+    .eq("node_id", nodeId)
+    .maybeSingle<WorkflowNodeConnectorBindingsRow>();
+  if (error) {
+    throw new Error(`workflow_node_connector_bindings.getForNodeServiceRole failed: ${error.message}`);
+  }
+  return data ? rowToRecord(data) : null;
+}
+
+/**
+ * Upsert the binding for one node (set or replace the connector). Keyed on the
+ * `(workflow_id, node_id)` unique index. Rejects account/service providers
+ * (`ACCOUNT_PROVIDER_NOT_BINDABLE`) at the single classifier. Service-role.
+ */
+export async function setForNodeServiceRole(input: {
+  workflowId: string;
+  nodeId: string;
+  provider: string;
+  connectorUserId: string;
+  createdByUserId: string | null;
+}): Promise<WorkflowNodeConnectorBindingRecord> {
+  if (!isPersonalCredentialProvider(input.provider)) {
+    throw new Error(ACCOUNT_PROVIDER_NOT_BINDABLE);
+  }
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: setForNode ${input.workflowId}/${input.nodeId}`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_connector_bindings")
+    .upsert(
+      {
+        workflow_id: input.workflowId,
+        node_id: input.nodeId,
+        provider: input.provider,
+        connector_user_id: input.connectorUserId,
+        created_by_user_id: input.createdByUserId,
+      },
+      { onConflict: "workflow_id,node_id" },
+    )
+    .select()
+    .single<WorkflowNodeConnectorBindingsRow>();
+  if (error || !data) {
+    throw new Error(
+      `workflow_node_connector_bindings.setForNodeServiceRole failed: ${error?.message ?? "no row"}`,
+    );
+  }
+  return rowToRecord(data);
+}
+
+/** Delete the binding for one node. Idempotent — returns whether a row was removed. Service-role. */
+export async function deleteForNodeServiceRole(
+  workflowId: string,
+  nodeId: string,
+): Promise<{ deleted: boolean }> {
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: deleteForNode ${workflowId}/${nodeId}`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_connector_bindings")
+    .delete()
+    .eq("workflow_id", workflowId)
+    .eq("node_id", nodeId)
+    .select("id");
+  if (error) {
+    throw new Error(`workflow_node_connector_bindings.deleteForNodeServiceRole failed: ${error.message}`);
+  }
+  return { deleted: (data ?? []).length > 0 };
+}

--- a/services/accounts/leaveAccount.ts
+++ b/services/accounts/leaveAccount.ts
@@ -2,6 +2,7 @@ import * as accountsRepo from "@/repositories/accounts";
 import * as membershipsRepo from "@/repositories/accountMemberships";
 import { softDisconnectPersonalForMember } from "@/repositories/integrations";
 import { revokeLiveForMemberServiceRole } from "@/repositories/workflowNodeCredentials";
+import { deleteForMemberInAccountServiceRole } from "@/repositories/workflowNodeConnectorBindings";
 import { clearActiveAccountIfMatchesServiceRole } from "@/repositories/userProfiles";
 
 /**
@@ -61,6 +62,23 @@ export async function leaveAccount(input: {
         event: "account.member.leave.node_credentials_revoked",
         accountId: input.accountId,
         count: revoked.revokedCount,
+      }),
+    );
+  }
+
+  // CS-4b: delete node connector bindings POINTING AT this leaver as a shared
+  // connector — data hygiene (the resolver also fails closed once their shared
+  // rows are disconnected below). Idempotent / 0-row no-op.
+  const bindingsDeleted = await deleteForMemberInAccountServiceRole({
+    accountId: input.accountId,
+    connectorUserId: input.userId,
+  });
+  if (bindingsDeleted.deletedCount > 0) {
+    console.info(
+      JSON.stringify({
+        event: "account.member.leave.connector_bindings_deleted",
+        accountId: input.accountId,
+        count: bindingsDeleted.deletedCount,
       }),
     );
   }

--- a/services/accounts/membership.ts
+++ b/services/accounts/membership.ts
@@ -3,6 +3,7 @@ import * as membershipsRepo from "@/repositories/accountMemberships";
 import * as accountsRepo from "@/repositories/accounts";
 import { softDisconnectPersonalForMember } from "@/repositories/integrations";
 import { revokeLiveForMemberServiceRole } from "@/repositories/workflowNodeCredentials";
+import { deleteForMemberInAccountServiceRole } from "@/repositories/workflowNodeConnectorBindings";
 import { clearActiveAccountIfMatchesServiceRole } from "@/repositories/userProfiles";
 import { countImpactedWorkflowsForMember } from "./offboardingImpact";
 
@@ -110,6 +111,24 @@ export async function removeMember(input: {
         event: "account.member.offboard.node_credentials_revoked",
         accountId: input.accountId,
         count: revoked.revokedCount,
+      }),
+    );
+  }
+
+  // Offboarding (CS-4b): delete any node connector bindings POINTING AT this
+  // member as a shared connector. The resolver already fails closed once their
+  // shared personal rows are disconnected (below) — this is data hygiene so no
+  // binding row is left dangling at a departed user. Idempotent / 0-row no-op.
+  const bindingsDeleted = await deleteForMemberInAccountServiceRole({
+    accountId: input.accountId,
+    connectorUserId: input.targetUserId,
+  });
+  if (bindingsDeleted.deletedCount > 0) {
+    console.info(
+      JSON.stringify({
+        event: "account.member.offboard.connector_bindings_deleted",
+        accountId: input.accountId,
+        count: bindingsDeleted.deletedCount,
       }),
     );
   }

--- a/services/execution/engine.ts
+++ b/services/execution/engine.ts
@@ -24,6 +24,11 @@ import {
   loadAcceptedNodeOwners,
   effectiveCredentialOwner,
 } from "@/services/teamCredentials/nodeCredentialOwners";
+import { isConnectionSharingEnabled } from "@/services/integrations/connectionSharingFlags";
+import {
+  buildWorkflowCredentialPlan,
+  type WorkflowCredentialPlan,
+} from "@/services/integrations/connectionResolution";
 import { estimateWorkflowTaskCost } from "@/services/billing/workflowCostEstimator";
 import { checkWorkflowReadiness } from "@/services/workflows/executionReadiness";
 import { recordShadowComparison } from "@/services/billing/reserveReconcileShadowMode";
@@ -386,11 +391,25 @@ export class WorkflowEngine {
     const steps: RunStepResult[] = [];
     let runFailed = false;
 
-    // CS-2 — batch-load this workflow's ACCEPTED per-node credential owners ONCE
-    // per run (flag-gated; flag OFF → empty map, NO DB call). Each personal-
-    // provider node then resolves credentials under its accepted owner if one
-    // exists, else the workflow creator. Account/service providers are unaffected.
-    const acceptedNodeOwners = await loadAcceptedNodeOwners(input.workflowId);
+    // CS-2 / CS-4b — resolve each personal-provider node's effective credential
+    // owner ONCE per run. With ENABLE_CONNECTION_SHARING ON, the shared
+    // `buildWorkflowCredentialPlan` applies the full precedence (accepted grant →
+    // valid binding → single-sharer → creator) — the SAME plan the run/edit gate
+    // used, so a run that passed the gate resolves to the exact connectors it
+    // validated, and ambiguous/unshared nodes fall to the creator pin (never an
+    // arbitrary co-member row). With the flag OFF, behavior is byte-identical to
+    // CS-2: accepted owner (flag-gated) else creator. Account/service providers are
+    // unaffected (refreshAndRetry ignores the context for them).
+    const sharingOn = isConnectionSharingEnabled();
+    const credentialPlan: WorkflowCredentialPlan | null = sharingOn
+      ? await buildWorkflowCredentialPlan({
+          workflowId: input.workflowId,
+          accountId: workflow.accountId,
+          createdByUserId: workflow.createdByUserId,
+          nodes: def.nodes,
+        })
+      : null;
+    const acceptedNodeOwners = sharingOn ? null : await loadAcceptedNodeOwners(input.workflowId);
 
     for (const node of order) {
       // Skip nodes that no activated edge has reached. The trigger is
@@ -540,12 +559,14 @@ export class WorkflowEngine {
       // service providers ignore the owner and stay account-shared. The handler's
       // `userId` stays the creator — it is provenance/billing only, never used for
       // integration lookups (see handlers/types.ts).
-      const effectiveOwner = effectiveCredentialOwner({
-        provider: node.provider,
-        nodeId: node.id,
-        creatorUserId: workflow.createdByUserId,
-        acceptedOwners: acceptedNodeOwners,
-      });
+      const effectiveOwner = credentialPlan
+        ? (credentialPlan.ownerByNode.get(node.id) ?? workflow.createdByUserId)
+        : effectiveCredentialOwner({
+            provider: node.provider,
+            nodeId: node.id,
+            creatorUserId: workflow.createdByUserId,
+            acceptedOwners: acceptedNodeOwners!,
+          });
       try {
         const result = await runWithCredentialResolutionContext(
           { createdByUserId: effectiveOwner },

--- a/services/integrations/connectionBinding.ts
+++ b/services/integrations/connectionBinding.ts
@@ -10,8 +10,10 @@ import {
   setForNodeServiceRole,
   deleteForNodeServiceRole,
   listByWorkflowServiceRole,
+  getForNodeServiceRole,
 } from "@/repositories/workflowNodeConnectorBindings";
 import { isPrivateCredentialProvider } from "@/core/integrations/workflowCredentialScope";
+import { loadAcceptedNodeOwners } from "@/services/teamCredentials/nodeCredentialOwners";
 import { listMembers } from "@/services/accounts/membership";
 import { isConnectionSharingEnabled } from "./connectionSharingFlags";
 
@@ -220,6 +222,100 @@ export async function listEligibleSharedConnectors(input: {
     .filter((m) => sharedSet.has(m.userId))
     .map((m) => ({ userId: m.userId, displayName: m.displayName, role: m.role }));
   return { ok: true, connectors };
+}
+
+/**
+ * The builder's per-node connector-binding STATE (Slice 4.CONN-SHARE / CS-5b) —
+ * the single read the config-modal picker uses. Editor-gated (same as set/clear).
+ *
+ * Status precedence mirrors the CS-4b resolver so the UI and execution agree:
+ *   - `not_applicable` — account/native provider, OR an accepted node-credential
+ *     grant owns the node (the reassignment UI covers it; the binding picker hides).
+ *   - `bound` — a VALID binding (the bound connector is still in the live shared
+ *     set). `currentConnectorDisplayName` names them.
+ *   - `unavailable` — a STALE binding (connector unshared/disconnected/left), OR no
+ *     member shares this provider at all. The UI must offer a re-pick; it must NEVER
+ *     silently switch to another connector.
+ *   - `single_sharer` — exactly one shared connector, auto-resolved (no picker
+ *     required); `currentConnectorDisplayName` names them.
+ *   - `needs_selection` — 2+ shared connectors and no valid binding → show the picker.
+ *
+ * No-leak: returns the status enum + the safe `{ userId, displayName, role }`
+ * options (same shape eligible-targets already exposes) + a display name. Never a
+ * token, provider account id, email, scope, or account metadata.
+ */
+export async function getNodeConnectorBindingState(input: {
+  workflowId: string;
+  nodeId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<
+  | {
+      ok: true;
+      status: "not_applicable" | "single_sharer" | "needs_selection" | "bound" | "unavailable";
+      connectors: readonly SharedConnectorOption[];
+      currentConnectorDisplayName: string | null;
+    }
+  | { ok: false; reason: ConnectorBindingReason }
+> {
+  if (!isConnectionSharingEnabled()) return fail("not_enabled");
+
+  const gate = await resolveBindableNode(input);
+  if (!gate.ok) {
+    // Account/service + native nodes are a valid "nothing to bind" STATE for the
+    // builder (200), not an error — the picker simply renders nothing.
+    if (gate.reason === "not_applicable") {
+      return { ok: true, status: "not_applicable", connectors: [], currentConnectorDisplayName: null };
+    }
+    return gate;
+  }
+  const { accountId, provider } = gate;
+
+  // An accepted per-node credential grant WINS over a connection binding — the
+  // reassignment UI owns that node; the connector picker stays out of the way.
+  const acceptedOwners = await loadAcceptedNodeOwners(input.workflowId);
+  if (acceptedOwners.get(input.nodeId)) {
+    return { ok: true, status: "not_applicable", connectors: [], currentConnectorDisplayName: null };
+  }
+
+  const [sharedSet, members, binding] = await Promise.all([
+    listSharedConnectorUserIdsServiceRole(accountId, provider),
+    listMembers(accountId),
+    getForNodeServiceRole(input.workflowId, input.nodeId),
+  ]);
+  const nameByUser = new Map(members.map((m) => [m.userId, m.displayName]));
+  const connectors: SharedConnectorOption[] = members
+    .filter((m) => sharedSet.has(m.userId))
+    .map((m) => ({ userId: m.userId, displayName: m.displayName, role: m.role }));
+
+  const bindingConnector =
+    binding && binding.provider === provider ? binding.connectorUserId : null;
+
+  if (bindingConnector !== null && sharedSet.has(bindingConnector)) {
+    return {
+      ok: true,
+      status: "bound",
+      connectors,
+      currentConnectorDisplayName: nameByUser.get(bindingConnector) ?? null,
+    };
+  }
+  if (bindingConnector !== null) {
+    // Stale binding — the connector unshared / disconnected / left. Never resolve
+    // to anyone else; the UI prompts a re-pick.
+    return { ok: true, status: "unavailable", connectors, currentConnectorDisplayName: null };
+  }
+  if (sharedSet.size === 0) {
+    return { ok: true, status: "unavailable", connectors, currentConnectorDisplayName: null };
+  }
+  if (sharedSet.size === 1) {
+    return {
+      ok: true,
+      status: "single_sharer",
+      connectors,
+      currentConnectorDisplayName: connectors[0]?.displayName ?? null,
+    };
+  }
+  return { ok: true, status: "needs_selection", connectors, currentConnectorDisplayName: null };
 }
 
 /**

--- a/services/integrations/connectionBinding.ts
+++ b/services/integrations/connectionBinding.ts
@@ -1,0 +1,254 @@
+import type { MembershipRole } from "@/contracts/accounts";
+import * as workflowsRepo from "@/repositories/workflows";
+import * as accountsRepo from "@/repositories/accounts";
+import { isMemberServiceRole } from "@/repositories/accountMemberships";
+import {
+  getActiveForExecution,
+  listSharedConnectorUserIdsServiceRole,
+} from "@/repositories/integrations";
+import {
+  setForNodeServiceRole,
+  deleteForNodeServiceRole,
+  listByWorkflowServiceRole,
+} from "@/repositories/workflowNodeConnectorBindings";
+import { isPrivateCredentialProvider } from "@/core/integrations/workflowCredentialScope";
+import { listMembers } from "@/services/accounts/membership";
+import { isConnectionSharingEnabled } from "./connectionSharingFlags";
+
+/**
+ * Node connector binding service (Slice 4.CONN-SHARE / CS-4a).
+ *
+ * Backend-only chokepoint to bind a workflow node to a SPECIFIC connector whose
+ * personal connection is explicitly `shared_with_account` — the §14.3 multi-sharer
+ * disambiguation. The route layer authenticates + membership-gates (404 no-leak)
+ * and passes the caller's resolved role; this service owns the fine-grained rules
+ * and the server-side validation a client can never forge.
+ *
+ * BEHAVIOR-INERT: CS-4a only STORES + LISTS bindings. Nothing reads them at
+ * resolve/run time yet — execution resolver, run/edit gate, CS-3a eligibility
+ * live path, workflow DTO booleans, Apps/builder UI, Disconnect/Reconnect,
+ * workflow_node_credentials are all untouched. CS-4b wires the precedence
+ * (accepted node-credential grant → valid connector binding → single-sharer →
+ * creator; ambiguous-no-binding fails closed) and the run/edit gate IN LOCKSTEP.
+ *
+ * Security invariants:
+ *   - Flag-gated (`ENABLE_CONNECTION_SHARING`, default OFF) ⇒ `not_enabled`.
+ *   - "No silent share" is STRUCTURAL: a binding can ONLY point to a connector
+ *     already in the live shared set for that provider — owner/admin cannot bind
+ *     to an unshared identity (`connector_not_shared`).
+ *   - Account/service + native providers are never bindable (`not_applicable`).
+ *   - The node + provider are re-verified from the workflow definition; the draft
+ *     definition is NEVER mutated.
+ *   - No OAuth token, provider account label, email, scope, or account metadata is
+ *     read or returned — only display names (member identity RPC) + opaque user ids.
+ */
+
+export type ConnectorBindingReason =
+  | "not_enabled"
+  | "workflow_not_found"
+  | "node_not_found"
+  | "not_applicable"
+  | "account_frozen"
+  | "forbidden"
+  | "connector_not_member"
+  | "connector_not_connected"
+  | "connector_not_shared";
+
+export type SetBindingResult = { ok: true } | { ok: false; reason: ConnectorBindingReason };
+export type ClearBindingResult =
+  | { ok: true; cleared: boolean }
+  | { ok: false; reason: ConnectorBindingReason };
+
+/** Safe picker option — reuses the eligible-targets shape (no email/label/token). */
+export interface SharedConnectorOption {
+  readonly userId: string;
+  readonly displayName: string | null;
+  readonly role: MembershipRole;
+}
+export type EligibleConnectorsResult =
+  | { ok: true; connectors: readonly SharedConnectorOption[] }
+  | { ok: false; reason: ConnectorBindingReason };
+
+/** Safe per-node binding view (display name + opaque user id; no identity detail). */
+export interface NodeBindingView {
+  readonly nodeId: string;
+  readonly provider: string;
+  readonly connectorUserId: string;
+  readonly connectorDisplayName: string | null;
+}
+export type WorkflowBindingsResult =
+  | { ok: true; bindings: readonly NodeBindingView[] }
+  | { ok: false; reason: ConnectorBindingReason };
+
+function fail<T extends { ok: false; reason: ConnectorBindingReason }>(
+  reason: ConnectorBindingReason,
+): T {
+  return { ok: false, reason } as T;
+}
+
+async function loadWorkflow(workflowId: string) {
+  const wf = await workflowsRepo.getByIdServiceRole(workflowId);
+  if (!wf || wf.state === "deleted") return null;
+  return wf;
+}
+
+async function isFrozen(accountId: string): Promise<boolean> {
+  return (await accountsRepo.getDeletionStatusServiceRole(accountId)) === "pending_deletion";
+}
+
+function isOwnerAdmin(role: MembershipRole): boolean {
+  return role === "owner" || role === "admin";
+}
+
+/** Caller may edit the workflow: owner/admin, or the workflow creator. (CS-4a does NOT widen this.) */
+function mayEdit(role: MembershipRole, callerUserId: string, createdByUserId: string): boolean {
+  return isOwnerAdmin(role) || callerUserId === createdByUserId;
+}
+
+/**
+ * Resolve + authorize a node for a binding mutation/read. Returns the workflow +
+ * the personal provider of the node, or a typed failure.
+ */
+async function resolveBindableNode(input: {
+  workflowId: string;
+  nodeId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<
+  | { ok: true; accountId: string; provider: string }
+  | { ok: false; reason: ConnectorBindingReason }
+> {
+  const wf = await loadWorkflow(input.workflowId);
+  if (!wf) return { ok: false, reason: "workflow_not_found" };
+
+  const node = wf.draftDefinition.nodes.find((n) => n.id === input.nodeId);
+  if (!node) return { ok: false, reason: "node_not_found" };
+  // Bindable = private-credential provider: personal AND not a native pseudo-
+  // provider (isPrivateCredentialProvider excludes `native` via NON_OAUTH_PROVIDERS;
+  // account/service providers are also excluded — both → not_applicable).
+  if (!node.provider || !isPrivateCredentialProvider(node.provider)) {
+    return { ok: false, reason: "not_applicable" };
+  }
+  if (await isFrozen(wf.accountId)) return { ok: false, reason: "account_frozen" };
+  if (!mayEdit(input.callerRole, input.callerUserId, wf.createdByUserId)) {
+    return { ok: false, reason: "forbidden" };
+  }
+  return { ok: true, accountId: wf.accountId, provider: node.provider };
+}
+
+/**
+ * Bind `connectorUserId`'s shared connection to a node. The connector must be a
+ * member, have an active connection, AND be in the live `shared_with_account` set
+ * for the provider — so an unshared identity can NEVER be bound (the no-silent-
+ * share fence). Upserts (replaces any existing binding for the node).
+ */
+export async function setNodeConnectorBinding(input: {
+  workflowId: string;
+  nodeId: string;
+  connectorUserId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<SetBindingResult> {
+  if (!isConnectionSharingEnabled()) return fail("not_enabled");
+
+  const gate = await resolveBindableNode(input);
+  if (!gate.ok) return gate;
+  const { accountId, provider } = gate;
+
+  if (!(await isMemberServiceRole(accountId, input.connectorUserId))) {
+    return fail("connector_not_member");
+  }
+  // Presence-only active-connection check (no token/label read).
+  const active = await getActiveForExecution(accountId, provider, null, {
+    connectedByUserId: input.connectorUserId,
+  });
+  if (active === null) return fail("connector_not_connected");
+
+  // Authoritative shared-set membership (active + shared_with_account; CS-3a).
+  const sharedSet = await listSharedConnectorUserIdsServiceRole(accountId, provider);
+  if (!sharedSet.has(input.connectorUserId)) return fail("connector_not_shared");
+
+  await setForNodeServiceRole({
+    workflowId: input.workflowId,
+    nodeId: input.nodeId,
+    provider,
+    connectorUserId: input.connectorUserId,
+    createdByUserId: input.callerUserId,
+  });
+  return { ok: true };
+}
+
+/** Remove a node's connector binding. Idempotent. */
+export async function clearNodeConnectorBinding(input: {
+  workflowId: string;
+  nodeId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<ClearBindingResult> {
+  if (!isConnectionSharingEnabled()) return fail("not_enabled");
+
+  const gate = await resolveBindableNode(input);
+  if (!gate.ok) return gate;
+
+  const { deleted } = await deleteForNodeServiceRole(input.workflowId, input.nodeId);
+  return { ok: true, cleared: deleted };
+}
+
+/**
+ * Eligible shared connectors for a node's provider — the safe picker. Reuses the
+ * `{ userId, displayName, role }` shape (display name via the member identity RPC;
+ * never email/provider account/token/scope). Editor-gated (reveals connection
+ * status), mirroring the credential-owner eligible-targets endpoint.
+ */
+export async function listEligibleSharedConnectors(input: {
+  workflowId: string;
+  nodeId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<EligibleConnectorsResult> {
+  if (!isConnectionSharingEnabled()) return fail("not_enabled");
+
+  const gate = await resolveBindableNode(input);
+  if (!gate.ok) return gate;
+  const { accountId, provider } = gate;
+
+  const [sharedSet, members] = await Promise.all([
+    listSharedConnectorUserIdsServiceRole(accountId, provider),
+    listMembers(accountId),
+  ]);
+  const connectors: SharedConnectorOption[] = members
+    .filter((m) => sharedSet.has(m.userId))
+    .map((m) => ({ userId: m.userId, displayName: m.displayName, role: m.role }));
+  return { ok: true, connectors };
+}
+
+/**
+ * List a workflow's node connector bindings as a safe view (display name + opaque
+ * user id; no identity detail). Editor-gated.
+ */
+export async function listWorkflowConnectorBindings(input: {
+  workflowId: string;
+  callerUserId: string;
+  callerRole: MembershipRole;
+}): Promise<WorkflowBindingsResult> {
+  if (!isConnectionSharingEnabled()) return fail("not_enabled");
+
+  const wf = await loadWorkflow(input.workflowId);
+  if (!wf) return fail("workflow_not_found");
+  if (!mayEdit(input.callerRole, input.callerUserId, wf.createdByUserId)) return fail("forbidden");
+
+  const [bindings, members] = await Promise.all([
+    listByWorkflowServiceRole(input.workflowId),
+    listMembers(wf.accountId),
+  ]);
+  const nameByUser = new Map(members.map((m) => [m.userId, m.displayName]));
+  return {
+    ok: true,
+    bindings: bindings.map((b) => ({
+      nodeId: b.nodeId,
+      provider: b.provider,
+      connectorUserId: b.connectorUserId,
+      connectorDisplayName: nameByUser.get(b.connectorUserId) ?? null,
+    })),
+  };
+}

--- a/services/integrations/connectionResolution.ts
+++ b/services/integrations/connectionResolution.ts
@@ -1,0 +1,100 @@
+import { isPrivateCredentialProvider } from "@/core/integrations/workflowCredentialScope";
+import { resolveNodeOwner, type NodeOwnerResolution } from "@/core/integrations/sharingEligibility";
+import { loadAcceptedNodeOwners } from "@/services/teamCredentials/nodeCredentialOwners";
+import { listByWorkflowServiceRole } from "@/repositories/workflowNodeConnectorBindings";
+import { listSharedConnectorUserIdsServiceRole } from "@/repositories/integrations";
+
+/**
+ * Shared workflow credential plan (Slice 4.CONN-SHARE / CS-4b).
+ *
+ * THE single computation the run/edit GATE and the execution ENGINE both consume,
+ * so they can never drift. For every PERSONAL-provider node it resolves the
+ * effective owner via the locked precedence (accepted grant → valid binding →
+ * single-sharer → creator; see `resolveNodeOwner`) and whether the node is
+ * team-runnable.
+ *
+ * - The GATE allows a non-creator iff `allTeamRunnable` (every personal node
+ *   resolves to a specific shared connector).
+ * - The ENGINE sets each node's credential-resolution context to
+ *   `ownerByNode.get(node.id) ?? creator` — the SAME owner the gate validated.
+ *
+ * ONLY called when `ENABLE_CONNECTION_SHARING` is ON (the caller checks the flag);
+ * the flag-OFF path keeps the exact pre-CS-4b behavior and never reaches here.
+ *
+ * No-leak: returns user ids for INTERNAL resolution only (the engine pins by user;
+ * the gate reads booleans). It is never serialized to a client — the run/edit DTO
+ * exposes only `viewerCanRunEdit`. Reads select no token/scope/label/metadata.
+ */
+
+export interface WorkflowCredentialPlan {
+  /** nodeId → effective owner user id (PERSONAL-provider nodes only). */
+  readonly ownerByNode: ReadonlyMap<string, string>;
+  /** nodeId → full resolution detail (PERSONAL-provider nodes only). */
+  readonly resolutions: ReadonlyMap<string, NodeOwnerResolution>;
+  /** Every personal-provider node resolves to a specific shared connector. */
+  readonly allTeamRunnable: boolean;
+}
+
+interface PlanInputNode {
+  readonly id: string;
+  readonly provider: string;
+}
+
+/**
+ * Build the plan for a workflow's nodes. Gathers — once — the accepted per-node
+ * grants (flag-gated inside `loadAcceptedNodeOwners`), the node connector
+ * bindings, and the per-provider shared-connector sets, then applies the pure
+ * precedence per personal node.
+ */
+export async function buildWorkflowCredentialPlan(input: {
+  workflowId: string;
+  accountId: string;
+  createdByUserId: string;
+  nodes: readonly PlanInputNode[];
+}): Promise<WorkflowCredentialPlan> {
+  const personalNodes = input.nodes.filter(
+    (n) => n.provider && isPrivateCredentialProvider(n.provider),
+  );
+  if (personalNodes.length === 0) {
+    return { ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: true };
+  }
+
+  const distinctProviders = [...new Set(personalNodes.map((n) => n.provider))];
+
+  const [acceptedOwners, bindings, sharedSetEntries] = await Promise.all([
+    loadAcceptedNodeOwners(input.workflowId),
+    listByWorkflowServiceRole(input.workflowId),
+    Promise.all(
+      distinctProviders.map(
+        async (provider) =>
+          [provider, await listSharedConnectorUserIdsServiceRole(input.accountId, provider)] as const,
+      ),
+    ),
+  ]);
+
+  const sharedByProvider = new Map(sharedSetEntries);
+  // Binding is per-node; only honor it when its provider still matches the node.
+  const bindingByNode = new Map(bindings.map((b) => [b.nodeId, b]));
+
+  const ownerByNode = new Map<string, string>();
+  const resolutions = new Map<string, NodeOwnerResolution>();
+  let allTeamRunnable = true;
+
+  for (const node of personalNodes) {
+    const binding = bindingByNode.get(node.id);
+    const bindingConnector =
+      binding && binding.provider === node.provider ? binding.connectorUserId : null;
+
+    const resolution = resolveNodeOwner({
+      creatorUserId: input.createdByUserId,
+      acceptedGrantOwner: acceptedOwners.get(node.id) ?? null,
+      bindingConnector,
+      sharedConnectors: sharedByProvider.get(node.provider) ?? new Set<string>(),
+    });
+    ownerByNode.set(node.id, resolution.owner);
+    resolutions.set(node.id, resolution);
+    if (!resolution.teamRunnable) allTeamRunnable = false;
+  }
+
+  return { ownerByNode, resolutions, allTeamRunnable };
+}

--- a/services/integrations/connectionSharing.ts
+++ b/services/integrations/connectionSharing.ts
@@ -1,0 +1,160 @@
+import {
+  getByIdForAccountServiceRole,
+  setSharingScopeByIdServiceRole,
+} from "@/repositories/integrations";
+import * as accountsRepo from "@/repositories/accounts";
+import { getRoleServiceRole } from "@/repositories/accountMemberships";
+import {
+  effectiveIntegrationSharingScope,
+  isProviderShareable,
+  type IntegrationSharingScope,
+} from "@/core/integrations/sharingScope";
+import { isConnectionSharingEnabled } from "./connectionSharingFlags";
+
+/**
+ * Explicit private-connection sharing service (Slice 4.CONN-SHARE / CS-2).
+ *
+ * Backend-only, single authorized chokepoint for flipping a PERSONAL connection
+ * between `private_to_connector` and `shared_with_account`. The route layer is
+ * thin: authenticate → call this → map a typed reason. Mirrors the disconnect
+ * service's resolve→authorize→typed-reason→no-leak-audit shape.
+ *
+ * BEHAVIOR-INERT beyond the column write: this slice writes ONLY
+ * `integration_sharing_scope`. Nothing downstream reads it yet — the run/edit
+ * gate, execution resolver, workflow DTO booleans, Apps UI, builder, Disconnect,
+ * Reconnect, and workflow_node_credentials are all untouched. CS-3+ wire it.
+ *
+ * Authorization (locked model — plan §0.4/§0.5):
+ *   - SHARE (`shared_with_account`): the CONNECTOR ONLY
+ *     (`connected_by_user_id === caller`). Owner/admin may NOT silently share a
+ *     member's personal external identity (impersonation) ⇒ `forbidden`.
+ *   - UNSHARE (`private_to_connector`): the connector, OR owner/admin as a FRAMED
+ *     admin safety/removal action (audit-logged via a distinct event). A plain
+ *     non-connector member ⇒ `forbidden`. Unshare is a restriction, never a way
+ *     to toggle someone's identity INTO shared.
+ *   - Account/service providers are shared by classification ⇒
+ *     `account_provider_not_shareable` (nothing for this feature to do).
+ *   - Non-member / cross-account / unknown / disconnected ⇒ `not_found` (no
+ *     existence or ownership inference).
+ *
+ * Flag gate runs FIRST and does zero I/O when OFF, so a disabled feature mutates
+ * nothing and leaks nothing (every caller gets the same `not_enabled`).
+ *
+ * No-leak: returns only a safe scope enum + booleans; never a token, scope list,
+ * provider_account_id, email, account metadata, or connector id. Audit events
+ * carry ids + provider slug (+ actor role on the admin path) only — never a user
+ * id, token, or raw error.
+ */
+
+export type SetSharingFailureReason =
+  | "not_enabled"
+  | "account_frozen"
+  | "not_found"
+  | "forbidden"
+  | "account_provider_not_shareable";
+
+export type SetSharingResult =
+  | { ok: true; scope: IntegrationSharingScope; changed: boolean }
+  | { ok: false; reason: SetSharingFailureReason };
+
+export interface SetSharingInput {
+  accountId: string;
+  integrationId: string;
+  callerUserId: string;
+  scope: IntegrationSharingScope;
+}
+
+function audit(event: string, payload: Record<string, string | number>): void {
+  // Structured-log audit (the V2 convention — no audit table). Ids/provider/role
+  // only; NEVER a token, scope, metadata, display name, connector id, or error.
+  console.info(JSON.stringify({ event, ...payload }));
+}
+
+/**
+ * Set the sharing scope on one personal connection. See the module doc for the
+ * full authorization + no-leak contract.
+ */
+export async function setIntegrationSharingScope(
+  input: SetSharingInput,
+): Promise<SetSharingResult> {
+  // 0. Temporary dev guard. OFF ⇒ no DB call, no mutation, uniform reason.
+  if (!isConnectionSharingEnabled()) {
+    return { ok: false, reason: "not_enabled" };
+  }
+
+  // 1. Frozen account fails safe (mirrors disconnect / member-management).
+  const status = await accountsRepo.getDeletionStatusServiceRole(input.accountId);
+  if (status === "pending_deletion") {
+    return { ok: false, reason: "account_frozen" };
+  }
+
+  // 2. Exact (id, account_id) scope ⇒ cross-account / unknown id is null.
+  const row = await getByIdForAccountServiceRole(input.accountId, input.integrationId);
+  if (!row) return { ok: false, reason: "not_found" };
+
+  // 3. Non-members can't infer the row exists ⇒ not_found (no existence leak).
+  const callerRole = await getRoleServiceRole(input.accountId, input.callerUserId);
+  if (callerRole === null) return { ok: false, reason: "not_found" };
+
+  // 4. A disconnected row carries no usable credential and is never mutated.
+  //    Collapse to not_found so its existence/state is not revealed.
+  if (row.disconnectedAt !== null) return { ok: false, reason: "not_found" };
+
+  // 5. Account/service providers are account-shared by classification — there is
+  //    nothing for explicit sharing to flip. (Provider class is not sensitive;
+  //    this is reached only by a verified member, after the not_found gate.)
+  if (!isProviderShareable(row.provider)) {
+    return { ok: false, reason: "account_provider_not_shareable" };
+  }
+
+  // 6. Authorize by direction.
+  const isConnector =
+    row.connectedByUserId !== null && row.connectedByUserId === input.callerUserId;
+  const isOwnerAdmin = callerRole === "owner" || callerRole === "admin";
+
+  if (input.scope === "shared_with_account") {
+    // SHARE: connector only. Owner/admin may NOT silently share a member's identity.
+    if (!isConnector) return { ok: false, reason: "forbidden" };
+  } else {
+    // UNSHARE: connector, OR owner/admin as a framed admin safety action.
+    if (!isConnector && !isOwnerAdmin) return { ok: false, reason: "forbidden" };
+  }
+
+  // 7. Mutate. shared_with_account writes the literal; private_to_connector
+  //    clears to NULL (the derived default). The repo guards disconnected_at IS
+  //    NULL, so a row disconnected mid-flight yields updated:false ⇒ not_found.
+  const targetColumn = input.scope === "shared_with_account" ? "shared_with_account" : null;
+  const before = effectiveIntegrationSharingScope(row.provider, row.integrationSharingScope);
+  const { updated } = await setSharingScopeByIdServiceRole({
+    integrationId: input.integrationId,
+    scope: targetColumn,
+  });
+  if (!updated) return { ok: false, reason: "not_found" };
+
+  const changed = before !== input.scope;
+
+  // 8. Audit. Distinct event for the owner/admin safety unshare (the framed,
+  //    audit-logged admin action) vs the connector's own toggle.
+  const adminSafetyUnshare = input.scope === "private_to_connector" && !isConnector && isOwnerAdmin;
+  if (adminSafetyUnshare) {
+    audit("account.integration.sharing.admin_unshared", {
+      accountId: input.accountId,
+      integrationId: input.integrationId,
+      provider: row.provider,
+      actorRole: callerRole,
+    });
+  } else {
+    audit(
+      input.scope === "shared_with_account"
+        ? "account.integration.sharing.shared"
+        : "account.integration.sharing.unshared",
+      {
+        accountId: input.accountId,
+        integrationId: input.integrationId,
+        provider: row.provider,
+      },
+    );
+  }
+
+  return { ok: true, scope: input.scope, changed };
+}

--- a/services/integrations/connectionSharingEligibility.ts
+++ b/services/integrations/connectionSharingEligibility.ts
@@ -1,0 +1,74 @@
+import type { WorkflowDefinition } from "@/contracts/workflowDefinition";
+import { listSharedConnectorUserIdsServiceRole } from "@/repositories/integrations";
+import {
+  computeRunEditEligibility,
+  distinctPrivateProviders,
+  type RunEditEligibilityResult,
+} from "@/core/integrations/sharingEligibility";
+import { isConnectionSharingEnabled } from "./connectionSharingFlags";
+
+/**
+ * Ambiguity-aware run/edit eligibility service (Slice 4.CONN-SHARE / CS-3a).
+ *
+ * Narrow read layer over the pure `computeRunEditEligibility`: it fetches the
+ * per-provider distinct shared-connector COUNT and hands it to the pure core. It
+ * returns ONLY the safe `RunEditEligibilityResult` (allowed + reason + provider
+ * slug/status views) — the connector user ids read from the repository are
+ * consumed as `.size` and NEVER returned to a caller.
+ *
+ * BEHAVIOR-INERT: no live run/edit path calls this in CS-3a. While
+ * `ENABLE_CONNECTION_SHARING` is OFF this does ZERO DB I/O and returns the exact
+ * WF-RUNPERM decision (the pure core delegates to `viewerMayRunEdit`). CS-3b
+ * wires this into the gate behind the flag.
+ */
+
+export interface WorkflowSharingEligibilityInput {
+  accountId: string;
+  definition: WorkflowDefinition;
+  createdByUserId: string | null;
+  callerUserId: string;
+}
+
+export async function computeWorkflowSharingEligibility(
+  input: WorkflowSharingEligibilityInput,
+): Promise<RunEditEligibilityResult> {
+  const flagEnabled = isConnectionSharingEnabled();
+
+  // Flag OFF → no DB read; pure WF-RUNPERM via the core helper.
+  if (!flagEnabled) {
+    return computeRunEditEligibility({
+      definition: input.definition,
+      createdByUserId: input.createdByUserId,
+      callerUserId: input.callerUserId,
+      sharedConnectorCountByProvider: new Map(),
+      flagEnabled: false,
+    });
+  }
+
+  // Only read shared-connector counts when they can change the outcome: the
+  // workflow has private providers AND the caller is NOT the creator. (The pure
+  // core short-circuits creator / no-private too, but skipping the DB read here
+  // keeps the common cases free.)
+  const isCreator =
+    input.createdByUserId !== null && input.createdByUserId === input.callerUserId;
+  const privateProviders = distinctPrivateProviders(input.definition);
+
+  let counts: ReadonlyMap<string, number> = new Map();
+  if (!isCreator && privateProviders.length > 0) {
+    const entries = await Promise.all(
+      privateProviders.map(async (provider) => {
+        const ids = await listSharedConnectorUserIdsServiceRole(input.accountId, provider);
+        return [provider, ids.size] as const;
+      }),
+    );
+    counts = new Map(entries);
+  }
+
+  return computeRunEditEligibility({
+    definition: input.definition,
+    createdByUserId: input.createdByUserId,
+    callerUserId: input.callerUserId,
+    sharedConnectorCountByProvider: counts,
+    flagEnabled: true,
+  });
+}

--- a/services/integrations/connectionSharingFlags.ts
+++ b/services/integrations/connectionSharingFlags.ts
@@ -1,0 +1,27 @@
+/**
+ * Explicit connection-sharing rollout flag (Slice 4.CONN-SHARE / CS-1).
+ *
+ * Read at call time (not module load) so tests + rollout can toggle without
+ * re-importing — mirrors services/teamCredentials/flags.ts and
+ * services/accounts/accountDeletionFlags.ts.
+ *
+ * TEMPORARY dev guard, NOT a permanently-hidden feature (plan §0.9): it exists
+ * so the CS-2+ slices (toggle service, run/edit gate, execution resolver, Apps
+ * surface) can land inert while in flight, and is flipped on — or removed — once
+ * the arc is complete and verified. Default OFF.
+ *
+ * CS-1 NEVER calls this. The column + pure helpers CS-1 ships are behavior-inert;
+ * this accessor exists only for the slices that follow, which stay dark until it
+ * is deliberately enabled and production-verified.
+ */
+
+/** Env var gating explicit connection-sharing behavior. */
+export const CONNECTION_SHARING_FLAG = "ENABLE_CONNECTION_SHARING";
+
+/**
+ * DEFAULT OFF. When false, every later connection-sharing path is inert
+ * (personal-provider connections stay private_to_connector exactly as today).
+ */
+export function isConnectionSharingEnabled(): boolean {
+  return process.env[CONNECTION_SHARING_FLAG] === "true";
+}

--- a/supabase/migrations/20260622000000_add_integration_sharing_scope.sql
+++ b/supabase/migrations/20260622000000_add_integration_sharing_scope.sql
@@ -1,0 +1,39 @@
+-- ChainReactV2 — explicit private-connection sharing scope on integrations
+-- (Slice 4.CONN-SHARE / CS-1).
+--
+-- Additive, null-safe SCHEMA ONLY. BEHAVIOR-INERT: NO runtime path reads this
+-- column yet — the run/edit gate, execution resolver, Apps DTO/UI, Disconnect,
+-- Reconnect, and workflow_node_credentials are all untouched. Wiring lands in
+-- later slices (CS-2+) behind the ENABLE_CONNECTION_SHARING dev guard.
+--
+-- Model (locked — see docs/slices/phase-4/explicit-private-connection-sharing-plan.md §0):
+--   - Sharing controls USAGE, not ownership. `account_id` still owns the row;
+--     `connected_by_user_id` stays provenance.
+--   - `integration_sharing_scope` is meaningful ONLY for PERSONAL-credential
+--     providers. Account/service providers (slack/notion/stripe/…) are shared by
+--     classification and IGNORE this column.
+--   - NULL = derive the default from classification (personal → private_to_connector).
+--     No backfill: existing rows stay NULL and read as private_to_connector.
+--
+-- Changes:
+--   1. Add nullable `integration_sharing_scope text`.
+--   2. Add CHECK: NULL allowed (the unset / derive-default state), else exactly
+--      one of the two known values.
+--
+-- No RLS change — `integrations` already enforces account-membership RLS and the
+-- additive column inherits it; it adds no new row visibility. No new GRANT —
+-- `integrations` is an existing (grandfathered) table.
+--
+-- ROLLBACK:
+--   ALTER TABLE public.integrations DROP CONSTRAINT integrations_sharing_scope_chk;
+--   ALTER TABLE public.integrations DROP COLUMN integration_sharing_scope;
+
+ALTER TABLE public.integrations
+  ADD COLUMN integration_sharing_scope text;
+
+ALTER TABLE public.integrations
+  ADD CONSTRAINT integrations_sharing_scope_chk
+  CHECK (
+    integration_sharing_scope IS NULL
+    OR integration_sharing_scope IN ('private_to_connector', 'shared_with_account')
+  );

--- a/supabase/migrations/20260623000000_workflow_node_connector_bindings.sql
+++ b/supabase/migrations/20260623000000_workflow_node_connector_bindings.sql
@@ -1,0 +1,107 @@
+-- ChainReactV2 — node connector binding foundation (Slice 4.CONN-SHARE / CS-4a).
+--
+-- Schema-only foundation per docs/slices/phase-4/explicit-private-connection-sharing-plan.md
+-- §15. Adds STRUCTURE only; it never reads, backfills, or rewrites an existing
+-- row, and it CHANGES NO RUNTIME BEHAVIOR.
+--
+-- public.workflow_node_connector_bindings — a side table holding, per
+-- (workflow, node), the specific CONNECTOR USER whose explicitly-shared personal
+-- connection that node should run under once row-level sharing resolves (the
+-- §14.3 multi-sharer disambiguation). It is DISTINCT from workflow_node_credentials:
+--   - workflow_node_credentials = CONSENT-grant (requester-pull, pending→accepted).
+--   - this table              = direct CONNECTOR-PUSH binding (connector already
+--                               consented by sharing; no status machine).
+-- The locked model (§0.3) keeps the two concepts separate — do NOT merge them.
+--
+-- Binds by connector_user_id (STABLE across reconnect — connected_by_user_id
+-- survives, the integration ROW id does not). NO status column: a binding is a
+-- direct pointer whose VALIDITY is recomputed at resolve time against the live
+-- shared set (CS-4b), never trusted from storage.
+--
+-- OUT OF SCOPE (later slices, intentionally absent here):
+--   - No execution resolution change (CS-4b extends effectiveCredentialOwner).
+--   - No run/edit gate change (CS-3b / CS-4b, in lockstep).
+--   - No builder/Apps UI (CS-5). No Disconnect/Reconnect change.
+--   - No change to workflows, integrations, draft_definition, or
+--     workflow_node_credentials. NO workflow.created_by_user_id change.
+--
+-- PROVIDER CLASSIFICATION IS NOT ENCODED IN SQL. personal (bindable) vs
+-- account/service (never bindable) lives in core/integrations/credentialSharing.ts
+-- and is enforced at the repository/service boundary — never duplicated here.
+--
+-- ROLLBACK (pre-launch, no prod data): DROP TABLE public.workflow_node_connector_bindings.
+
+CREATE TABLE public.workflow_node_connector_bindings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- The workflow whose node this binding belongs to. ON DELETE CASCADE: a binding
+  -- has no meaning without its workflow.
+  workflow_id uuid NOT NULL REFERENCES public.workflows(id) ON DELETE CASCADE,
+
+  -- Node id within workflows.draft_definition (the graph node). Stable across
+  -- edits/republish (the binding keys on it, NOT on definition contents).
+  node_id text NOT NULL,
+
+  -- Provider string for the node (e.g. 'gmail'). MUST be a personal-credential
+  -- provider — enforced in code (see header), not by a SQL provider list.
+  provider text NOT NULL,
+
+  -- The connector whose explicitly-shared personal connection this node runs
+  -- under. ON DELETE CASCADE: if the user is deleted the binding cannot resolve.
+  connector_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Who set the binding (the workflow editor). Provenance only — SET NULL if that
+  -- user is later deleted. Never used for authorization.
+  created_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- One binding per node (full unique — no status, so no partial predicate).
+CREATE UNIQUE INDEX workflow_node_connector_bindings_one_per_node
+  ON public.workflow_node_connector_bindings (workflow_id, node_id);
+
+-- Per-workflow read (builder/resolution read path, later slices).
+CREATE INDEX workflow_node_connector_bindings_workflow_idx
+  ON public.workflow_node_connector_bindings (workflow_id);
+
+-- Offboarding cleanup (CS-4b): "bindings pointing at a leaving connector".
+CREATE INDEX workflow_node_connector_bindings_connector_idx
+  ON public.workflow_node_connector_bindings (connector_user_id);
+
+CREATE TRIGGER workflow_node_connector_bindings_set_updated_at
+  BEFORE UPDATE ON public.workflow_node_connector_bindings
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ── RLS + GRANTs ─────────────────────────────────────────────────────────────
+--
+-- SELECT is membership-gated THROUGH the workflow's account (the table carries no
+-- account_id — it derives the account via workflows). The join also requires the
+-- account to be active (deletion_status = 'active'), so a frozen account never
+-- exposes its bindings. There is NO client INSERT/UPDATE/DELETE policy: every
+-- write is service-role (the binding service authorizes). Default-deny means a
+-- member can never self-bind a node by writing this table directly.
+
+ALTER TABLE public.workflow_node_connector_bindings ENABLE ROW LEVEL SECURITY;
+
+-- Data API access (explicit GRANTs required after Supabase removes implicit grants
+-- on public tables, Oct 30 2026). RLS still gates row visibility; authenticated
+-- may only SELECT (narrowed to member rows), service_role owns all writes.
+GRANT SELECT ON public.workflow_node_connector_bindings TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.workflow_node_connector_bindings TO service_role;
+
+CREATE POLICY workflow_node_connector_bindings_select_account_member
+  ON public.workflow_node_connector_bindings
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.workflows w
+      JOIN public.account_memberships am ON am.account_id = w.account_id
+      JOIN public.accounts a ON a.id = w.account_id
+      WHERE w.id = workflow_node_connector_bindings.workflow_id
+        AND am.user_id = auth.uid()
+        AND a.deletion_status = 'active'
+    )
+  );

--- a/tests/unit/app/api/accounts/integration-sharing.route.test.ts
+++ b/tests/unit/app/api/accounts/integration-sharing.route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment node
+ *
+ * Route tests for POST /api/accounts/[id]/integrations/[integrationId]/sharing
+ * (Slice 4.CONN-SHARE / CS-2). Mocks session auth + the sharing service; asserts
+ * the thin route's scope validation, the typed-error → HTTP mapping, the
+ * session-caller plumbing, and a sanitized response DTO. The authz matrix itself
+ * lives in the service test.
+ */
+const mockGetUser = jest.fn();
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(async () => ({ auth: { getUser: () => mockGetUser() } })),
+}));
+
+const mockSetSharing = jest.fn();
+jest.mock("@/services/integrations/connectionSharing", () => ({
+  setIntegrationSharingScope: (...a: unknown[]) => mockSetSharing(...a),
+}));
+
+import { POST } from "@/app/api/accounts/[id]/integrations/[integrationId]/sharing/route";
+
+const CALLER = "user-1";
+const ACCOUNT = "acc-1";
+const INTEGRATION = "int-1";
+
+function params() {
+  return { params: Promise.resolve({ id: ACCOUNT, integrationId: INTEGRATION }) };
+}
+function signedIn() {
+  mockGetUser.mockResolvedValueOnce({ data: { user: { id: CALLER } }, error: null });
+}
+function req(body: unknown) {
+  return new Request("http://x", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST integrations/[integrationId]/sharing", () => {
+  it("401 when unauthenticated — service not called", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    const res = await POST(req({ scope: "shared_with_account" }), params());
+    expect(res.status).toBe(401);
+    expect(mockSetSharing).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing scope", {}],
+    ["unknown scope", { scope: "public" }],
+    ["non-string scope", { scope: 1 }],
+    ["empty body", undefined],
+  ])("400 INVALID_SHARING_SCOPE for %s — service not called", async (_label, body) => {
+    signedIn();
+    const res = await POST(req(body), params());
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("INVALID_SHARING_SCOPE");
+    expect(mockSetSharing).not.toHaveBeenCalled();
+  });
+
+  it("200 share: passes session caller id + path ids + scope; returns {scope, shared:true, changed}", async () => {
+    signedIn();
+    mockSetSharing.mockResolvedValueOnce({ ok: true, scope: "shared_with_account", changed: true });
+    const res = await POST(req({ scope: "shared_with_account" }), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ scope: "shared_with_account", shared: true, changed: true });
+    expect(mockSetSharing).toHaveBeenCalledWith({
+      accountId: ACCOUNT,
+      integrationId: INTEGRATION,
+      callerUserId: CALLER,
+      scope: "shared_with_account",
+    });
+  });
+
+  it("200 unshare: returns {scope, shared:false, changed}", async () => {
+    signedIn();
+    mockSetSharing.mockResolvedValueOnce({ ok: true, scope: "private_to_connector", changed: false });
+    const res = await POST(req({ scope: "private_to_connector" }), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ scope: "private_to_connector", shared: false, changed: false });
+  });
+
+  it.each([
+    ["not_enabled", 404, "CONNECTION_SHARING_NOT_ENABLED"],
+    ["not_found", 404, "INTEGRATION_NOT_FOUND"],
+    ["forbidden", 403, "FORBIDDEN"],
+    ["account_frozen", 403, "ACCOUNT_PENDING_DELETION"],
+    ["account_provider_not_shareable", 422, "ACCOUNT_PROVIDER_NOT_SHAREABLE"],
+  ] as const)("maps service reason %s ⇒ %i %s", async (reason, status, code) => {
+    signedIn();
+    mockSetSharing.mockResolvedValueOnce({ ok: false, reason });
+    const res = await POST(req({ scope: "shared_with_account" }), params());
+    expect(res.status).toBe(status);
+    expect((await res.json()).code).toBe(code);
+  });
+
+  it("NO LEAK: success body has exactly {changed, scope, shared}, no token/provider detail", async () => {
+    signedIn();
+    mockSetSharing.mockResolvedValueOnce({ ok: true, scope: "shared_with_account", changed: true });
+    const res = await POST(req({ scope: "shared_with_account" }), params());
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual(["changed", "scope", "shared"]);
+    expect(JSON.stringify(body)).not.toMatch(/token|enc-|secret|provider_account|@/i);
+  });
+});

--- a/tests/unit/app/api/workflows/_shared.test.ts
+++ b/tests/unit/app/api/workflows/_shared.test.ts
@@ -62,11 +62,13 @@ describe("WF-RUNPERM — assertWorkflowRunEditAllowed", () => {
   const gmail = recordWith({ draftDefinition: { nodes: [node("gmail")], edges: [] } as never, createdByUserId: "creator-1" });
   const slack = recordWith({ draftDefinition: { nodes: [node("slack")], edges: [] } as never, createdByUserId: "creator-1" });
 
-  it("creator may run/edit a private-credential workflow → null (allowed)", () => {
-    expect(assertWorkflowRunEditAllowed(gmail, "creator-1")).toBeNull();
+  // These run with ENABLE_CONNECTION_SHARING unset (OFF) → the gate takes the
+  // flag-off branch, which is byte-identical WF-RUNPERM (now async).
+  it("creator may run/edit a private-credential workflow → null (allowed)", async () => {
+    expect(await assertWorkflowRunEditAllowed(gmail, "creator-1")).toBeNull();
   });
   it("non-creator (incl. owner/admin) blocked on private → typed 403 with SAFE copy", async () => {
-    const res = assertWorkflowRunEditAllowed(gmail, "other-member");
+    const res = await assertWorkflowRunEditAllowed(gmail, "other-member");
     expect(res).not.toBeNull();
     expect(res!.status).toBe(403);
     const body = await res!.json();
@@ -75,17 +77,17 @@ describe("WF-RUNPERM — assertWorkflowRunEditAllowed", () => {
     const serialized = JSON.stringify(body);
     expect(serialized).not.toMatch(/gmail|creator-1|token|email|scope/i);
   });
-  it("null-creator private workflow blocked for everyone", () => {
+  it("null-creator private workflow blocked for everyone", async () => {
     // createdByUserId is typed `string` (DB is ON DELETE SET NULL — a known
     // type-lie for the deleted-member edge); model the null at runtime via cast.
     const orphan = {
       ...recordWith({ draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
       createdByUserId: null,
     } as unknown as WorkflowRecord;
-    expect(assertWorkflowRunEditAllowed(orphan, "creator-1")).not.toBeNull();
+    expect(await assertWorkflowRunEditAllowed(orphan, "creator-1")).not.toBeNull();
   });
-  it("account-only workflow allowed for any member → null", () => {
-    expect(assertWorkflowRunEditAllowed(slack, "any-member")).toBeNull();
+  it("account-only workflow allowed for any member → null", async () => {
+    expect(await assertWorkflowRunEditAllowed(slack, "any-member")).toBeNull();
   });
 });
 

--- a/tests/unit/app/api/workflows/_shared.test.ts
+++ b/tests/unit/app/api/workflows/_shared.test.ts
@@ -95,17 +95,18 @@ describe("WF-RUNPERM — DTO booleans (no credential detail)", () => {
   const gmail = recordWith({ createdByUserId: "creator-1", draftDefinition: { nodes: [node("gmail")], edges: [] } as never });
   const slack = recordWith({ createdByUserId: "creator-1", draftDefinition: { nodes: [node("slack")], edges: [] } as never });
 
-  it("detail: creator gets usesPrivateCredential+viewerCanRunEdit; no createdByUserId leak", () => {
-    const d = toWorkflowDetail(gmail, "creator-1");
+  // toWorkflowDetail is now async (CS-5a). Flag OFF (env unset) → exact WF-RUNPERM.
+  it("detail: creator gets usesPrivateCredential+viewerCanRunEdit; no createdByUserId leak", async () => {
+    const d = await toWorkflowDetail(gmail, "creator-1");
     expect(d.usesPrivateCredential).toBe(true);
     expect(d.viewerCanRunEdit).toBe(true);
     expect(d).not.toHaveProperty("createdByUserId");
   });
-  it("detail: non-creator on private → viewerCanRunEdit false", () => {
-    expect(toWorkflowDetail(gmail, "other").viewerCanRunEdit).toBe(false);
+  it("detail: non-creator on private → viewerCanRunEdit false", async () => {
+    expect((await toWorkflowDetail(gmail, "other")).viewerCanRunEdit).toBe(false);
   });
-  it("detail: account-only → not private, runnable by anyone", () => {
-    const d = toWorkflowDetail(slack, "other");
+  it("detail: account-only → not private, runnable by anyone", async () => {
+    const d = await toWorkflowDetail(slack, "other");
     expect(d.usesPrivateCredential).toBe(false);
     expect(d.viewerCanRunEdit).toBe(true);
   });
@@ -308,7 +309,7 @@ describe("toWorkflowSummary", () => {
 });
 
 describe("toWorkflowDetail", () => {
-  it("includes activeRevisionId + draftDefinition; still strips userId", () => {
+  it("includes activeRevisionId + draftDefinition; still strips userId", async () => {
     const record: WorkflowRecord = {
       id: "wf-1",
       createdByUserId: "user-1",
@@ -340,7 +341,7 @@ describe("toWorkflowDetail", () => {
       createdAt: "2026-05-06T00:00:00Z",
       updatedAt: "2026-05-06T01:00:00Z",
     };
-    const detail = toWorkflowDetail(record, "user-1");
+    const detail = await toWorkflowDetail(record, "user-1");
     expect(detail.activeRevisionId).toBe("rev-1");
     expect(detail.draftDefinition.nodes[0]?.id).toBe("n1");
     expect(detail.draftDefinition.edges).toEqual([]);

--- a/tests/unit/app/api/workflows/connection-runedit-gate.test.ts
+++ b/tests/unit/app/api/workflows/connection-runedit-gate.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment node
+ *
+ * CS-4b — assertWorkflowRunEditAllowed with ENABLE_CONNECTION_SHARING ON. Proves
+ * the gate consumes the SHARED buildWorkflowCredentialPlan: a non-creator is
+ * allowed iff `allTeamRunnable`, with creator / no-private short-circuits doing no
+ * plan read. The flag-OFF parity lives in _shared.test.ts.
+ */
+const mockBuildPlan = jest.fn();
+jest.mock("@/services/integrations/connectionResolution", () => ({
+  buildWorkflowCredentialPlan: (...a: unknown[]) => mockBuildPlan(...a),
+}));
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(async () => ({ auth: { getUser: jest.fn() } })),
+}));
+
+import { assertWorkflowRunEditAllowed } from "@/app/api/workflows/_shared";
+import type { WorkflowRecord } from "@/repositories/workflows";
+
+const FLAG = "ENABLE_CONNECTION_SHARING";
+const CREATOR = "creator-1";
+const OTHER = "member-2";
+
+function node(provider: string) {
+  return { id: provider, kind: "action" as const, provider, type: "x", config: {}, position: { x: 0, y: 0 } };
+}
+function record(over: Partial<WorkflowRecord> = {}): WorkflowRecord {
+  return {
+    id: "wf-1", accountId: "acc-1", createdByUserId: CREATOR, name: "WF", state: "active",
+    disabledReason: null, disabledContext: null, activeRevisionId: null,
+    draftDefinition: { nodes: [node("gmail")], edges: [] } as never,
+    deletedAt: null, folderId: null, deletedByUserId: null, purgeAfter: null,
+    deletedFromFolderId: null, deleteOperationId: null,
+    createdAt: "2026-06-01T00:00:00Z", updatedAt: "2026-06-01T00:00:00Z",
+    ...over,
+  } as WorkflowRecord;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env[FLAG] = "true";
+});
+afterAll(() => {
+  delete process.env[FLAG];
+});
+
+describe("CS-4b gate (flag ON)", () => {
+  it("creator → allowed (null) WITHOUT a plan read", async () => {
+    expect(await assertWorkflowRunEditAllowed(record(), CREATOR)).toBeNull();
+    expect(mockBuildPlan).not.toHaveBeenCalled();
+  });
+
+  it("no private providers → allowed (null) WITHOUT a plan read", async () => {
+    const res = await assertWorkflowRunEditAllowed(
+      record({ draftDefinition: { nodes: [node("slack")], edges: [] } as never }),
+      OTHER,
+    );
+    expect(res).toBeNull();
+    expect(mockBuildPlan).not.toHaveBeenCalled();
+  });
+
+  it("non-creator + plan.allTeamRunnable=true → allowed (null)", async () => {
+    mockBuildPlan.mockResolvedValue({ ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: true });
+    expect(await assertWorkflowRunEditAllowed(record(), OTHER)).toBeNull();
+    expect(mockBuildPlan).toHaveBeenCalledWith({
+      workflowId: "wf-1", accountId: "acc-1", createdByUserId: CREATOR,
+      nodes: [node("gmail")],
+    });
+  });
+
+  it("non-creator + plan.allTeamRunnable=false → 403 WORKFLOW_USES_PRIVATE_CREDENTIAL, no leak", async () => {
+    mockBuildPlan.mockResolvedValue({ ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: false });
+    const res = await assertWorkflowRunEditAllowed(record(), OTHER);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
+    const body = await res!.json();
+    expect(body.code).toBe("WORKFLOW_USES_PRIVATE_CREDENTIAL");
+    expect(JSON.stringify(body)).not.toMatch(/gmail|creator-1|connector|token|email|scope/i);
+  });
+});

--- a/tests/unit/app/api/workflows/connection-runedit-gate.test.ts
+++ b/tests/unit/app/api/workflows/connection-runedit-gate.test.ts
@@ -14,7 +14,7 @@ jest.mock("@/utils/supabase/server", () => ({
   createClient: jest.fn(async () => ({ auth: { getUser: jest.fn() } })),
 }));
 
-import { assertWorkflowRunEditAllowed } from "@/app/api/workflows/_shared";
+import { assertWorkflowRunEditAllowed, computeViewerCanRunEdit } from "@/app/api/workflows/_shared";
 import type { WorkflowRecord } from "@/repositories/workflows";
 
 const FLAG = "ENABLE_CONNECTION_SHARING";
@@ -76,5 +76,26 @@ describe("CS-4b gate (flag ON)", () => {
     const body = await res!.json();
     expect(body.code).toBe("WORKFLOW_USES_PRIVATE_CREDENTIAL");
     expect(JSON.stringify(body)).not.toMatch(/gmail|creator-1|connector|token|email|scope/i);
+  });
+});
+
+describe("CS-5a — computeViewerCanRunEdit (DTO boolean, flag ON) shares the gate plan", () => {
+  it("creator → true (no plan read)", async () => {
+    expect(await computeViewerCanRunEdit(record(), CREATOR)).toBe(true);
+    expect(mockBuildPlan).not.toHaveBeenCalled();
+  });
+  it("no private providers → true (no plan read)", async () => {
+    expect(
+      await computeViewerCanRunEdit(record({ draftDefinition: { nodes: [node("slack")], edges: [] } as never }), OTHER),
+    ).toBe(true);
+    expect(mockBuildPlan).not.toHaveBeenCalled();
+  });
+  it("non-creator + one shared connector (allTeamRunnable) → true", async () => {
+    mockBuildPlan.mockResolvedValue({ ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: true });
+    expect(await computeViewerCanRunEdit(record(), OTHER)).toBe(true);
+  });
+  it("non-creator + ambiguous/unshared (not allTeamRunnable) → false", async () => {
+    mockBuildPlan.mockResolvedValue({ ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: false });
+    expect(await computeViewerCanRunEdit(record(), OTHER)).toBe(false);
   });
 });

--- a/tests/unit/app/api/workflows/connector-binding.route.test.ts
+++ b/tests/unit/app/api/workflows/connector-binding.route.test.ts
@@ -25,13 +25,15 @@ jest.mock("@/repositories/accountMemberships", () => ({
 const mockSet = jest.fn();
 const mockClear = jest.fn();
 const mockEligible = jest.fn();
+const mockState = jest.fn();
 jest.mock("@/services/integrations/connectionBinding", () => ({
   setNodeConnectorBinding: (...a: unknown[]) => mockSet(...a),
   clearNodeConnectorBinding: (...a: unknown[]) => mockClear(...a),
   listEligibleSharedConnectors: (...a: unknown[]) => mockEligible(...a),
+  getNodeConnectorBindingState: (...a: unknown[]) => mockState(...a),
 }));
 
-import { PUT, DELETE } from "@/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route";
+import { PUT, DELETE, GET as GET_STATE } from "@/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route";
 import { GET } from "@/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/eligible-connectors/route";
 
 const record = {
@@ -126,6 +128,34 @@ describe("DELETE connector-binding", () => {
     mockClear.mockResolvedValue({ ok: false, reason: "forbidden" });
     const res = await DELETE(new Request("http://t/", { method: "DELETE" }), params());
     expect(res.status).toBe(403);
+  });
+});
+
+describe("GET connector-binding (CS-5b state)", () => {
+  it("200 returns {status, connectors, currentConnectorDisplayName}", async () => {
+    mockState.mockResolvedValue({
+      ok: true, status: "needs_selection",
+      connectors: [{ userId: "alice", displayName: "Alice", role: "owner" }],
+      currentConnectorDisplayName: null,
+    });
+    const res = await GET_STATE(new Request("http://t/"), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "needs_selection",
+      connectors: [{ userId: "alice", displayName: "Alice", role: "owner" }],
+      currentConnectorDisplayName: null,
+    });
+  });
+  it("404 non-member → state service not called", async () => {
+    mockIsMember.mockResolvedValue(false);
+    const res = await GET_STATE(new Request("http://t/"), params());
+    expect(res.status).toBe(404);
+    expect(mockState).not.toHaveBeenCalled();
+  });
+  it("not_enabled → 404 (feature hidden)", async () => {
+    mockState.mockResolvedValue({ ok: false, reason: "not_enabled" });
+    const res = await GET_STATE(new Request("http://t/"), params());
+    expect(res.status).toBe(404);
   });
 });
 

--- a/tests/unit/app/api/workflows/connector-binding.route.test.ts
+++ b/tests/unit/app/api/workflows/connector-binding.route.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment node
+ *
+ * CS-4a — node connector-binding routes: auth, scope validation, typed-error
+ * mapping, no-leak. Mocks supabase auth, the workflows repo (getById),
+ * accountMemberships (isMember + getRole — used by requireWorkflowAccountMember +
+ * requireAccountRole), and the binding service. The authz matrix itself lives in
+ * the service test; here we prove the thin route plumbing.
+ */
+const mockGetUser = jest.fn();
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(async () => ({ auth: { getUser: () => mockGetUser() } })),
+}));
+
+const mockGetById = jest.fn();
+jest.mock("@/repositories/workflows", () => ({ getById: (...a: unknown[]) => mockGetById(...a) }));
+
+const mockIsMember = jest.fn();
+const mockGetRole = jest.fn();
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMember: (...a: unknown[]) => mockIsMember(...a),
+  getRole: (...a: unknown[]) => mockGetRole(...a),
+}));
+
+const mockSet = jest.fn();
+const mockClear = jest.fn();
+const mockEligible = jest.fn();
+jest.mock("@/services/integrations/connectionBinding", () => ({
+  setNodeConnectorBinding: (...a: unknown[]) => mockSet(...a),
+  clearNodeConnectorBinding: (...a: unknown[]) => mockClear(...a),
+  listEligibleSharedConnectors: (...a: unknown[]) => mockEligible(...a),
+}));
+
+import { PUT, DELETE } from "@/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/route";
+import { GET } from "@/app/api/workflows/[id]/nodes/[nodeId]/connector-binding/eligible-connectors/route";
+
+const record = {
+  id: "wf-1",
+  accountId: "team-1",
+  createdByUserId: "creatorA",
+  name: "WF",
+  state: "active" as const,
+  draftDefinition: { nodes: [], edges: [] },
+};
+function params(id = "wf-1", nodeId = "node-7") {
+  return { params: Promise.resolve({ id, nodeId }) };
+}
+function req(body: unknown = {}) {
+  return new Request("http://t/", { method: "PUT", body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: { id: "callerX" } }, error: null });
+  mockGetById.mockResolvedValue(record);
+  mockIsMember.mockResolvedValue(true);
+  mockGetRole.mockResolvedValue("owner");
+});
+
+describe("PUT connector-binding", () => {
+  it("401 unauthenticated → service not called", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await PUT(req({ connectorUserId: "c1" }), params());
+    expect(res.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("404 non-member → service not called (no existence leak)", async () => {
+    mockIsMember.mockResolvedValue(false);
+    const res = await PUT(req({ connectorUserId: "c1" }), params());
+    expect(res.status).toBe(404);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it.each([{}, { connectorUserId: "" }, { connectorUserId: 5 }])(
+    "400 INVALID_CONNECTOR for bad body %p → service not called",
+    async (body) => {
+      const res = await PUT(req(body), params());
+      expect(res.status).toBe(400);
+      expect((await res.json()).code).toBe("INVALID_CONNECTOR");
+      expect(mockSet).not.toHaveBeenCalled();
+    },
+  );
+
+  it("200 {bound:true}; passes session caller + path ids + connector to service", async () => {
+    mockSet.mockResolvedValue({ ok: true });
+    const res = await PUT(req({ connectorUserId: "conn-9" }), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ bound: true });
+    expect(mockSet).toHaveBeenCalledWith({
+      workflowId: "wf-1", nodeId: "node-7", connectorUserId: "conn-9", callerUserId: "callerX", callerRole: "owner",
+    });
+  });
+
+  it.each([
+    ["not_enabled", 404, "WORKFLOW_NOT_FOUND"],
+    ["node_not_found", 404, "NODE_NOT_FOUND"],
+    ["not_applicable", 400, "NOT_APPLICABLE"],
+    ["account_frozen", 403, "ACCOUNT_PENDING_DELETION"],
+    ["forbidden", 403, "FORBIDDEN"],
+    ["connector_not_member", 400, "CONNECTOR_NOT_MEMBER"],
+    ["connector_not_connected", 400, "CONNECTOR_NOT_CONNECTED"],
+    ["connector_not_shared", 400, "CONNECTOR_NOT_SHARED"],
+  ] as const)("maps service reason %s → %i %s", async (reason, status, code) => {
+    mockSet.mockResolvedValue({ ok: false, reason });
+    const res = await PUT(req({ connectorUserId: "c1" }), params());
+    expect(res.status).toBe(status);
+    expect((await res.json()).code).toBe(code);
+  });
+
+  it("NO LEAK: success body has exactly { bound }", async () => {
+    mockSet.mockResolvedValue({ ok: true });
+    const res = await PUT(req({ connectorUserId: "c1" }), params());
+    expect(Object.keys(await res.json())).toEqual(["bound"]);
+  });
+});
+
+describe("DELETE connector-binding", () => {
+  it("200 {cleared:true} when service clears", async () => {
+    mockClear.mockResolvedValue({ ok: true, cleared: true });
+    const res = await DELETE(new Request("http://t/", { method: "DELETE" }), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cleared: true });
+  });
+  it("maps forbidden → 403", async () => {
+    mockClear.mockResolvedValue({ ok: false, reason: "forbidden" });
+    const res = await DELETE(new Request("http://t/", { method: "DELETE" }), params());
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET eligible-connectors", () => {
+  it("200 with connectors list", async () => {
+    mockEligible.mockResolvedValue({
+      ok: true,
+      connectors: [{ userId: "alice", displayName: "Alice", role: "owner" }],
+    });
+    const res = await GET(new Request("http://t/"), params());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connectors: [{ userId: "alice", displayName: "Alice", role: "owner" }] });
+  });
+  it("not_enabled → 404 (feature hidden)", async () => {
+    mockEligible.mockResolvedValue({ ok: false, reason: "not_enabled" });
+    const res = await GET(new Request("http://t/"), params());
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/app/apps/_shared.test.ts
+++ b/tests/unit/app/apps/_shared.test.ts
@@ -90,13 +90,18 @@ describe("toAppCatalogItem — route-DTO safety contract", () => {
     const item = toAppCatalogItem(mkProvider(), [mkRecord()]);
     expect(item.accounts).toHaveLength(1);
     for (const acc of item.accounts) {
-      // 4.APPS-RECONNECT adds `canReconnect` — a boolean only; still NO identity.
+      // 4.APPS-RECONNECT adds `canReconnect`; CS-5a adds sharingStatus +
+      // sharedWithAccount + canShare + canUnshare — all boolean/enum, still NO identity.
       expect(Object.keys(acc).sort()).toEqual([
         "canDisconnect",
         "canReconnect",
+        "canShare",
+        "canUnshare",
         "connectedAt",
         "displayName",
         "id",
+        "sharedWithAccount",
+        "sharingStatus",
       ]);
     }
     // The provenance input to canDisconnect / canReconnect must never be emitted.
@@ -237,6 +242,92 @@ describe("toAppCatalogItem — canDisconnect derivation (CD-3)", () => {
     // And with no context, both are false (control never renders).
     const noCtx = toAppCatalogItem(mkProvider({ id: "slack" }), [mkRecord({ provider: "slack" })]).accounts[0]!;
     expect(noCtx.canReconnect).toBe(false);
+  });
+});
+
+describe("CS-5a — sharing DTO fields", () => {
+  const FLAG = "ENABLE_CONNECTION_SHARING";
+  const enabled = (over: Partial<{ callerUserId: string; callerRole: "owner" | "admin" | "member" | null }> = {}) => ({
+    callerUserId: "user-1",
+    callerRole: "member" as const,
+    ...over,
+  });
+  function acct(over: { provider: string; connectedBy?: string; scope?: string | null; displayName?: string | null }, ctx: ReturnType<typeof enabled>) {
+    return toAppCatalogItem(
+      mkProvider({ id: over.provider }),
+      [mkRecord({
+        provider: over.provider,
+        connectedByUserId: over.connectedBy ?? "user-1",
+        integrationSharingScope: over.scope ?? null,
+        ...(over.displayName !== undefined ? { displayName: over.displayName } : {}),
+      })],
+      ctx,
+    ).accounts[0]!;
+  }
+
+  afterEach(() => delete process.env[FLAG]);
+
+  it("flag OFF → not_applicable, all sharing booleans false (no behavior change)", () => {
+    const a = acct({ provider: "gmail" }, enabled());
+    expect(a.sharingStatus).toBe("not_applicable");
+    expect(a.sharedWithAccount).toBe(false);
+    expect(a.canShare).toBe(false);
+    expect(a.canUnshare).toBe(false);
+  });
+
+  describe("flag ON", () => {
+    beforeEach(() => { process.env[FLAG] = "true"; });
+
+    it("account provider (slack) → not_applicable, no toggle", () => {
+      const a = acct({ provider: "slack" }, enabled({ callerRole: "owner" }));
+      expect(a.sharingStatus).toBe("not_applicable");
+      expect(a.canShare).toBe(false);
+      expect(a.canUnshare).toBe(false);
+    });
+
+    it("personal PRIVATE row → connector can share; non-connector cannot", () => {
+      const asConnector = acct({ provider: "gmail", connectedBy: "user-1" }, enabled({ callerUserId: "user-1" }));
+      expect(asConnector.sharingStatus).toBe("private_to_connector");
+      expect(asConnector.sharedWithAccount).toBe(false);
+      expect(asConnector.canShare).toBe(true);
+      expect(asConnector.canUnshare).toBe(false);
+
+      // Owner/admin who is NOT the connector cannot share another member's identity.
+      const asOwner = acct({ provider: "gmail", connectedBy: "member-7" }, enabled({ callerRole: "owner", callerUserId: "owner-1" }));
+      expect(asOwner.canShare).toBe(false);
+
+      const asOtherMember = acct({ provider: "gmail", connectedBy: "member-7" }, enabled({ callerRole: "member", callerUserId: "member-OTHER" }));
+      expect(asOtherMember.canShare).toBe(false);
+    });
+
+    it("personal SHARED row → shared status; connector AND owner/admin can unshare", () => {
+      const asConnector = acct({ provider: "gmail", connectedBy: "user-1", scope: "shared_with_account" }, enabled({ callerUserId: "user-1" }));
+      expect(asConnector.sharingStatus).toBe("shared_with_account");
+      expect(asConnector.sharedWithAccount).toBe(true);
+      expect(asConnector.canUnshare).toBe(true);
+      expect(asConnector.canShare).toBe(false);
+
+      const asOwner = acct({ provider: "gmail", connectedBy: "member-7", scope: "shared_with_account" }, enabled({ callerRole: "owner", callerUserId: "owner-1" }));
+      expect(asOwner.canUnshare).toBe(true); // admin-safety removal
+
+      const asOtherMember = acct({ provider: "gmail", connectedBy: "member-7", scope: "shared_with_account" }, enabled({ callerRole: "member", callerUserId: "member-OTHER" }));
+      expect(asOtherMember.canUnshare).toBe(false);
+    });
+
+    it("NO LEAK: sharing fields never carry connector id / raw scope / provider_account_id / metadata", () => {
+      // displayName (the row's own OAuth label) is a pre-existing exposed field —
+      // set it neutral here so the assertion isolates what the SHARING fields add.
+      const a = acct(
+        { provider: "gmail", connectedBy: "member-7", scope: "shared_with_account", displayName: "Gmail" },
+        enabled({ callerRole: "owner", callerUserId: "owner-1" }),
+      );
+      const serialized = JSON.stringify(a);
+      expect(serialized).not.toContain("member-7"); // connector id
+      expect(serialized).not.toContain("T-WORKSPACE-12345"); // provider_account_id / metadata
+      expect(serialized).not.toContain("chat:write"); // scope
+      // Only the safe enum/booleans are present.
+      expect(a.sharingStatus).toBe("shared_with_account");
+    });
   });
 });
 

--- a/tests/unit/core/integrations/sharingEligibility.test.ts
+++ b/tests/unit/core/integrations/sharingEligibility.test.ts
@@ -12,6 +12,7 @@ import {
   computeProviderSharingStatus,
   computeRunEditEligibility,
   distinctPrivateProviders,
+  resolveNodeOwner,
 } from "@/core/integrations/sharingEligibility";
 import { viewerMayRunEdit } from "@/core/integrations/workflowCredentialScope";
 
@@ -223,5 +224,51 @@ describe("computeRunEditEligibility — flag ON", () => {
     for (const p of res.providerStatuses) {
       expect(Object.keys(p).sort()).toEqual(["provider", "status"]);
     }
+  });
+});
+
+describe("CS-4b — resolveNodeOwner precedence", () => {
+  const base = { creatorUserId: CREATOR, acceptedGrantOwner: null, bindingConnector: null, sharedConnectors: new Set<string>() };
+
+  it("1. accepted grant WINS over everything (binding + shared set ignored)", () => {
+    expect(
+      resolveNodeOwner({ ...base, acceptedGrantOwner: "grantOwner", bindingConnector: "boundX", sharedConnectors: new Set(["alice", "bob"]) }),
+    ).toEqual({ owner: "grantOwner", via: "grant", teamRunnable: true });
+  });
+
+  it("2. VALID binding wins next (connector in the shared set)", () => {
+    expect(
+      resolveNodeOwner({ ...base, bindingConnector: "alice", sharedConnectors: new Set(["alice", "bob"]) }),
+    ).toEqual({ owner: "alice", via: "binding", teamRunnable: true });
+  });
+
+  it("2b. INVALID binding (connector NOT in shared set) is IGNORED → falls through", () => {
+    // bound to 'carol' who is no longer shared; only 'alice' shares → single-sharer.
+    expect(
+      resolveNodeOwner({ ...base, bindingConnector: "carol", sharedConnectors: new Set(["alice"]) }),
+    ).toEqual({ owner: "alice", via: "single_sharer", teamRunnable: true });
+  });
+
+  it("2c. invalid binding + ambiguous remainder → creator (fail closed), never the bound or an arbitrary connector", () => {
+    const r = resolveNodeOwner({ ...base, bindingConnector: "carol", sharedConnectors: new Set(["alice", "bob"]) });
+    expect(r).toEqual({ owner: CREATOR, via: "creator", teamRunnable: false });
+  });
+
+  it("3. single shared connector → that connector", () => {
+    expect(resolveNodeOwner({ ...base, sharedConnectors: new Set(["solo"]) })).toEqual({
+      owner: "solo", via: "single_sharer", teamRunnable: true,
+    });
+  });
+
+  it("4. unshared (0) → creator pin, NOT team-runnable", () => {
+    expect(resolveNodeOwner({ ...base, sharedConnectors: new Set() })).toEqual({
+      owner: CREATOR, via: "creator", teamRunnable: false,
+    });
+  });
+
+  it("4b. ambiguous (2+) with no binding/grant → creator pin (fail closed), NOT an arbitrary row", () => {
+    expect(resolveNodeOwner({ ...base, sharedConnectors: new Set(["alice", "bob", "carol"]) })).toEqual({
+      owner: CREATOR, via: "creator", teamRunnable: false,
+    });
   });
 });

--- a/tests/unit/core/integrations/sharingEligibility.test.ts
+++ b/tests/unit/core/integrations/sharingEligibility.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @jest-environment node
+ *
+ * Pure-helper tests for ambiguity-aware run/edit eligibility
+ * (Slice 4.CONN-SHARE / CS-3a). No DB, no I/O. `credentialSharing` +
+ * `workflowCredentialScope` run for real, so provider classification +
+ * WF-RUNPERM delegation are exercised end-to-end.
+ */
+
+import type { WorkflowDefinition } from "@/contracts/workflowDefinition";
+import {
+  computeProviderSharingStatus,
+  computeRunEditEligibility,
+  distinctPrivateProviders,
+} from "@/core/integrations/sharingEligibility";
+import { viewerMayRunEdit } from "@/core/integrations/workflowCredentialScope";
+
+let nodeSeq = 0;
+function node(provider: string, kind: "trigger" | "action" = "action") {
+  return {
+    id: `n${nodeSeq++}`,
+    kind,
+    provider,
+    type: "x",
+    config: {},
+    position: { x: 0, y: 0 },
+  };
+}
+function def(...providers: string[]): WorkflowDefinition {
+  nodeSeq = 0;
+  return { nodes: providers.map((p, i) => node(p, i === 0 ? "trigger" : "action")), edges: [] };
+}
+
+const CREATOR = "creator-1";
+const OTHER = "member-2";
+
+describe("computeProviderSharingStatus", () => {
+  it.each([
+    ["gmail", 0, "unshared"],
+    ["gmail", 1, "single_shared_connector"],
+    ["gmail", 2, "ambiguous_shared_connectors"],
+    ["gmail", 5, "ambiguous_shared_connectors"],
+    ["google-drive", 0, "unshared"],
+    ["unknown-provider", 0, "unshared"], // unknown → personal (fail-safe) → private
+    ["unknown-provider", 1, "single_shared_connector"],
+    ["slack", 0, "not_private"], // account provider
+    ["slack", 3, "not_private"],
+    ["native", 0, "not_private"], // native pseudo-provider
+  ] as const)("%s with %i shared ⇒ %s", (provider, count, expected) => {
+    expect(computeProviderSharingStatus(provider, count)).toBe(expected);
+  });
+});
+
+describe("distinctPrivateProviders", () => {
+  it("returns only distinct private providers (excludes account + native)", () => {
+    expect(distinctPrivateProviders(def("native", "gmail", "gmail", "slack", "google-drive")).sort()).toEqual([
+      "gmail",
+      "google-drive",
+    ]);
+  });
+  it("malformed definition ⇒ [] (no throw)", () => {
+    expect(distinctPrivateProviders({ nodes: null } as unknown as WorkflowDefinition)).toEqual([]);
+  });
+});
+
+const NONE: ReadonlyMap<string, number> = new Map();
+function counts(rec: Record<string, number>): ReadonlyMap<string, number> {
+  return new Map(Object.entries(rec));
+}
+
+describe("computeRunEditEligibility — flag OFF preserves WF-RUNPERM exactly", () => {
+  it.each([
+    ["no private (native+slack), non-creator", def("native", "slack"), OTHER],
+    ["private (gmail), creator", def("native", "gmail"), CREATOR],
+    ["private (gmail), non-creator", def("native", "gmail"), OTHER],
+  ] as const)("%s matches viewerMayRunEdit", (_label, definition, caller) => {
+    const res = computeRunEditEligibility({
+      definition,
+      createdByUserId: CREATOR,
+      callerUserId: caller,
+      sharedConnectorCountByProvider: NONE,
+      flagEnabled: false,
+    });
+    expect(res.reason).toBe("flag_off_legacy");
+    expect(res.allowed).toBe(viewerMayRunEdit({ createdByUserId: CREATOR, definition }, caller));
+    expect(res.providerStatuses).toEqual([]);
+  });
+});
+
+describe("computeRunEditEligibility — flag ON", () => {
+  it("no private providers ⇒ allowed (no_private_credentials)", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "slack"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: NONE,
+      flagEnabled: true,
+    });
+    expect(res).toEqual({ allowed: true, reason: "no_private_credentials", providerStatuses: [] });
+  });
+
+  it("creator with private providers ⇒ allowed (creator)", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "gmail"),
+      createdByUserId: CREATOR,
+      callerUserId: CREATOR,
+      sharedConnectorCountByProvider: NONE,
+      flagEnabled: true,
+    });
+    expect(res).toEqual({ allowed: true, reason: "creator", providerStatuses: [] });
+  });
+
+  it("non-creator, gmail UNSHARED ⇒ blocked_unshared", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "gmail"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: counts({ gmail: 0 }),
+      flagEnabled: true,
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("blocked_unshared");
+    expect(res.providerStatuses).toEqual([{ provider: "gmail", status: "unshared" }]);
+  });
+
+  it("non-creator, gmail SINGLE shared connector ⇒ eligible (all_providers_single_shared)", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "gmail"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: counts({ gmail: 1 }),
+      flagEnabled: true,
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.reason).toBe("all_providers_single_shared");
+    expect(res.providerStatuses).toEqual([{ provider: "gmail", status: "single_shared_connector" }]);
+  });
+
+  it("non-creator, gmail TWO shared connectors ⇒ blocked_ambiguous (fail closed)", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "gmail"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: counts({ gmail: 2 }),
+      flagEnabled: true,
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("blocked_ambiguous");
+    expect(res.providerStatuses).toEqual([
+      { provider: "gmail", status: "ambiguous_shared_connectors" },
+    ]);
+  });
+
+  describe("mixed providers", () => {
+    it("all single-shared ⇒ eligible", () => {
+      const res = computeRunEditEligibility({
+        definition: def("native", "gmail", "google-drive"),
+        createdByUserId: CREATOR,
+        callerUserId: OTHER,
+        sharedConnectorCountByProvider: counts({ gmail: 1, "google-drive": 1 }),
+        flagEnabled: true,
+      });
+      expect(res.allowed).toBe(true);
+      expect(res.reason).toBe("all_providers_single_shared");
+    });
+
+    it("one unshared ⇒ blocked_unshared", () => {
+      const res = computeRunEditEligibility({
+        definition: def("native", "gmail", "google-drive"),
+        createdByUserId: CREATOR,
+        callerUserId: OTHER,
+        sharedConnectorCountByProvider: counts({ gmail: 1, "google-drive": 0 }),
+        flagEnabled: true,
+      });
+      expect(res.allowed).toBe(false);
+      expect(res.reason).toBe("blocked_unshared");
+    });
+
+    it("one ambiguous ⇒ blocked_ambiguous (ambiguous reported before unshared)", () => {
+      const res = computeRunEditEligibility({
+        definition: def("native", "gmail", "google-drive", "microsoft-outlook"),
+        createdByUserId: CREATOR,
+        callerUserId: OTHER,
+        sharedConnectorCountByProvider: counts({ gmail: 1, "google-drive": 2, "microsoft-outlook": 0 }),
+        flagEnabled: true,
+      });
+      expect(res.allowed).toBe(false);
+      expect(res.reason).toBe("blocked_ambiguous");
+    });
+
+    it("account + native nodes are unaffected (not counted as private)", () => {
+      const res = computeRunEditEligibility({
+        definition: def("native", "slack", "gmail"),
+        createdByUserId: CREATOR,
+        callerUserId: OTHER,
+        sharedConnectorCountByProvider: counts({ gmail: 1 }),
+        flagEnabled: true,
+      });
+      expect(res.allowed).toBe(true);
+      expect(res.providerStatuses.map((p) => p.provider)).toEqual(["gmail"]); // slack/native absent
+    });
+  });
+
+  it("malformed definition ⇒ blocked_malformed (fail closed)", () => {
+    const res = computeRunEditEligibility({
+      definition: { nodes: null } as unknown as WorkflowDefinition,
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: NONE,
+      flagEnabled: true,
+    });
+    expect(res).toEqual({ allowed: false, reason: "blocked_malformed", providerStatuses: [] });
+  });
+
+  it("NO LEAK: providerStatuses carry only {provider, status} — no ids/counts", () => {
+    const res = computeRunEditEligibility({
+      definition: def("native", "gmail"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+      sharedConnectorCountByProvider: counts({ gmail: 2 }),
+      flagEnabled: true,
+    });
+    for (const p of res.providerStatuses) {
+      expect(Object.keys(p).sort()).toEqual(["provider", "status"]);
+    }
+  });
+});

--- a/tests/unit/core/integrations/sharingScope.test.ts
+++ b/tests/unit/core/integrations/sharingScope.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment node
+ *
+ * Pure-helper unit tests for explicit connection sharing scope
+ * (Slice 4.CONN-SHARE / CS-1). No DB, no I/O — these assert ONLY the pure
+ * classification logic. The helpers are behavior-inert in CS-1 (nothing wires
+ * them into runtime paths yet).
+ */
+
+import {
+  effectiveIntegrationSharingScope,
+  isProviderShareable,
+  isRowShareable,
+  INTEGRATION_SHARING_SCOPE_VALUES,
+} from "@/core/integrations/sharingScope";
+
+// Representative providers from core/integrations/credentialSharing.ts POLICY.
+const PERSONAL = "gmail";
+const ACCOUNT = "slack";
+const UNKNOWN = "totally-unregistered-provider"; // classifies personal (fail-safe)
+
+describe("CS-1 — effectiveIntegrationSharingScope", () => {
+  describe("personal provider", () => {
+    it("NULL → private_to_connector (derived default)", () => {
+      expect(effectiveIntegrationSharingScope(PERSONAL, null)).toBe("private_to_connector");
+    });
+
+    it("undefined → private_to_connector (derived default)", () => {
+      expect(effectiveIntegrationSharingScope(PERSONAL, undefined)).toBe("private_to_connector");
+    });
+
+    it('"private_to_connector" → private_to_connector', () => {
+      expect(effectiveIntegrationSharingScope(PERSONAL, "private_to_connector")).toBe(
+        "private_to_connector",
+      );
+    });
+
+    it('"shared_with_account" → shared_with_account', () => {
+      expect(effectiveIntegrationSharingScope(PERSONAL, "shared_with_account")).toBe(
+        "shared_with_account",
+      );
+    });
+
+    it("invalid / unknown value → private_to_connector (fail safe, never widens access)", () => {
+      for (const bad of ["", "SHARED_WITH_ACCOUNT", "shared", "public", "true", "1", "null"]) {
+        expect(effectiveIntegrationSharingScope(PERSONAL, bad)).toBe("private_to_connector");
+      }
+    });
+
+    it("unknown provider (fail-safe personal) follows the personal rules", () => {
+      expect(effectiveIntegrationSharingScope(UNKNOWN, null)).toBe("private_to_connector");
+      expect(effectiveIntegrationSharingScope(UNKNOWN, "shared_with_account")).toBe(
+        "shared_with_account",
+      );
+      expect(effectiveIntegrationSharingScope(UNKNOWN, "garbage")).toBe("private_to_connector");
+    });
+  });
+
+  describe("account provider (ignores the column — shared by classification)", () => {
+    it("NULL → shared_with_account", () => {
+      expect(effectiveIntegrationSharingScope(ACCOUNT, null)).toBe("shared_with_account");
+    });
+
+    it('"private_to_connector" is IGNORED → still shared_with_account', () => {
+      expect(effectiveIntegrationSharingScope(ACCOUNT, "private_to_connector")).toBe(
+        "shared_with_account",
+      );
+    });
+
+    it("invalid value is IGNORED → still shared_with_account", () => {
+      expect(effectiveIntegrationSharingScope(ACCOUNT, "garbage")).toBe("shared_with_account");
+    });
+  });
+});
+
+describe("CS-1 — isProviderShareable", () => {
+  it("personal providers are shareable through this feature", () => {
+    expect(isProviderShareable(PERSONAL)).toBe(true);
+    expect(isProviderShareable("microsoft-outlook")).toBe(true);
+    expect(isProviderShareable("google-drive")).toBe(true);
+  });
+
+  it("account/service providers are NOT shareable through this feature (already account-shared)", () => {
+    expect(isProviderShareable(ACCOUNT)).toBe(false);
+    expect(isProviderShareable("stripe")).toBe(false);
+    expect(isProviderShareable("notion")).toBe(false);
+  });
+
+  it("unknown providers classify personal (fail-safe) → shareable", () => {
+    expect(isProviderShareable(UNKNOWN)).toBe(true);
+  });
+});
+
+describe("CS-1 — isRowShareable", () => {
+  it("active personal-provider row is shareable", () => {
+    expect(isRowShareable({ provider: PERSONAL, disconnectedAt: null })).toBe(true);
+  });
+
+  it("disconnected personal-provider row is NOT shareable (no usable credential)", () => {
+    expect(
+      isRowShareable({ provider: PERSONAL, disconnectedAt: "2026-06-22T00:00:00.000Z" }),
+    ).toBe(false);
+  });
+
+  it("account-provider row is NOT shareable, active or not", () => {
+    expect(isRowShareable({ provider: ACCOUNT, disconnectedAt: null })).toBe(false);
+    expect(
+      isRowShareable({ provider: ACCOUNT, disconnectedAt: "2026-06-22T00:00:00.000Z" }),
+    ).toBe(false);
+  });
+});
+
+describe("CS-1 — INTEGRATION_SHARING_SCOPE_VALUES", () => {
+  it("is exactly the two CHECK-constraint values (NULL is a separate DB-layer state)", () => {
+    expect([...INTEGRATION_SHARING_SCOPE_VALUES]).toEqual([
+      "private_to_connector",
+      "shared_with_account",
+    ]);
+  });
+});

--- a/tests/unit/features/apps/AppCard.test.tsx
+++ b/tests/unit/features/apps/AppCard.test.tsx
@@ -125,8 +125,8 @@ describe("AppCard — connected", () => {
   const connected = mkApp({
     isConnected: true,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false },
-      { id: "int-2", displayName: "Acme · ops@example.com", connectedAt: "2026-05-01T12:00:00Z", canDisconnect: false, canReconnect: false },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
+      { id: "int-2", displayName: "Acme · ops@example.com", connectedAt: "2026-05-01T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });
@@ -181,6 +181,57 @@ describe("AppCard — connected", () => {
     }
   });
 
+  // ── CS-5a — sharing pill + Share/Stop-sharing controls ──────────────────────
+  type AccountSummary = AppCatalogItem["accounts"][number];
+  function shareAccount(over: Partial<AccountSummary>): AccountSummary {
+    return {
+      id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z",
+      canDisconnect: false, canReconnect: false,
+      sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false,
+      ...over,
+    };
+  }
+
+  it("private personal row: shows 'Private to you' pill + 'Share with team'; opens the share confirmation", async () => {
+    const user = userEvent.setup();
+    const app = mkApp({
+      providerId: "gmail", name: "Gmail", isConnected: true,
+      accounts: [shareAccount({ sharingStatus: "private_to_connector", canShare: true })],
+    });
+    render(<AppCard app={app} accountId="acc-1" />);
+    await user.click(screen.getByTestId("app-card-expand"));
+    expect(screen.getByTestId("app-card-sharing-pill")).toHaveTextContent("Private to you");
+    await user.click(screen.getByTestId("app-card-share"));
+    expect(screen.getByTestId("share-warning")).toHaveTextContent(
+      "Team members will be able to run workflows using this connection.",
+    );
+  });
+
+  it("shared row: shows 'Shared with team' pill + 'Stop sharing'; opens the stop-sharing confirmation", async () => {
+    const user = userEvent.setup();
+    const app = mkApp({
+      providerId: "gmail", name: "Gmail", isConnected: true,
+      accounts: [shareAccount({ sharingStatus: "shared_with_account", sharedWithAccount: true, canUnshare: true })],
+    });
+    render(<AppCard app={app} accountId="acc-1" />);
+    await user.click(screen.getByTestId("app-card-expand"));
+    expect(screen.getByTestId("app-card-sharing-pill")).toHaveTextContent("Shared with team");
+    await user.click(screen.getByTestId("app-card-unshare"));
+    expect(screen.getByTestId("share-warning")).toHaveTextContent(
+      "Team workflows using this connection may become creator-only again.",
+    );
+  });
+
+  it("not_applicable row (account provider / flag off): no sharing pill, no share controls", async () => {
+    const user = userEvent.setup();
+    const app = mkApp({ isConnected: true, accounts: [shareAccount({})] });
+    render(<AppCard app={app} accountId="acc-1" />);
+    await user.click(screen.getByTestId("app-card-expand"));
+    expect(screen.queryByTestId("app-card-sharing-pill")).toBeNull();
+    expect(screen.queryByTestId("app-card-share")).toBeNull();
+    expect(screen.queryByTestId("app-card-unshare")).toBeNull();
+  });
+
   it("expanded view renders 'Connect another' when supportsMultipleAccounts && canConnect", async () => {
     const user = userEvent.setup();
     render(<AppCard app={connected} accountId="acc-1" />);
@@ -222,14 +273,14 @@ describe("AppCard — per-account Disconnect (CD-3)", () => {
   const disconnectable = mkApp({
     isConnected: true,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });
   const notDisconnectable = mkApp({
     isConnected: true,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });
@@ -288,8 +339,8 @@ describe("AppCard — per-account Reconnect (4.APPS-RECONNECT)", () => {
     isConnected: true,
     canConnect: true,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true },
-      { id: "int-2", displayName: "Acme · ops@example.com", connectedAt: "2026-05-01T12:00:00Z", canDisconnect: true, canReconnect: true },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
+      { id: "int-2", displayName: "Acme · ops@example.com", connectedAt: "2026-05-01T12:00:00Z", canDisconnect: true, canReconnect: true, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });
@@ -298,7 +349,7 @@ describe("AppCard — per-account Reconnect (4.APPS-RECONNECT)", () => {
     canConnect: true,
     supportsMultipleAccounts: false,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: true, canReconnect: true, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });
@@ -306,7 +357,7 @@ describe("AppCard — per-account Reconnect (4.APPS-RECONNECT)", () => {
     isConnected: true,
     canConnect: true,
     accounts: [
-      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false },
+      { id: "int-1", displayName: "Personal · marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
     ],
     firstConnectedAt: "2026-04-15T12:00:00Z",
   });

--- a/tests/unit/features/apps/AppsDashboard.test.tsx
+++ b/tests/unit/features/apps/AppsDashboard.test.tsx
@@ -63,7 +63,7 @@ describe("AppsDashboard — render", () => {
             category: "Communication",
             isConnected: true,
             accounts: [
-              { id: "int-1", displayName: "marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false },
+              { id: "int-1", displayName: "marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
             ],
             firstConnectedAt: "2026-04-15T12:00:00Z",
           }),
@@ -173,7 +173,7 @@ describe("AppsDashboard — status tabs", () => {
       name: "Gmail",
       isConnected: true,
       accounts: [
-        { id: "int-1", displayName: "marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false },
+        { id: "int-1", displayName: "marcus@example.com", connectedAt: "2026-04-15T12:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
       ],
       firstConnectedAt: "2026-04-15T12:00:00Z",
     }),
@@ -234,7 +234,7 @@ describe("AppsDashboard — sort", () => {
             isConnected: true,
             firstConnectedAt: "2026-01-10T00:00:00Z",
             accounts: [
-              { id: "int-1", displayName: "a", connectedAt: "2026-01-10T00:00:00Z", canDisconnect: false, canReconnect: false },
+              { id: "int-1", displayName: "a", connectedAt: "2026-01-10T00:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
             ],
           }),
           mkApp({
@@ -243,7 +243,7 @@ describe("AppsDashboard — sort", () => {
             isConnected: true,
             firstConnectedAt: "2026-05-01T00:00:00Z",
             accounts: [
-              { id: "int-2", displayName: "b", connectedAt: "2026-05-01T00:00:00Z", canDisconnect: false, canReconnect: false },
+              { id: "int-2", displayName: "b", connectedAt: "2026-05-01T00:00:00Z", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false },
             ],
           }),
           mkApp({ providerId: "stripe", name: "Stripe" }),

--- a/tests/unit/features/apps/AppsStatCards.test.tsx
+++ b/tests/unit/features/apps/AppsStatCards.test.tsx
@@ -31,8 +31,8 @@ describe("AppsStatCards", () => {
     render(
       <AppsStatCards
         items={[
-          mkApp({ providerId: "slack", category: "Communication", isConnected: true, accounts: [{ id: "1", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false }, { id: "2", displayName: null, connectedAt: "y", canDisconnect: false, canReconnect: false }] }),
-          mkApp({ providerId: "stripe", category: "Payments", isConnected: true, accounts: [{ id: "3", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false }] }),
+          mkApp({ providerId: "slack", category: "Communication", isConnected: true, accounts: [{ id: "1", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false }, { id: "2", displayName: null, connectedAt: "y", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false }] }),
+          mkApp({ providerId: "stripe", category: "Payments", isConnected: true, accounts: [{ id: "3", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false }] }),
           mkApp({ providerId: "notion", category: "Productivity", isConnected: false }),
         ]}
       />,
@@ -64,7 +64,7 @@ describe("AppsStatCards", () => {
 
   it("does NOT render the design's 'Powering workflows' or 'Need attention' tiles (locked deferrals)", () => {
     render(
-      <AppsStatCards items={[mkApp({ providerId: "slack", isConnected: true, accounts: [{ id: "1", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false }] })]} />,
+      <AppsStatCards items={[mkApp({ providerId: "slack", isConnected: true, accounts: [{ id: "1", displayName: null, connectedAt: "x", canDisconnect: false, canReconnect: false, sharingStatus: "not_applicable", sharedWithAccount: false, canShare: false, canUnshare: false }] })]} />,
     );
     expect(screen.queryByText(/Powering/i)).toBeNull();
     expect(screen.queryByText(/Need attention/i)).toBeNull();

--- a/tests/unit/features/apps/ShareConnectionDialog.test.tsx
+++ b/tests/unit/features/apps/ShareConnectionDialog.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Tests for features/apps/ShareConnectionDialog (Slice 4.CONN-SHARE / CS-5a).
+ * Mocks the typed client so no real fetch happens; asserts the confirmation copy,
+ * the correct scope per mode, success → onDone, and a SAFE generic error message.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockSetSharing = jest.fn();
+jest.mock("@/lib/api/integrations", () => ({
+  setIntegrationSharing: (...a: unknown[]) => mockSetSharing(...a),
+}));
+
+import { ShareConnectionDialog } from "@/features/apps/ShareConnectionDialog";
+
+function setup(mode: "share" | "unshare", onDone = jest.fn(), onClose = jest.fn()) {
+  render(
+    <ShareConnectionDialog
+      accountId="acc-1"
+      integrationId="int-1"
+      appName="Gmail"
+      accountLabel="Personal · marcus@example.com"
+      mode={mode}
+      onClose={onClose}
+      onDone={onDone}
+    />,
+  );
+  return { onDone, onClose };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("ShareConnectionDialog", () => {
+  it("share mode shows the run-warning copy", () => {
+    setup("share");
+    expect(screen.getByTestId("share-warning")).toHaveTextContent(
+      "Team members will be able to run workflows using this connection.",
+    );
+  });
+
+  it("unshare mode shows the creator-only warning copy", () => {
+    setup("unshare");
+    expect(screen.getByTestId("share-warning")).toHaveTextContent(
+      "Team workflows using this connection may become creator-only again.",
+    );
+  });
+
+  it("confirm (share) calls the route with shared_with_account, then onDone + onClose", async () => {
+    mockSetSharing.mockResolvedValue({ scope: "shared_with_account", shared: true, changed: true });
+    const { onDone, onClose } = setup("share");
+    await userEvent.click(screen.getByTestId("share-confirm"));
+    expect(mockSetSharing).toHaveBeenCalledWith("acc-1", "int-1", "shared_with_account");
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirm (unshare) calls the route with private_to_connector", async () => {
+    mockSetSharing.mockResolvedValue({ scope: "private_to_connector", shared: false, changed: true });
+    setup("unshare");
+    await userEvent.click(screen.getByTestId("share-confirm"));
+    expect(mockSetSharing).toHaveBeenCalledWith("acc-1", "int-1", "private_to_connector");
+  });
+
+  it("failure (incl. flag-off not_enabled) shows a SAFE generic error; onDone NOT called", async () => {
+    mockSetSharing.mockRejectedValue(new Error("Connection sharing is not available."));
+    const { onDone } = setup("share");
+    await userEvent.click(screen.getByTestId("share-confirm"));
+    expect(await screen.findByTestId("share-error")).toHaveTextContent(
+      "Couldn't share this connection. Please try again.",
+    );
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/workflow-builder/NodeConnectorBindingControl.test.tsx
+++ b/tests/unit/features/workflow-builder/NodeConnectorBindingControl.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for features/workflow-builder/config-modal/NodeConnectorBindingControl
+ * (Slice 4.CONN-SHARE / CS-5b). Mocks the typed client so no real fetch happens.
+ * Asserts the per-status copy/controls, that Save/Clear call the binding routes,
+ * the invalid (unavailable) state, and a no-leak check (display names only).
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockFetch = jest.fn();
+const mockSet = jest.fn();
+const mockClear = jest.fn();
+jest.mock("@/lib/api/connectorBindings", () => ({
+  fetchNodeConnectorBindingState: (...a: unknown[]) => mockFetch(...a),
+  setNodeConnectorBinding: (...a: unknown[]) => mockSet(...a),
+  clearNodeConnectorBinding: (...a: unknown[]) => mockClear(...a),
+}));
+
+import { NodeConnectorBindingControl } from "@/features/workflow-builder/config-modal/NodeConnectorBindingControl";
+
+function renderControl() {
+  render(<NodeConnectorBindingControl workflowId="wf-1" nodeId="node-7" />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSet.mockResolvedValue({ ok: true });
+  mockClear.mockResolvedValue({ ok: true });
+});
+
+describe("NodeConnectorBindingControl", () => {
+  it.each(["not_applicable", "single_sharer"])("%s → renders nothing", async (status) => {
+    mockFetch.mockResolvedValue({ status, connectors: [], currentConnectorDisplayName: "Alice" });
+    renderControl();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByTestId("connector-binding-control")).toBeNull();
+  });
+
+  it("needs_selection → ambiguous copy + safe options; Save binds the chosen connector", async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: "needs_selection",
+      connectors: [
+        { userId: "alice", displayName: "Alice", role: "owner" },
+        { userId: "bob", displayName: "Bob", role: "member" },
+      ],
+      currentConnectorDisplayName: null,
+    });
+    // After save, the control refetches → return a bound state.
+    mockFetch.mockResolvedValueOnce({ status: "bound", connectors: [], currentConnectorDisplayName: "Bob" });
+    renderControl();
+
+    expect(await screen.findByTestId("connector-binding-picker")).toHaveTextContent(
+      "Multiple team members shared this connection. Choose which one this node should use.",
+    );
+    await userEvent.selectOptions(screen.getByTestId("connector-binding-select"), "bob");
+    await userEvent.click(screen.getByTestId("connector-binding-save"));
+    expect(mockSet).toHaveBeenCalledWith("wf-1", "node-7", "bob");
+  });
+
+  it("bound → 'Using shared connection from {name}'; Stop using clears the binding", async () => {
+    mockFetch.mockResolvedValueOnce({ status: "bound", connectors: [], currentConnectorDisplayName: "Alice" });
+    mockFetch.mockResolvedValueOnce({ status: "needs_selection", connectors: [], currentConnectorDisplayName: null });
+    renderControl();
+
+    expect(await screen.findByTestId("connector-binding-bound")).toHaveTextContent(
+      "Using shared connection from Alice.",
+    );
+    await userEvent.click(screen.getByTestId("connector-binding-clear"));
+    expect(mockClear).toHaveBeenCalledWith("wf-1", "node-7");
+  });
+
+  it("unavailable → safe 'no longer available' copy + re-pick (never silently another connector)", async () => {
+    mockFetch.mockResolvedValue({
+      status: "unavailable",
+      connectors: [{ userId: "bob", displayName: "Bob", role: "member" }],
+      currentConnectorDisplayName: null,
+    });
+    renderControl();
+    expect(await screen.findByTestId("connector-binding-picker")).toHaveTextContent(
+      "This shared connection is no longer available. Choose another connection.",
+    );
+    // No auto-selection — the select starts at the placeholder.
+    expect((screen.getByTestId("connector-binding-select") as HTMLSelectElement).value).toBe("");
+  });
+
+  it("NO LEAK: only display names appear (no email/provider account id)", async () => {
+    mockFetch.mockResolvedValue({
+      status: "needs_selection",
+      connectors: [{ userId: "alice", displayName: "Alice", role: "owner" }],
+      currentConnectorDisplayName: null,
+    });
+    const { container } = render(<NodeConnectorBindingControl workflowId="wf-1" nodeId="node-7" />);
+    await screen.findByTestId("connector-binding-picker");
+    expect(container.textContent ?? "").not.toMatch(/@|token|scope|T-WORKSPACE/i);
+  });
+});

--- a/tests/unit/migrations/integrationSharingScope.test.ts
+++ b/tests/unit/migrations/integrationSharingScope.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ *
+ * Static guard for the explicit-connection-sharing column
+ * (Slice 4.CONN-SHARE / CS-1). Reads the migration SQL (no DB) so CI proves the
+ * shape + the behavior-inert fences on every run:
+ *   - additive nullable `integration_sharing_scope text` on public.integrations,
+ *   - CHECK allows NULL OR one of exactly two known values,
+ *   - NO backfill (no INSERT / UPDATE),
+ *   - NO RLS change (no ENABLE RLS, no CREATE/DROP POLICY),
+ *   - touches NO OAuth/integration token material,
+ *   - operates ONLY on public.integrations (no other table touched).
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const ROOT = process.cwd();
+const MIGRATIONS = resolve(ROOT, "supabase/migrations");
+const FILE = "20260622000000_add_integration_sharing_scope.sql";
+
+const sql = readFileSync(join(MIGRATIONS, FILE), "utf8");
+const code = sql.replace(/--[^\n]*/g, ""); // strip comments for code assertions
+
+describe("CS-1 — integration_sharing_scope column (static guards)", () => {
+  describe("additive nullable column", () => {
+    it("adds integration_sharing_scope text to public.integrations", () => {
+      expect(code).toMatch(
+        /ALTER\s+TABLE\s+public\.integrations\s+ADD\s+COLUMN\s+integration_sharing_scope\s+text/i,
+      );
+    });
+
+    it("does NOT declare the column NOT NULL (nullable = unset/derive-default state)", () => {
+      expect(code).not.toMatch(/integration_sharing_scope\s+text\s+NOT\s+NULL/i);
+    });
+  });
+
+  describe("CHECK constraint", () => {
+    it("allows NULL OR exactly the two known values", () => {
+      expect(code).toMatch(
+        /CHECK\s*\(\s*integration_sharing_scope\s+IS\s+NULL\s+OR\s+integration_sharing_scope\s+IN\s*\(\s*'private_to_connector'\s*,\s*'shared_with_account'\s*\)\s*\)/i,
+      );
+    });
+
+    it("names the constraint", () => {
+      expect(code).toMatch(/ADD\s+CONSTRAINT\s+integrations_sharing_scope_chk/i);
+    });
+
+    it("permits no other scope literal", () => {
+      const literals = [...code.matchAll(/'([a-z_]+)'/gi)].map((m) => m[1]);
+      expect(new Set(literals)).toEqual(new Set(["private_to_connector", "shared_with_account"]));
+    });
+  });
+
+  describe("behavior-inert fences", () => {
+    it("performs NO backfill / data write", () => {
+      expect(code).not.toMatch(/\bINSERT\s+INTO\b/i);
+      expect(code).not.toMatch(/\bUPDATE\s+public\./i);
+    });
+
+    it("makes NO RLS change (no ENABLE RLS, no CREATE/DROP POLICY)", () => {
+      expect(code).not.toMatch(/ENABLE\s+ROW\s+LEVEL\s+SECURITY/i);
+      expect(code).not.toMatch(/CREATE\s+POLICY/i);
+      expect(code).not.toMatch(/DROP\s+POLICY/i);
+    });
+
+    it("touches NO OAuth/integration token material", () => {
+      expect(code).not.toMatch(/access_token/i);
+      expect(code).not.toMatch(/refresh_token/i);
+      expect(code).not.toMatch(/encrypted/i);
+    });
+
+    it("operates ONLY on public.integrations", () => {
+      const tablesTouched = [...code.matchAll(/ALTER\s+TABLE\s+public\.(\w+)/gi)].map((m) =>
+        m[1]!.toLowerCase(),
+      );
+      expect(new Set(tablesTouched)).toEqual(new Set(["integrations"]));
+    });
+
+    it("creates NO new table (so no RLS/GRANT obligation)", () => {
+      expect(code).not.toMatch(/CREATE\s+TABLE/i);
+    });
+  });
+});

--- a/tests/unit/migrations/workflowNodeConnectorBindings.test.ts
+++ b/tests/unit/migrations/workflowNodeConnectorBindings.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ *
+ * Static guard for the workflow_node_connector_bindings foundation
+ * (Slice 4.CONN-SHARE / CS-4a). Reads the migration SQL (no DB) so CI proves the
+ * shape + behavior-inert fences: table + columns + FKs, one-per-node unique,
+ * indexes, set_updated_at trigger, RLS + membership-gated SELECT policy + NO
+ * client write policy, explicit GRANTs, NO status column, NO provider map in SQL,
+ * NO backfill, NO token columns.
+ */
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const MIGRATIONS = resolve(process.cwd(), "supabase/migrations");
+const FILE = "20260623000000_workflow_node_connector_bindings.sql";
+const sql = readFileSync(join(MIGRATIONS, FILE), "utf8");
+const code = sql.replace(/--[^\n]*/g, ""); // strip comments for code assertions
+
+describe("CS-4a — workflow_node_connector_bindings foundation (static guards)", () => {
+  describe("table + columns", () => {
+    it("creates the side table", () => {
+      expect(code).toMatch(/CREATE\s+TABLE\s+public\.workflow_node_connector_bindings/i);
+    });
+    it("keys the workflow with ON DELETE CASCADE", () => {
+      expect(code).toMatch(
+        /workflow_id\s+uuid\s+NOT\s+NULL\s+REFERENCES\s+public\.workflows\(id\)\s+ON\s+DELETE\s+CASCADE/i,
+      );
+    });
+    it("binds connector_user_id to auth.users with ON DELETE CASCADE", () => {
+      expect(code).toMatch(
+        /connector_user_id\s+uuid\s+NOT\s+NULL\s+REFERENCES\s+auth\.users\(id\)\s+ON\s+DELETE\s+CASCADE/i,
+      );
+    });
+    it("records created_by_user_id provenance with ON DELETE SET NULL", () => {
+      expect(code).toMatch(
+        /created_by_user_id\s+uuid\s+REFERENCES\s+auth\.users\(id\)\s+ON\s+DELETE\s+SET\s+NULL/i,
+      );
+    });
+    it("has NOT NULL node_id + provider", () => {
+      expect(code).toMatch(/node_id\s+text\s+NOT\s+NULL/i);
+      expect(code).toMatch(/provider\s+text\s+NOT\s+NULL/i);
+    });
+    it("has NO status column (direct binding, not a consent machine)", () => {
+      expect(code).not.toMatch(/\bstatus\b/i);
+    });
+  });
+
+  describe("indexes + trigger", () => {
+    it("one binding per node (full unique on workflow_id, node_id)", () => {
+      expect(code).toMatch(
+        /CREATE\s+UNIQUE\s+INDEX\s+workflow_node_connector_bindings_one_per_node\s+ON\s+public\.workflow_node_connector_bindings\s*\(\s*workflow_id\s*,\s*node_id\s*\)/i,
+      );
+    });
+    it("indexes workflow_id and connector_user_id", () => {
+      expect(code).toMatch(/CREATE\s+INDEX\s+workflow_node_connector_bindings_workflow_idx[\s\S]*?\(\s*workflow_id\s*\)/i);
+      expect(code).toMatch(/CREATE\s+INDEX\s+workflow_node_connector_bindings_connector_idx[\s\S]*?\(\s*connector_user_id\s*\)/i);
+    });
+    it("wires the set_updated_at trigger", () => {
+      expect(code).toMatch(
+        /CREATE\s+TRIGGER\s+workflow_node_connector_bindings_set_updated_at[\s\S]*?EXECUTE\s+FUNCTION\s+public\.set_updated_at\(\)/i,
+      );
+    });
+  });
+
+  describe("RLS + GRANTs", () => {
+    it("enables RLS", () => {
+      expect(code).toMatch(
+        /ALTER\s+TABLE\s+public\.workflow_node_connector_bindings\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY/i,
+      );
+    });
+    it("has a membership-gated, freeze-aware SELECT policy", () => {
+      expect(code).toMatch(
+        /CREATE\s+POLICY\s+workflow_node_connector_bindings_select_account_member\s+ON\s+public\.workflow_node_connector_bindings\s+FOR\s+SELECT/i,
+      );
+      expect(code).toMatch(/JOIN\s+public\.account_memberships\s+am/i);
+      expect(code).toMatch(/am\.user_id\s*=\s*auth\.uid\(\)/i);
+      expect(code).toMatch(/a\.deletion_status\s*=\s*'active'/i);
+    });
+    it("has NO user-facing write policy (writes are service-role only)", () => {
+      expect(code).not.toMatch(/FOR\s+INSERT/i);
+      expect(code).not.toMatch(/FOR\s+UPDATE/i);
+      expect(code).not.toMatch(/FOR\s+DELETE/i);
+    });
+    it("grants SELECT to authenticated and all to service_role", () => {
+      expect(code).toMatch(/GRANT\s+SELECT\s+ON\s+public\.workflow_node_connector_bindings\s+TO\s+authenticated/i);
+      expect(code).toMatch(
+        /GRANT\s+SELECT,\s*INSERT,\s*UPDATE,\s*DELETE\s+ON\s+public\.workflow_node_connector_bindings\s+TO\s+service_role/i,
+      );
+    });
+  });
+
+  describe("hard fences", () => {
+    it("does NOT duplicate the provider classification map in SQL", () => {
+      expect(code).not.toMatch(/'gmail'/i);
+      expect(code).not.toMatch(/'slack'/i);
+    });
+    it("touches NO OAuth/integration token material", () => {
+      expect(code).not.toMatch(/access_token|refresh_token|encrypted|integration_sharing_scope/i);
+    });
+    it("performs NO backfill / data write", () => {
+      expect(code).not.toMatch(/\bINSERT\s+INTO\b/i);
+      expect(code).not.toMatch(/\bUPDATE\s+public\./i);
+    });
+  });
+});

--- a/tests/unit/repositories/integrations-sharedConnectors.test.ts
+++ b/tests/unit/repositories/integrations-sharedConnectors.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for repositories/integrations.listSharedConnectorUserIdsServiceRole
+ * (Slice 4.CONN-SHARE / CS-3a). Asserts the query filters so DISCONNECTED and
+ * UNSHARED rows are excluded by construction, selects ONLY connected_by_user_id
+ * (no token/scope/metadata read), and returns a deduped, null-safe id set.
+ */
+
+interface ChainState {
+  filters: Array<{ op: string; args: unknown[] }>;
+  selected: string | null;
+  resultData: unknown;
+  resultError: { message: string } | null;
+}
+
+function makeMockClient(state: ChainState) {
+  const builder: Record<string, unknown> = {};
+  Object.assign(builder, {
+    select: jest.fn((cols: string) => {
+      state.selected = cols;
+      return builder;
+    }),
+    eq: jest.fn((col: string, val: unknown) => {
+      state.filters.push({ op: "eq", args: [col, val] });
+      return builder;
+    }),
+    is: jest.fn((col: string, val: unknown) => {
+      state.filters.push({ op: "is", args: [col, val] });
+      return builder;
+    }),
+    // The repo awaits the builder directly (list query, no maybeSingle) — make it thenable.
+    then: (onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) =>
+      Promise.resolve({ data: state.resultData, error: state.resultError }).then(onF, onR),
+  });
+  return { from: jest.fn(() => builder) };
+}
+
+const mockServiceRole: { current: ReturnType<typeof makeMockClient> | null } = { current: null };
+jest.mock("@/repositories/supabase/serviceRoleClient", () => ({
+  getServiceRoleClient: jest.fn(() => mockServiceRole.current),
+}));
+
+import { listSharedConnectorUserIdsServiceRole } from "@/repositories/integrations";
+
+function freshState(resultData: unknown): ChainState {
+  return { filters: [], selected: null, resultData, resultError: null };
+}
+
+describe("listSharedConnectorUserIdsServiceRole", () => {
+  it("filters account, provider, sharing_scope='shared_with_account', and disconnected_at IS NULL", async () => {
+    const state = freshState([{ connected_by_user_id: "u1" }]);
+    mockServiceRole.current = makeMockClient(state);
+    await listSharedConnectorUserIdsServiceRole("acct-A", "gmail");
+
+    expect(state.filters).toContainEqual({ op: "eq", args: ["account_id", "acct-A"] });
+    expect(state.filters).toContainEqual({ op: "eq", args: ["provider", "gmail"] });
+    expect(state.filters).toContainEqual({
+      op: "eq",
+      args: ["integration_sharing_scope", "shared_with_account"],
+    });
+    expect(state.filters).toContainEqual({ op: "is", args: ["disconnected_at", null] });
+  });
+
+  it("selects ONLY connected_by_user_id (no token/scope/metadata)", async () => {
+    const state = freshState([]);
+    mockServiceRole.current = makeMockClient(state);
+    await listSharedConnectorUserIdsServiceRole("acct-A", "gmail");
+    expect(state.selected).toBe("connected_by_user_id");
+  });
+
+  it("returns a deduped, null-safe set of distinct connector ids", async () => {
+    const state = freshState([
+      { connected_by_user_id: "u1" },
+      { connected_by_user_id: "u1" }, // dup (two shared rows, same connector)
+      { connected_by_user_id: "u2" },
+      { connected_by_user_id: null }, // ignored
+    ]);
+    mockServiceRole.current = makeMockClient(state);
+    const ids = await listSharedConnectorUserIdsServiceRole("acct-A", "gmail");
+    expect([...ids].sort()).toEqual(["u1", "u2"]);
+  });
+
+  it("empty result ⇒ empty set", async () => {
+    const state = freshState([]);
+    mockServiceRole.current = makeMockClient(state);
+    const ids = await listSharedConnectorUserIdsServiceRole("acct-A", "gmail");
+    expect(ids.size).toBe(0);
+  });
+
+  it("propagates supabase errors", async () => {
+    const state: ChainState = { filters: [], selected: null, resultData: null, resultError: { message: "permission denied" } };
+    mockServiceRole.current = makeMockClient(state);
+    await expect(listSharedConnectorUserIdsServiceRole("acct-A", "gmail")).rejects.toThrow(
+      /permission denied/,
+    );
+  });
+});

--- a/tests/unit/repositories/workflowNodeConnectorBindings.test.ts
+++ b/tests/unit/repositories/workflowNodeConnectorBindings.test.ts
@@ -32,6 +32,10 @@ function makeMockClient(state: ChainState) {
       state.filters.push({ op: "eq", args: [col, val] });
       return builder;
     }),
+    in: jest.fn((col: string, val: unknown) => {
+      state.filters.push({ op: "in", args: [col, val] });
+      return builder;
+    }),
     order: jest.fn(() => builder),
     single: jest.fn(async () => ({ data: state.resultData, error: state.resultError })),
     maybeSingle: jest.fn(async () => ({ data: state.resultData, error: state.resultError })),
@@ -50,6 +54,7 @@ import {
   getForNodeServiceRole,
   setForNodeServiceRole,
   deleteForNodeServiceRole,
+  deleteForMemberInAccountServiceRole,
   listByWorkflowServiceRole,
   ACCOUNT_PROVIDER_NOT_BINDABLE,
 } from "@/repositories/workflowNodeConnectorBindings";
@@ -135,5 +140,25 @@ describe("workflowNodeConnectorBindings repo", () => {
     const state: ChainState = { filters: [], resultData: null, resultError: { message: "permission denied" } };
     mockServiceRole.current = makeMockClient(state);
     await expect(listByWorkflowServiceRole("wf-1")).rejects.toThrow(/permission denied/);
+  });
+
+  describe("deleteForMemberInAccountServiceRole (offboarding)", () => {
+    it("scopes by account_id (via FK embed) + connector_user_id and deletes the matched ids", async () => {
+      const state = freshState([{ id: "b1" }, { id: "b2" }]);
+      mockServiceRole.current = makeMockClient(state);
+      const res = await deleteForMemberInAccountServiceRole({ accountId: "acc-1", connectorUserId: "conn-2" });
+      expect(res).toEqual({ deletedCount: 2 });
+      expect(state.filters).toContainEqual({ op: "eq", args: ["workflows.account_id", "acc-1"] });
+      expect(state.filters).toContainEqual({ op: "eq", args: ["connector_user_id", "conn-2"] });
+      expect(state.filters).toContainEqual({ op: "in", args: ["id", ["b1", "b2"]] });
+    });
+
+    it("0 matches → no delete, deletedCount 0 (idempotent no-op)", async () => {
+      const state = freshState([]);
+      mockServiceRole.current = makeMockClient(state);
+      const res = await deleteForMemberInAccountServiceRole({ accountId: "acc-1", connectorUserId: "nobody" });
+      expect(res).toEqual({ deletedCount: 0 });
+      expect(state.filters).not.toContainEqual({ op: "in", args: ["id", expect.anything()] });
+    });
   });
 });

--- a/tests/unit/repositories/workflowNodeConnectorBindings.test.ts
+++ b/tests/unit/repositories/workflowNodeConnectorBindings.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for repositories/workflowNodeConnectorBindings.ts (CS-4a). Mocks the
+ * service-role client to verify row payloads, snake_case translation, the
+ * upsert onConflict key, the per-node filters, and the account-provider reject.
+ * No DB — live RLS proofs would be a gated harness.
+ */
+
+interface ChainState {
+  upsertPayload?: unknown;
+  upsertOpts?: unknown;
+  filters: Array<{ op: string; args: unknown[] }>;
+  resultData: unknown;
+  resultError: { message: string; code?: string } | null;
+}
+
+function makeMockClient(state: ChainState) {
+  const builder: Record<string, unknown> = {};
+  Object.assign(builder, {
+    upsert: jest.fn((p: unknown, opts: unknown) => {
+      state.upsertPayload = p;
+      state.upsertOpts = opts;
+      return builder;
+    }),
+    delete: jest.fn(() => builder),
+    select: jest.fn((cols?: string) => {
+      state.filters.push({ op: "select", args: [cols ?? "*"] });
+      return builder;
+    }),
+    eq: jest.fn((col: string, val: unknown) => {
+      state.filters.push({ op: "eq", args: [col, val] });
+      return builder;
+    }),
+    order: jest.fn(() => builder),
+    single: jest.fn(async () => ({ data: state.resultData, error: state.resultError })),
+    maybeSingle: jest.fn(async () => ({ data: state.resultData, error: state.resultError })),
+    then: (resolve: (v: unknown) => void) =>
+      resolve({ data: state.resultData, error: state.resultError }),
+  });
+  return { from: jest.fn(() => builder), state };
+}
+
+const mockServiceRole: { current: ReturnType<typeof makeMockClient> | null } = { current: null };
+jest.mock("@/repositories/supabase/serviceRoleClient", () => ({
+  getServiceRoleClient: jest.fn(() => mockServiceRole.current),
+}));
+
+import {
+  getForNodeServiceRole,
+  setForNodeServiceRole,
+  deleteForNodeServiceRole,
+  listByWorkflowServiceRole,
+  ACCOUNT_PROVIDER_NOT_BINDABLE,
+} from "@/repositories/workflowNodeConnectorBindings";
+
+const baseRow = {
+  id: "bind-1",
+  workflow_id: "wf-1",
+  node_id: "node-7",
+  provider: "gmail",
+  connector_user_id: "conn-2",
+  created_by_user_id: "user-1",
+  created_at: "2026-06-12T00:00:00Z",
+  updated_at: "2026-06-12T00:00:00Z",
+};
+
+function freshState(resultData: unknown): ChainState {
+  return { filters: [], resultData, resultError: null };
+}
+
+describe("workflowNodeConnectorBindings repo", () => {
+  it("setForNode UPSERTs with the (workflow_id,node_id) conflict key + snake_case payload", async () => {
+    const state = freshState(baseRow);
+    mockServiceRole.current = makeMockClient(state);
+    const rec = await setForNodeServiceRole({
+      workflowId: "wf-1", nodeId: "node-7", provider: "gmail", connectorUserId: "conn-2", createdByUserId: "user-1",
+    });
+    expect(rec.connectorUserId).toBe("conn-2");
+    expect(state.upsertPayload).toMatchObject({
+      workflow_id: "wf-1", node_id: "node-7", provider: "gmail", connector_user_id: "conn-2", created_by_user_id: "user-1",
+    });
+    expect(state.upsertOpts).toEqual({ onConflict: "workflow_id,node_id" });
+  });
+
+  it("setForNode REJECTS an account/service provider (no SQL write)", async () => {
+    const state = freshState(baseRow);
+    mockServiceRole.current = makeMockClient(state);
+    await expect(
+      setForNodeServiceRole({ workflowId: "wf-1", nodeId: "n", provider: "slack", connectorUserId: "c", createdByUserId: "u" }),
+    ).rejects.toThrow(ACCOUNT_PROVIDER_NOT_BINDABLE);
+    expect(state.upsertPayload).toBeUndefined();
+  });
+
+  it("getForNode filters by workflow_id + node_id and maps the row", async () => {
+    const state = freshState(baseRow);
+    mockServiceRole.current = makeMockClient(state);
+    const rec = await getForNodeServiceRole("wf-1", "node-7");
+    expect(rec?.id).toBe("bind-1");
+    expect(state.filters).toContainEqual({ op: "eq", args: ["workflow_id", "wf-1"] });
+    expect(state.filters).toContainEqual({ op: "eq", args: ["node_id", "node-7"] });
+  });
+
+  it("getForNode returns null when no row", async () => {
+    const state = freshState(null);
+    mockServiceRole.current = makeMockClient(state);
+    expect(await getForNodeServiceRole("wf-1", "node-x")).toBeNull();
+  });
+
+  it("deleteForNode filters by node and reports deleted:true when a row matched", async () => {
+    const state = freshState([{ id: "bind-1" }]);
+    mockServiceRole.current = makeMockClient(state);
+    const res = await deleteForNodeServiceRole("wf-1", "node-7");
+    expect(res).toEqual({ deleted: true });
+    expect(state.filters).toContainEqual({ op: "eq", args: ["workflow_id", "wf-1"] });
+    expect(state.filters).toContainEqual({ op: "eq", args: ["node_id", "node-7"] });
+  });
+
+  it("deleteForNode reports deleted:false when nothing matched (idempotent)", async () => {
+    const state = freshState([]);
+    mockServiceRole.current = makeMockClient(state);
+    expect(await deleteForNodeServiceRole("wf-1", "node-x")).toEqual({ deleted: false });
+  });
+
+  it("listByWorkflow filters by workflow_id and maps rows", async () => {
+    const state = freshState([baseRow]);
+    mockServiceRole.current = makeMockClient(state);
+    const rows = await listByWorkflowServiceRole("wf-1");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.nodeId).toBe("node-7");
+    expect(state.filters).toContainEqual({ op: "eq", args: ["workflow_id", "wf-1"] });
+  });
+
+  it("propagates supabase errors", async () => {
+    const state: ChainState = { filters: [], resultData: null, resultError: { message: "permission denied" } };
+    mockServiceRole.current = makeMockClient(state);
+    await expect(listByWorkflowServiceRole("wf-1")).rejects.toThrow(/permission denied/);
+  });
+});

--- a/tests/unit/services/accounts/leaveAccount.test.ts
+++ b/tests/unit/services/accounts/leaveAccount.test.ts
@@ -41,6 +41,14 @@ jest.mock("@/repositories/workflowNodeCredentials", () => ({
   },
 }));
 
+const mockDeleteBindings = jest.fn();
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  deleteForMemberInAccountServiceRole: (...a: unknown[]) => {
+    order.push("deleteBindings");
+    return mockDeleteBindings(...a);
+  },
+}));
+
 const mockClearActive = jest.fn();
 jest.mock("@/repositories/userProfiles", () => ({
   clearActiveAccountIfMatchesServiceRole: (...a: unknown[]) => {
@@ -77,6 +85,7 @@ beforeEach(() => {
   mockRemove.mockReset().mockResolvedValue(undefined);
   mockSoftDisconnect.mockReset().mockResolvedValue({ disconnectedCount: 0, disconnectedProviders: [] });
   mockRevokeGrants.mockReset().mockResolvedValue({ revokedCount: 0 });
+  mockDeleteBindings.mockReset().mockResolvedValue({ deletedCount: 0 });
   mockClearActive.mockReset().mockResolvedValue(undefined);
 });
 
@@ -88,7 +97,7 @@ describe("leaveAccount", () => {
     const r = await leaveAccount({ accountId: ACCOUNT, userId: USER });
 
     expect(r).toEqual({ ok: true });
-    expect(order).toEqual(["revoke", "disconnect", "remove", "clearActive"]);
+    expect(order).toEqual(["revoke", "deleteBindings", "disconnect", "remove", "clearActive"]);
     expect(mockRevokeGrants).toHaveBeenCalledWith({ accountId: ACCOUNT, credentialOwnerUserId: USER });
     expect(mockSoftDisconnect).toHaveBeenCalledWith({ accountId: ACCOUNT, connectedByUserId: USER });
     expect(mockRemove).toHaveBeenCalledWith(ACCOUNT, USER);
@@ -100,7 +109,7 @@ describe("leaveAccount", () => {
     mockGetRoleSR.mockResolvedValueOnce("admin");
     const r = await leaveAccount({ accountId: ACCOUNT, userId: USER });
     expect(r).toEqual({ ok: true });
-    expect(order).toEqual(["revoke", "disconnect", "remove", "clearActive"]);
+    expect(order).toEqual(["revoke", "deleteBindings", "disconnect", "remove", "clearActive"]);
   });
 
   it("a sole owner is blocked and NO offboarding runs", async () => {

--- a/tests/unit/services/accounts/membership.test.ts
+++ b/tests/unit/services/accounts/membership.test.ts
@@ -43,6 +43,12 @@ jest.mock("@/repositories/workflowNodeCredentials", () => ({
   listAcceptedOwnedByUserInAccountServiceRole: (...a: unknown[]) => mockListAcceptedOwned(...a),
 }));
 
+// CS-4b: node connector binding delete on offboarding.
+const mockDeleteBindings = jest.fn();
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  deleteForMemberInAccountServiceRole: (...a: unknown[]) => mockDeleteBindings(...a),
+}));
+
 // TW-5: getMemberWorkflowImpact → countImpactedWorkflowsForMember reads the
 // workflows repo. Mock it so the impact path can be exercised without a DB.
 const mockWfListByAccount = jest.fn();
@@ -72,6 +78,7 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue({ disconnectedCount: 0, disconnectedProviders: [] });
   mockRevokeGrants.mockReset().mockResolvedValue({ revokedCount: 0 });
+  mockDeleteBindings.mockReset().mockResolvedValue({ deletedCount: 0 });
   mockListAcceptedOwned.mockReset().mockResolvedValue([]);
   mockWfListByAccount.mockReset().mockResolvedValue([]);
 });

--- a/tests/unit/services/execution/engine.test.ts
+++ b/tests/unit/services/execution/engine.test.ts
@@ -118,6 +118,25 @@ jest.mock("@/services/billing/workflowCostEstimator", () => ({
   estimateWorkflowTaskCost: (...args: unknown[]) => mockEstimateWorkflowTaskCost(...args),
 }));
 
+// CS-4b — capture the credential-resolution context owner per handler call, and
+// stub the shared plan. Flag OFF (default for every other test) → the engine
+// never calls buildWorkflowCredentialPlan, so these stubs are inert there.
+const mockBuildPlan = jest.fn();
+jest.mock("@/services/integrations/connectionResolution", () => ({
+  buildWorkflowCredentialPlan: (...a: unknown[]) => mockBuildPlan(...a),
+}));
+const mockCapturedOwners: Array<string | null> = [];
+jest.mock("@/services/oauth/credentialResolutionContext", () => ({
+  runWithCredentialResolutionContext: (
+    ctx: { createdByUserId: string | null },
+    fn: () => unknown,
+  ) => {
+    mockCapturedOwners.push(ctx.createdByUserId);
+    return fn();
+  },
+  getCredentialResolutionContext: () => undefined,
+}));
+
 const SHADOW_FLAG = "ENABLE_RESERVE_RECONCILE_SHADOW";
 const BILLING_FLAG = "ENABLE_RESERVE_RECONCILE_BILLING";
 
@@ -2733,5 +2752,58 @@ describe("WorkflowEngine — live reserve/reconcile billing (Slice 4.COST-15H)",
     expect(mockBillingGate).toHaveBeenCalledWith("acct-user-1", { testMode: false });
     expect(mockCreateBillingReservation).not.toHaveBeenCalled();
     expect(mockReconcileBillingReservation).not.toHaveBeenCalled();
+  });
+});
+
+describe("CS-4b — execution resolves to the shared plan owner (ENABLE_CONNECTION_SHARING ON)", () => {
+  const CONN_FLAG = "ENABLE_CONNECTION_SHARING";
+  const gmailAction = {
+    id: "a-gmail", kind: "action" as const, provider: "gmail", type: "send",
+    config: {}, position: { x: 0, y: 100 },
+  };
+  const gmailWf = {
+    ...baseWorkflow,
+    createdByUserId: "creator-1",
+    draftDefinition: { nodes: [trigger("t1"), gmailAction], edges: [edge("e1", "t1", "a-gmail")] },
+  };
+
+  beforeEach(() => {
+    mockCapturedOwners.length = 0;
+    process.env[CONN_FLAG] = "true";
+  });
+  afterEach(() => {
+    delete process.env[CONN_FLAG];
+  });
+
+  async function runWithPlanOwner(owner: string) {
+    mockGetByIdServiceRole.mockResolvedValueOnce(gmailWf);
+    mockGetActionHandler.mockReturnValueOnce(async () => ({ output: {} }));
+    mockBuildPlan.mockResolvedValueOnce({
+      ownerByNode: new Map([["a-gmail", owner]]),
+      resolutions: new Map(),
+      allTeamRunnable: true,
+    });
+    await new WorkflowEngine({ resolveStrict: (v) => v }).runWorkflow({
+      workflowId: "wf-1",
+      triggerNodeId: "t1",
+      triggerEvent,
+    });
+    // The gmail action is processed last → its owner is the last captured context.
+    return mockCapturedOwners[mockCapturedOwners.length - 1];
+  }
+
+  it("builds the shared plan and runs the gmail node under the plan's connector (not creator/runner)", async () => {
+    const owner = await runWithPlanOwner("connector-bob");
+    expect(mockBuildPlan).toHaveBeenCalledWith({
+      workflowId: "wf-1", accountId: "acct-user-1", createdByUserId: "creator-1",
+      nodes: gmailWf.draftDefinition.nodes,
+    });
+    expect(owner).toBe("connector-bob");
+  });
+
+  it("when the plan resolves a node to the creator (ambiguous/unshared), execution uses the creator — never an arbitrary co-member", async () => {
+    const owner = await runWithPlanOwner("creator-1");
+    expect(owner).toBe("creator-1");
+    expect(mockCapturedOwners).not.toContain("connector-bob");
   });
 });

--- a/tests/unit/services/integrations/connectionBinding.test.ts
+++ b/tests/unit/services/integrations/connectionBinding.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-4a node connector binding service
+ * (services/integrations/connectionBinding). The pure classifier runs for real;
+ * repos + membership + flag are mocked. Covers: flag gate, the resolve/authz
+ * matrix, account/native rejection, the connector validation chain (member →
+ * connected → shared) incl. the no-silent-share fence, the fail-closed lifecycle
+ * (unshared/disconnected ⇒ rejected), the safe picker, list, and no-leak.
+ */
+const mockGetWf = jest.fn();
+const mockGetDeletionStatus = jest.fn();
+const mockIsMember = jest.fn();
+const mockGetActive = jest.fn();
+const mockListShared = jest.fn();
+const mockSetForNode = jest.fn();
+const mockDeleteForNode = jest.fn();
+const mockListByWorkflow = jest.fn();
+const mockListMembers = jest.fn();
+const mockFlag = jest.fn();
+
+jest.mock("@/repositories/workflows", () => ({ getByIdServiceRole: (...a: unknown[]) => mockGetWf(...a) }));
+jest.mock("@/repositories/accounts", () => ({ getDeletionStatusServiceRole: (...a: unknown[]) => mockGetDeletionStatus(...a) }));
+jest.mock("@/repositories/accountMemberships", () => ({ isMemberServiceRole: (...a: unknown[]) => mockIsMember(...a) }));
+jest.mock("@/repositories/integrations", () => ({
+  getActiveForExecution: (...a: unknown[]) => mockGetActive(...a),
+  listSharedConnectorUserIdsServiceRole: (...a: unknown[]) => mockListShared(...a),
+}));
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  setForNodeServiceRole: (...a: unknown[]) => mockSetForNode(...a),
+  deleteForNodeServiceRole: (...a: unknown[]) => mockDeleteForNode(...a),
+  listByWorkflowServiceRole: (...a: unknown[]) => mockListByWorkflow(...a),
+}));
+jest.mock("@/services/accounts/membership", () => ({ listMembers: (...a: unknown[]) => mockListMembers(...a) }));
+jest.mock("@/services/integrations/connectionSharingFlags", () => ({ isConnectionSharingEnabled: () => mockFlag() }));
+
+import {
+  setNodeConnectorBinding,
+  clearNodeConnectorBinding,
+  listEligibleSharedConnectors,
+  listWorkflowConnectorBindings,
+} from "@/services/integrations/connectionBinding";
+
+const ACCOUNT = "acc-1";
+const CREATOR = "creator-1";
+const CONNECTOR = "connector-9";
+
+function wf(over: Record<string, unknown> = {}) {
+  return {
+    id: "wf-1",
+    accountId: ACCOUNT,
+    createdByUserId: CREATOR,
+    state: "active",
+    draftDefinition: { nodes: [{ id: "node-7", provider: "gmail" }], edges: [] },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFlag.mockReturnValue(true);
+  mockGetWf.mockResolvedValue(wf());
+  mockGetDeletionStatus.mockResolvedValue("active");
+  mockIsMember.mockResolvedValue(true);
+  mockGetActive.mockResolvedValue({ id: "int-1" }); // active connection present
+  mockListShared.mockResolvedValue(new Set([CONNECTOR]));
+  mockSetForNode.mockResolvedValue({});
+  mockDeleteForNode.mockResolvedValue({ deleted: true });
+});
+
+const setArgs = (over = {}) => ({
+  workflowId: "wf-1", nodeId: "node-7", connectorUserId: CONNECTOR, callerUserId: CREATOR, callerRole: "member" as const, ...over,
+});
+
+describe("setNodeConnectorBinding — flag + resolve gate", () => {
+  it("flag OFF ⇒ not_enabled, no reads/writes", async () => {
+    mockFlag.mockReturnValue(false);
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "not_enabled" });
+    expect(mockGetWf).not.toHaveBeenCalled();
+    expect(mockSetForNode).not.toHaveBeenCalled();
+  });
+  it("missing/deleted workflow ⇒ workflow_not_found", async () => {
+    mockGetWf.mockResolvedValue(null);
+    expect((await setNodeConnectorBinding(setArgs())).ok).toBe(false);
+    mockGetWf.mockResolvedValue(wf({ state: "deleted" }));
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "workflow_not_found" });
+  });
+  it("unknown node ⇒ node_not_found", async () => {
+    expect(await setNodeConnectorBinding(setArgs({ nodeId: "nope" }))).toEqual({ ok: false, reason: "node_not_found" });
+  });
+  it("account provider node ⇒ not_applicable", async () => {
+    mockGetWf.mockResolvedValue(wf({ draftDefinition: { nodes: [{ id: "node-7", provider: "slack" }], edges: [] } }));
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "not_applicable" });
+  });
+  it("native node ⇒ not_applicable", async () => {
+    mockGetWf.mockResolvedValue(wf({ draftDefinition: { nodes: [{ id: "node-7", provider: "native" }], edges: [] } }));
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "not_applicable" });
+  });
+  it("frozen account ⇒ account_frozen", async () => {
+    mockGetDeletionStatus.mockResolvedValue("pending_deletion");
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "account_frozen" });
+  });
+  it("non-editor (plain member, not creator) ⇒ forbidden, no write", async () => {
+    expect(await setNodeConnectorBinding(setArgs({ callerUserId: "member-x", callerRole: "member" }))).toEqual({
+      ok: false, reason: "forbidden",
+    });
+    expect(mockSetForNode).not.toHaveBeenCalled();
+  });
+});
+
+describe("setNodeConnectorBinding — connector validation (fail closed)", () => {
+  it("connector not a member ⇒ connector_not_member", async () => {
+    mockIsMember.mockResolvedValue(false);
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "connector_not_member" });
+    expect(mockSetForNode).not.toHaveBeenCalled();
+  });
+  it("connector disconnected / no active row ⇒ connector_not_connected", async () => {
+    mockGetActive.mockResolvedValue(null);
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "connector_not_connected" });
+    expect(mockSetForNode).not.toHaveBeenCalled();
+  });
+  it("connector connected but UNSHARED ⇒ connector_not_shared (no silent share)", async () => {
+    mockListShared.mockResolvedValue(new Set()); // not in shared set
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: false, reason: "connector_not_shared" });
+    expect(mockSetForNode).not.toHaveBeenCalled();
+  });
+  it("owner/admin binding to an UNSHARED connector is STILL connector_not_shared", async () => {
+    mockListShared.mockResolvedValue(new Set());
+    expect(await setNodeConnectorBinding(setArgs({ callerUserId: "owner-1", callerRole: "owner" }))).toEqual({
+      ok: false, reason: "connector_not_shared",
+    });
+  });
+});
+
+describe("setNodeConnectorBinding — success", () => {
+  it("creator binds a member + connected + shared connector ⇒ ok, upserts", async () => {
+    expect(await setNodeConnectorBinding(setArgs())).toEqual({ ok: true });
+    expect(mockSetForNode).toHaveBeenCalledWith({
+      workflowId: "wf-1", nodeId: "node-7", provider: "gmail", connectorUserId: CONNECTOR, createdByUserId: CREATOR,
+    });
+  });
+  it("owner (non-creator) may bind a shared connector ⇒ ok", async () => {
+    expect(await setNodeConnectorBinding(setArgs({ callerUserId: "owner-1", callerRole: "owner" }))).toEqual({ ok: true });
+  });
+  it("connector binding their OWN shared connection ⇒ ok (connector is the creator here)", async () => {
+    expect(await setNodeConnectorBinding(setArgs({ connectorUserId: CREATOR, callerUserId: CREATOR }))).toEqual({ ok: false, reason: "connector_not_shared" });
+    // (creator not in shared set in this fixture) — flip the set to prove the happy path:
+    mockListShared.mockResolvedValue(new Set([CREATOR]));
+    expect(await setNodeConnectorBinding(setArgs({ connectorUserId: CREATOR, callerUserId: CREATOR }))).toEqual({ ok: true });
+  });
+});
+
+describe("clearNodeConnectorBinding", () => {
+  it("flag OFF ⇒ not_enabled", async () => {
+    mockFlag.mockReturnValue(false);
+    expect(await clearNodeConnectorBinding({ workflowId: "wf-1", nodeId: "node-7", callerUserId: CREATOR, callerRole: "member" })).toEqual({
+      ok: false, reason: "not_enabled",
+    });
+  });
+  it("non-editor ⇒ forbidden", async () => {
+    expect(await clearNodeConnectorBinding({ workflowId: "wf-1", nodeId: "node-7", callerUserId: "m", callerRole: "member" })).toEqual({
+      ok: false, reason: "forbidden",
+    });
+    expect(mockDeleteForNode).not.toHaveBeenCalled();
+  });
+  it("editor clears ⇒ ok with cleared flag", async () => {
+    expect(await clearNodeConnectorBinding({ workflowId: "wf-1", nodeId: "node-7", callerUserId: CREATOR, callerRole: "member" })).toEqual({
+      ok: true, cleared: true,
+    });
+  });
+});
+
+describe("listEligibleSharedConnectors — safe picker", () => {
+  it("returns {userId, displayName, role} for members in the shared set; NO email leak", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"]));
+    mockListMembers.mockResolvedValue([
+      { userId: "alice", displayName: "Alice", role: "owner", email: "alice@example.com" },
+      { userId: "bob", displayName: "Bob", role: "member", email: "bob@example.com" },
+      { userId: "carol", displayName: "Carol", role: "member", email: "carol@example.com" }, // not shared
+    ]);
+    const res = await listEligibleSharedConnectors({ workflowId: "wf-1", nodeId: "node-7", callerUserId: CREATOR, callerRole: "member" });
+    expect(res).toEqual({
+      ok: true,
+      connectors: [
+        { userId: "alice", displayName: "Alice", role: "owner" },
+        { userId: "bob", displayName: "Bob", role: "member" },
+      ],
+    });
+    const serialized = JSON.stringify(res);
+    expect(serialized).not.toContain("@example.com");
+    expect(serialized).not.toContain("carol");
+  });
+  it("non-editor ⇒ forbidden", async () => {
+    expect(await listEligibleSharedConnectors({ workflowId: "wf-1", nodeId: "node-7", callerUserId: "m", callerRole: "member" })).toEqual({
+      ok: false, reason: "forbidden",
+    });
+  });
+  it("flag OFF ⇒ not_enabled", async () => {
+    mockFlag.mockReturnValue(false);
+    expect((await listEligibleSharedConnectors({ workflowId: "wf-1", nodeId: "node-7", callerUserId: CREATOR, callerRole: "member" })).ok).toBe(false);
+  });
+});
+
+describe("listWorkflowConnectorBindings", () => {
+  it("editor sees per-node bindings with display name (no email)", async () => {
+    mockListByWorkflow.mockResolvedValue([{ nodeId: "node-7", provider: "gmail", connectorUserId: "alice" }]);
+    mockListMembers.mockResolvedValue([{ userId: "alice", displayName: "Alice", role: "owner", email: "alice@example.com" }]);
+    const res = await listWorkflowConnectorBindings({ workflowId: "wf-1", callerUserId: CREATOR, callerRole: "member" });
+    expect(res).toEqual({
+      ok: true,
+      bindings: [{ nodeId: "node-7", provider: "gmail", connectorUserId: "alice", connectorDisplayName: "Alice" }],
+    });
+    expect(JSON.stringify(res)).not.toContain("@example.com");
+  });
+  it("non-editor ⇒ forbidden", async () => {
+    expect(await listWorkflowConnectorBindings({ workflowId: "wf-1", callerUserId: "m", callerRole: "member" })).toEqual({
+      ok: false, reason: "forbidden",
+    });
+  });
+});

--- a/tests/unit/services/integrations/connectionBindingState.test.ts
+++ b/tests/unit/services/integrations/connectionBindingState.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-5b builder state read
+ * (services/integrations/connectionBinding.getNodeConnectorBindingState). The
+ * status precedence mirrors the CS-4b resolver: grant → bound(valid) → stale →
+ * single-sharer → ambiguous. No-leak: status + safe {userId,displayName,role} +
+ * a display name only.
+ */
+const mockGetWf = jest.fn();
+const mockGetDeletionStatus = jest.fn();
+const mockListShared = jest.fn();
+const mockAccepted = jest.fn();
+const mockGetBinding = jest.fn();
+const mockListMembers = jest.fn();
+const mockFlag = jest.fn();
+
+jest.mock("@/repositories/workflows", () => ({ getByIdServiceRole: (...a: unknown[]) => mockGetWf(...a) }));
+jest.mock("@/repositories/accounts", () => ({ getDeletionStatusServiceRole: (...a: unknown[]) => mockGetDeletionStatus(...a) }));
+jest.mock("@/repositories/accountMemberships", () => ({ isMemberServiceRole: jest.fn() }));
+jest.mock("@/repositories/integrations", () => ({
+  getActiveForExecution: jest.fn(),
+  listSharedConnectorUserIdsServiceRole: (...a: unknown[]) => mockListShared(...a),
+}));
+jest.mock("@/services/teamCredentials/nodeCredentialOwners", () => ({
+  loadAcceptedNodeOwners: (...a: unknown[]) => mockAccepted(...a),
+}));
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  setForNodeServiceRole: jest.fn(),
+  deleteForNodeServiceRole: jest.fn(),
+  listByWorkflowServiceRole: jest.fn(),
+  getForNodeServiceRole: (...a: unknown[]) => mockGetBinding(...a),
+}));
+jest.mock("@/services/accounts/membership", () => ({ listMembers: (...a: unknown[]) => mockListMembers(...a) }));
+jest.mock("@/services/integrations/connectionSharingFlags", () => ({ isConnectionSharingEnabled: () => mockFlag() }));
+
+import { getNodeConnectorBindingState } from "@/services/integrations/connectionBinding";
+
+const CREATOR = "creator-1";
+function wf(over: Record<string, unknown> = {}) {
+  return {
+    id: "wf-1", accountId: "acc-1", createdByUserId: CREATOR, state: "active",
+    draftDefinition: { nodes: [{ id: "node-7", provider: "gmail" }], edges: [] }, ...over,
+  };
+}
+const args = (over = {}) => ({ workflowId: "wf-1", nodeId: "node-7", callerUserId: CREATOR, callerRole: "owner" as const, ...over });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFlag.mockReturnValue(true);
+  mockGetWf.mockResolvedValue(wf());
+  mockGetDeletionStatus.mockResolvedValue("active");
+  mockAccepted.mockResolvedValue(new Map());
+  mockGetBinding.mockResolvedValue(null);
+  mockListShared.mockResolvedValue(new Set());
+  mockListMembers.mockResolvedValue([
+    { userId: "alice", displayName: "Alice", role: "owner", email: "alice@example.com" },
+    { userId: "bob", displayName: "Bob", role: "member", email: "bob@example.com" },
+  ]);
+});
+
+describe("getNodeConnectorBindingState", () => {
+  it("flag OFF → not_enabled", async () => {
+    mockFlag.mockReturnValue(false);
+    expect(await getNodeConnectorBindingState(args())).toEqual({ ok: false, reason: "not_enabled" });
+  });
+
+  it("account/native node → 200 not_applicable state (not an error)", async () => {
+    mockGetWf.mockResolvedValue(wf({ draftDefinition: { nodes: [{ id: "node-7", provider: "slack" }], edges: [] } }));
+    const r = await getNodeConnectorBindingState(args());
+    expect(r).toEqual({ ok: true, status: "not_applicable", connectors: [], currentConnectorDisplayName: null });
+  });
+
+  it("accepted node-credential grant WINS → not_applicable (reassignment UI owns it)", async () => {
+    mockAccepted.mockResolvedValue(new Map([["node-7", "grantOwner"]]));
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"]));
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("not_applicable");
+  });
+
+  it("0 shared → unavailable", async () => {
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("unavailable");
+  });
+
+  it("exactly one shared connector → single_sharer + that display name", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice"]));
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("single_sharer");
+    expect(r.ok && r.currentConnectorDisplayName).toBe("Alice");
+  });
+
+  it("2+ shared, no binding → needs_selection with safe connector options", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"]));
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("needs_selection");
+    expect(r.ok && r.connectors).toEqual([
+      { userId: "alice", displayName: "Alice", role: "owner" },
+      { userId: "bob", displayName: "Bob", role: "member" },
+    ]);
+  });
+
+  it("2+ shared + VALID binding → bound with the bound connector's display name", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"]));
+    mockGetBinding.mockResolvedValue({ nodeId: "node-7", provider: "gmail", connectorUserId: "bob" });
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("bound");
+    expect(r.ok && r.currentConnectorDisplayName).toBe("Bob");
+  });
+
+  it("STALE binding (bound connector no longer shared) → unavailable, never silently another", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"])); // 'carol' not shared
+    mockGetBinding.mockResolvedValue({ nodeId: "node-7", provider: "gmail", connectorUserId: "carol" });
+    const r = await getNodeConnectorBindingState(args());
+    expect(r.ok && r.status).toBe("unavailable");
+    expect(r.ok && r.currentConnectorDisplayName).toBe(null);
+  });
+
+  it("non-editor (plain member) → forbidden", async () => {
+    const r = await getNodeConnectorBindingState(args({ callerUserId: "m", callerRole: "member" }));
+    expect(r).toEqual({ ok: false, reason: "forbidden" });
+  });
+
+  it("NO LEAK: no email / raw scope / provider account id in the state", async () => {
+    mockListShared.mockResolvedValue(new Set(["alice", "bob"]));
+    const r = await getNodeConnectorBindingState(args());
+    expect(JSON.stringify(r)).not.toContain("@example.com");
+  });
+});

--- a/tests/unit/services/integrations/connectionResolution.test.ts
+++ b/tests/unit/services/integrations/connectionResolution.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-4b shared credential plan
+ * (services/integrations/connectionResolution.buildWorkflowCredentialPlan) — the
+ * single computation the run/edit gate and the execution engine both consume.
+ * The pure precedence + classifier run for real; the three reads (accepted
+ * grants, bindings, shared sets) are mocked. This is the canonical EXECUTION-OWNER
+ * proof: `ownerByNode` is exactly what the engine threads into the credential
+ * context, and `allTeamRunnable` is exactly what the gate decides on.
+ */
+const mockAccepted = jest.fn();
+const mockBindings = jest.fn();
+const mockShared = jest.fn();
+
+jest.mock("@/services/teamCredentials/nodeCredentialOwners", () => ({
+  loadAcceptedNodeOwners: (...a: unknown[]) => mockAccepted(...a),
+}));
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  listByWorkflowServiceRole: (...a: unknown[]) => mockBindings(...a),
+}));
+jest.mock("@/repositories/integrations", () => ({
+  listSharedConnectorUserIdsServiceRole: (...a: unknown[]) => mockShared(...a),
+}));
+
+import { buildWorkflowCredentialPlan } from "@/services/integrations/connectionResolution";
+
+const CREATOR = "creator-1";
+const gmailNode = { id: "n-gmail", provider: "gmail" };
+
+function plan(over: { nodes?: { id: string; provider: string }[] } = {}) {
+  return buildWorkflowCredentialPlan({
+    workflowId: "wf-1",
+    accountId: "acc-1",
+    createdByUserId: CREATOR,
+    nodes: over.nodes ?? [{ id: "t", provider: "native" }, gmailNode],
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAccepted.mockResolvedValue(new Map()); // no grants
+  mockBindings.mockResolvedValue([]); // no bindings
+  mockShared.mockResolvedValue(new Set()); // no sharers
+});
+
+describe("buildWorkflowCredentialPlan", () => {
+  it("no personal nodes (native/account only) → empty plan, allTeamRunnable, NO reads", async () => {
+    const p = await plan({ nodes: [{ id: "t", provider: "native" }, { id: "a", provider: "slack" }] });
+    expect(p.ownerByNode.size).toBe(0);
+    expect(p.allTeamRunnable).toBe(true);
+    expect(mockBindings).not.toHaveBeenCalled();
+    expect(mockShared).not.toHaveBeenCalled();
+  });
+
+  it("single shared connector → owner = that connector (execution), teamRunnable", async () => {
+    mockShared.mockResolvedValue(new Set(["alice"]));
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe("alice");
+    expect(p.resolutions.get("n-gmail")!.via).toBe("single_sharer");
+    expect(p.allTeamRunnable).toBe(true);
+  });
+
+  it("two shared, NO binding → owner = creator (fail closed); NOT team-runnable; NOT earliest row", async () => {
+    mockShared.mockResolvedValue(new Set(["alice", "bob"]));
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe(CREATOR); // creator pin, never 'alice'/'bob'
+    expect(p.allTeamRunnable).toBe(false);
+  });
+
+  it("two shared + VALID binding → owner = bound connector; team-runnable", async () => {
+    mockShared.mockResolvedValue(new Set(["alice", "bob"]));
+    mockBindings.mockResolvedValue([{ nodeId: "n-gmail", provider: "gmail", connectorUserId: "bob" }]);
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe("bob");
+    expect(p.resolutions.get("n-gmail")!.via).toBe("binding");
+    expect(p.allTeamRunnable).toBe(true);
+  });
+
+  it("accepted grant BEATS binding + share", async () => {
+    mockShared.mockResolvedValue(new Set(["alice", "bob"]));
+    mockBindings.mockResolvedValue([{ nodeId: "n-gmail", provider: "gmail", connectorUserId: "bob" }]);
+    mockAccepted.mockResolvedValue(new Map([["n-gmail", "grantOwner"]]));
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe("grantOwner");
+    expect(p.resolutions.get("n-gmail")!.via).toBe("grant");
+  });
+
+  it("INVALID binding (bound connector no longer shared) → ignored, falls to creator (fail closed)", async () => {
+    mockShared.mockResolvedValue(new Set(["alice", "bob"])); // 'carol' not shared anymore
+    mockBindings.mockResolvedValue([{ nodeId: "n-gmail", provider: "gmail", connectorUserId: "carol" }]);
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe(CREATOR); // never silently 'carol' or an arbitrary row
+    expect(p.allTeamRunnable).toBe(false);
+  });
+
+  it("stale binding for a DIFFERENT provider is ignored", async () => {
+    mockShared.mockResolvedValue(new Set(["alice"]));
+    mockBindings.mockResolvedValue([{ nodeId: "n-gmail", provider: "google-drive", connectorUserId: "zzz" }]);
+    const p = await plan();
+    expect(p.ownerByNode.get("n-gmail")).toBe("alice"); // single-sharer, not the mismatched binding
+  });
+
+  it("mixed providers: all single-shared → allTeamRunnable", async () => {
+    mockShared.mockImplementation(async (_acc: string, provider: string) =>
+      provider === "gmail" ? new Set(["alice"]) : new Set(["bob"]),
+    );
+    const p = await plan({ nodes: [{ id: "t", provider: "native" }, gmailNode, { id: "n-drive", provider: "google-drive" }] });
+    expect(p.allTeamRunnable).toBe(true);
+    expect(p.ownerByNode.get("n-gmail")).toBe("alice");
+    expect(p.ownerByNode.get("n-drive")).toBe("bob");
+  });
+
+  it("mixed providers: one unresolved blocks allTeamRunnable", async () => {
+    mockShared.mockImplementation(async (_acc: string, provider: string) =>
+      provider === "gmail" ? new Set(["alice"]) : new Set(), // drive unshared
+    );
+    const p = await plan({ nodes: [{ id: "t", provider: "native" }, gmailNode, { id: "n-drive", provider: "google-drive" }] });
+    expect(p.allTeamRunnable).toBe(false);
+  });
+
+  it("NO LEAK: ownerByNode holds user ids for INTERNAL use; reads select no token/scope (covered by repo tests)", async () => {
+    mockShared.mockResolvedValue(new Set(["alice"]));
+    const p = await plan();
+    // The plan is never serialized to a client — it carries owner user ids by design
+    // (the engine pins by user). Assert it exposes ONLY the documented shape.
+    expect(Object.keys(p).sort()).toEqual(["allTeamRunnable", "ownerByNode", "resolutions"]);
+  });
+});

--- a/tests/unit/services/integrations/connectionSharing.test.ts
+++ b/tests/unit/services/integrations/connectionSharing.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-2 connection-sharing service
+ * (services/integrations/connectionSharing.setIntegrationSharingScope).
+ *
+ * Covers: flag gate (OFF ⇒ no I/O, no mutation), frozen-account refusal, the
+ * authz matrix (SHARE = connector only; UNSHARE = connector OR owner/admin
+ * safety), cross-account / non-member / disconnected ⇒ not_found, account-
+ * provider rejection, the changed flag, the disconnected-mid-flight race, the
+ * admin-safety audit event, and a NO-LEAK assertion that no token / email /
+ * scope / connector id appears in the result or the structured audit logs.
+ * `credentialSharing` + `sharingScope` run for real; repos + the flag are mocked.
+ */
+const mockGetById = jest.fn();
+const mockSetScope = jest.fn();
+const mockGetDeletionStatus = jest.fn();
+const mockGetRole = jest.fn();
+const mockFlag = jest.fn();
+
+jest.mock("@/repositories/integrations", () => ({
+  getByIdForAccountServiceRole: (...a: unknown[]) => mockGetById(...a),
+  setSharingScopeByIdServiceRole: (...a: unknown[]) => mockSetScope(...a),
+}));
+jest.mock("@/repositories/accounts", () => ({
+  getDeletionStatusServiceRole: (...a: unknown[]) => mockGetDeletionStatus(...a),
+}));
+jest.mock("@/repositories/accountMemberships", () => ({
+  getRoleServiceRole: (...a: unknown[]) => mockGetRole(...a),
+}));
+jest.mock("@/services/integrations/connectionSharingFlags", () => ({
+  isConnectionSharingEnabled: () => mockFlag(),
+}));
+
+import { setIntegrationSharingScope } from "@/services/integrations/connectionSharing";
+
+const SECRET_ACCESS = "enc-access-SECRET";
+const CONNECTOR = "user-A-connector-id";
+
+function gmailRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "int-1",
+    accountId: "acc-1",
+    connectedByUserId: CONNECTOR,
+    provider: "gmail", // personal
+    providerAccountId: "pa-secret-1",
+    displayName: "Personal · a@example.com",
+    accessTokenEncrypted: SECRET_ACCESS,
+    refreshTokenEncrypted: "enc-refresh-SECRET",
+    accessTokenExpiresAt: null,
+    scopes: ["gmail.send"],
+    accountMetadata: {},
+    disconnectedAt: null,
+    integrationSharingScope: null, // unset = private_to_connector
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+function slackRow(over: Record<string, unknown> = {}) {
+  return gmailRow({ id: "int-s", provider: "slack", ...over });
+}
+
+let infoSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFlag.mockReturnValue(true); // feature ON for most tests
+  mockGetDeletionStatus.mockResolvedValue("active");
+  mockSetScope.mockResolvedValue({ updated: true });
+  infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+});
+afterEach(() => infoSpy.mockRestore());
+
+function allLoggedJson(): string {
+  return infoSpy.mock.calls.map((c) => String(c[0])).join("\n");
+}
+
+describe("setIntegrationSharingScope — flag gate", () => {
+  it("flag OFF ⇒ not_enabled, ZERO I/O and no mutation", async () => {
+    mockFlag.mockReturnValue(false);
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1",
+      integrationId: "int-1",
+      callerUserId: CONNECTOR,
+      scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_enabled" });
+    expect(mockGetDeletionStatus).not.toHaveBeenCalled();
+    expect(mockGetById).not.toHaveBeenCalled();
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+});
+
+describe("setIntegrationSharingScope — guards (no existence leak)", () => {
+  it("frozen account ⇒ account_frozen, no row lookup, no mutation", async () => {
+    mockGetDeletionStatus.mockResolvedValue("pending_deletion");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "account_frozen" });
+    expect(mockGetById).not.toHaveBeenCalled();
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+
+  it("unknown / cross-account id ⇒ not_found", async () => {
+    mockGetById.mockResolvedValue(null);
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-x", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+
+  it("non-member caller ⇒ not_found (no existence leak)", async () => {
+    mockGetById.mockResolvedValue(gmailRow());
+    mockGetRole.mockResolvedValue(null);
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "stranger", scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+
+  it("disconnected row ⇒ not_found, never mutated", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ disconnectedAt: "2026-06-01T00:00:00Z" }));
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+
+  it("disconnected mid-flight (updated:false) ⇒ not_found", async () => {
+    mockGetById.mockResolvedValue(gmailRow());
+    mockGetRole.mockResolvedValue("member");
+    mockSetScope.mockResolvedValue({ updated: false });
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "not_found" });
+  });
+});
+
+describe("setIntegrationSharingScope — account provider not shareable", () => {
+  it.each(["shared_with_account", "private_to_connector"] as const)(
+    "account provider (slack) + %s ⇒ account_provider_not_shareable, no mutation",
+    async (scope) => {
+      mockGetById.mockResolvedValue(slackRow());
+      mockGetRole.mockResolvedValue("owner");
+      const res = await setIntegrationSharingScope({
+        accountId: "acc-1", integrationId: "int-s", callerUserId: CONNECTOR, scope,
+      });
+      expect(res).toEqual({ ok: false, reason: "account_provider_not_shareable" });
+      expect(mockSetScope).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe("setIntegrationSharingScope — SHARE (connector only)", () => {
+  it("the connector CAN share their own active personal connection", async () => {
+    mockGetById.mockResolvedValue(gmailRow());
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: true, scope: "shared_with_account", changed: true });
+    expect(mockSetScope).toHaveBeenCalledWith({ integrationId: "int-1", scope: "shared_with_account" });
+    expect(allLoggedJson()).toContain("account.integration.sharing.shared");
+  });
+
+  it("already shared ⇒ changed:false (idempotent), still writes", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ integrationSharingScope: "shared_with_account" }));
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: true, scope: "shared_with_account", changed: false });
+  });
+
+  it.each(["owner", "admin"])("a NON-connector %s CANNOT silently share a member's connection ⇒ forbidden", async (role) => {
+    mockGetById.mockResolvedValue(gmailRow({ connectedByUserId: "member-1" }));
+    mockGetRole.mockResolvedValue(role);
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "admin-z", scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "forbidden" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+
+  it("a non-connector plain member CANNOT share another member's connection ⇒ forbidden", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ connectedByUserId: "member-1" }));
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "member-2", scope: "shared_with_account",
+    });
+    expect(res).toEqual({ ok: false, reason: "forbidden" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+});
+
+describe("setIntegrationSharingScope — UNSHARE", () => {
+  it("the connector CAN unshare their own connection (clears to NULL)", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ integrationSharingScope: "shared_with_account" }));
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: CONNECTOR, scope: "private_to_connector",
+    });
+    expect(res).toEqual({ ok: true, scope: "private_to_connector", changed: true });
+    expect(mockSetScope).toHaveBeenCalledWith({ integrationId: "int-1", scope: null });
+    expect(allLoggedJson()).toContain("account.integration.sharing.unshared");
+    expect(allLoggedJson()).not.toContain("admin_unshared");
+  });
+
+  it.each(["owner", "admin"])("a non-connector %s CAN unshare as a framed admin-safety action (audit-logged)", async (role) => {
+    mockGetById.mockResolvedValue(gmailRow({ connectedByUserId: "member-1", integrationSharingScope: "shared_with_account" }));
+    mockGetRole.mockResolvedValue(role);
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "admin-z", scope: "private_to_connector",
+    });
+    expect(res).toEqual({ ok: true, scope: "private_to_connector", changed: true });
+    expect(mockSetScope).toHaveBeenCalledWith({ integrationId: "int-1", scope: null });
+    const logged = allLoggedJson();
+    expect(logged).toContain("account.integration.sharing.admin_unshared");
+    expect(logged).toContain(`"actorRole":"${role}"`);
+  });
+
+  it("a non-connector plain member CANNOT unshare another member's connection ⇒ forbidden", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ connectedByUserId: "member-1", integrationSharingScope: "shared_with_account" }));
+    mockGetRole.mockResolvedValue("member");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "member-2", scope: "private_to_connector",
+    });
+    expect(res).toEqual({ ok: false, reason: "forbidden" });
+    expect(mockSetScope).not.toHaveBeenCalled();
+  });
+});
+
+describe("setIntegrationSharingScope — NO LEAK", () => {
+  it("never returns or logs a token / email / scope / connector id", async () => {
+    mockGetById.mockResolvedValue(gmailRow({ integrationSharingScope: "shared_with_account" }));
+    mockGetRole.mockResolvedValue("owner");
+    const res = await setIntegrationSharingScope({
+      accountId: "acc-1", integrationId: "int-1", callerUserId: "admin-z", scope: "private_to_connector",
+    });
+    const serialized = JSON.stringify(res) + "\n" + allLoggedJson();
+    expect(serialized).not.toContain(SECRET_ACCESS);
+    expect(serialized).not.toContain("enc-refresh-SECRET");
+    expect(serialized).not.toContain("a@example.com");
+    expect(serialized).not.toContain("gmail.send");
+    expect(serialized).not.toContain("pa-secret-1"); // provider_account_id
+    expect(serialized).not.toContain(CONNECTOR); // connector id
+  });
+});

--- a/tests/unit/services/integrations/connectionSharingEligibility.test.ts
+++ b/tests/unit/services/integrations/connectionSharingEligibility.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-3a eligibility service
+ * (services/integrations/connectionSharingEligibility.computeWorkflowSharingEligibility).
+ *
+ * The pure core (`computeRunEditEligibility`) runs for real; the repo read + flag
+ * are mocked. Covers: flag-OFF no-I/O WF-RUNPERM parity, creator / no-private
+ * short-circuit (no DB read), single/ambiguous/unshared resolution, the per-
+ * provider read fan-out, and a no-leak check that connector ids never appear in
+ * the result.
+ */
+const mockListShared = jest.fn();
+const mockFlag = jest.fn();
+
+jest.mock("@/repositories/integrations", () => ({
+  listSharedConnectorUserIdsServiceRole: (...a: unknown[]) => mockListShared(...a),
+}));
+jest.mock("@/services/integrations/connectionSharingFlags", () => ({
+  isConnectionSharingEnabled: () => mockFlag(),
+}));
+
+import type { WorkflowDefinition } from "@/contracts/workflowDefinition";
+import { computeWorkflowSharingEligibility } from "@/services/integrations/connectionSharingEligibility";
+
+let seq = 0;
+function def(...providers: string[]): WorkflowDefinition {
+  seq = 0;
+  return {
+    nodes: providers.map((p, i) => ({
+      id: `n${seq++}`,
+      kind: i === 0 ? "trigger" : "action",
+      provider: p,
+      type: "x",
+      config: {},
+      position: { x: 0, y: 0 },
+    })),
+    edges: [],
+  } as WorkflowDefinition;
+}
+
+const ACCOUNT = "acc-1";
+const CREATOR = "creator-1";
+const OTHER = "member-2";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFlag.mockReturnValue(true);
+});
+
+describe("computeWorkflowSharingEligibility", () => {
+  it("flag OFF ⇒ NO DB read; WF-RUNPERM parity (private non-creator blocked)", async () => {
+    mockFlag.mockReturnValue(false);
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res).toEqual({ allowed: false, reason: "flag_off_legacy", providerStatuses: [] });
+    expect(mockListShared).not.toHaveBeenCalled();
+  });
+
+  it("flag OFF, no private ⇒ allowed, no DB read", async () => {
+    mockFlag.mockReturnValue(false);
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "slack"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.reason).toBe("flag_off_legacy");
+    expect(mockListShared).not.toHaveBeenCalled();
+  });
+
+  it("flag ON, creator ⇒ allowed WITHOUT a DB read (short-circuit)", async () => {
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: CREATOR,
+    });
+    expect(res).toEqual({ allowed: true, reason: "creator", providerStatuses: [] });
+    expect(mockListShared).not.toHaveBeenCalled();
+  });
+
+  it("flag ON, no private providers ⇒ allowed WITHOUT a DB read", async () => {
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "slack"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res.reason).toBe("no_private_credentials");
+    expect(mockListShared).not.toHaveBeenCalled();
+  });
+
+  it("flag ON, non-creator, ONE shared connector ⇒ eligible; reads exactly that provider", async () => {
+    mockListShared.mockResolvedValue(new Set(["connector-A"]));
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res.allowed).toBe(true);
+    expect(res.reason).toBe("all_providers_single_shared");
+    expect(mockListShared).toHaveBeenCalledWith(ACCOUNT, "gmail");
+    expect(mockListShared).toHaveBeenCalledTimes(1);
+  });
+
+  it("flag ON, non-creator, TWO shared connectors ⇒ blocked_ambiguous", async () => {
+    mockListShared.mockResolvedValue(new Set(["connector-A", "connector-B"]));
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("blocked_ambiguous");
+  });
+
+  it("flag ON, non-creator, ZERO shared ⇒ blocked_unshared", async () => {
+    mockListShared.mockResolvedValue(new Set());
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe("blocked_unshared");
+  });
+
+  it("flag ON, mixed providers: reads each provider once; all single ⇒ eligible", async () => {
+    mockListShared.mockImplementation(async (_acc: string, provider: string) =>
+      provider === "gmail" ? new Set(["A"]) : new Set(["B"]),
+    );
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT,
+      definition: def("native", "gmail", "google-drive"),
+      createdByUserId: CREATOR,
+      callerUserId: OTHER,
+    });
+    expect(res.allowed).toBe(true);
+    const providersRead = mockListShared.mock.calls.map((c) => c[1]).sort();
+    expect(providersRead).toEqual(["gmail", "google-drive"]);
+  });
+
+  it("NO LEAK: connector ids from the repo never appear in the result", async () => {
+    mockListShared.mockResolvedValue(new Set(["secret-connector-id-xyz", "secret-connector-id-2"]));
+    const res = await computeWorkflowSharingEligibility({
+      accountId: ACCOUNT, definition: def("native", "gmail"), createdByUserId: CREATOR, callerUserId: OTHER,
+    });
+    const serialized = JSON.stringify(res);
+    expect(serialized).not.toContain("secret-connector-id-xyz");
+    expect(serialized).not.toContain("secret-connector-id-2");
+  });
+});


### PR DESCRIPTION
## CONN-SHARE production promotion (scoped)

Promotes the explicit private-connection sharing feature (CS-1 → CS-5b) to production.

**Scope:** CONN-SHARE only — 13 cherry-picked commits off `v2-main`. Verified to contain **no** AI-DIAG, AI-CREDITS, billing, MCP, or unrelated files.

**Verified on this exact commit (`65d5b2b86`):**
- typecheck 0 errors · lint 0 errors · lint:structure · lint:migrations
- build 75/75 static pages
- full Jest 17,615 passed / 0 failed
- targeted CONN-SHARE + Apps + builder picker + run/edit + engine + offboarding: 385/385

**Prod DB migrations confirmed applied** (`20260622000000`, `20260623000000`) with objects + RLS + grants verified. **Vercel Production** has `ENABLE_CONNECTION_SHARING=true`.

Feature enablement is env-var driven; code stays opt-in (`=== "true"`). Kill-switch: set `ENABLE_CONNECTION_SHARING=false`.
