### PR TITLE
fix(oauth): bind connect-start active account into state (account-scoping hotfix)

### DIFF
--- a/app/api/integrations/oauth/[provider]/callback/route.ts
+++ b/app/api/integrations/oauth/[provider]/callback/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import {
   handleCallback,
   ReconnectIdentityMismatchError,
+  StateAccountAccessError,
 } from "@/services/oauth/dispatcher";
 
 /**
@@ -67,6 +68,14 @@ export async function GET(
     if (err instanceof ReconnectIdentityMismatchError) {
       return NextResponse.redirect(
         new URL("/apps?integration_error=reconnect_account_mismatch", base),
+      );
+    }
+    // OAUTH-ACCT-BIND — the initiator lost access to the state-bound account
+    // between connect and callback. Stable, non-leaking code (never the account
+    // or user id); the Apps banner renders friendly copy. Nothing was written.
+    if (err instanceof StateAccountAccessError) {
+      return NextResponse.redirect(
+        new URL("/apps?integration_error=account_access_revoked", base),
       );
     }
     const message = err instanceof Error ? err.message : "callback_failed";

--- a/app/api/integrations/oauth/[provider]/connect/route.ts
+++ b/app/api/integrations/oauth/[provider]/connect/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/utils/supabase/server";
 import type { ProviderHint } from "@/contracts/integration";
 import { connect } from "@/services/oauth/dispatcher";
 import { resolveReconnectTarget } from "@/services/integrations/reconnect";
+import { resolveActiveAccount } from "@/services/accounts/activeAccount";
 
 /**
  * Initiates an OAuth connection for the authenticated user.
@@ -126,9 +127,35 @@ export async function POST(
     };
   }
 
+  // OAUTH-ACCT-BIND fix: resolve the target account at connect-START and bind it
+  // into the signed OAuth state (in the dispatcher). A normal connect targets the
+  // user's ACTIVE account (the account switcher) — so a connect started on a Team
+  // account lands on that Team account, never silently on Personal. A reconnect
+  // already resolved + authorized the intended ROW's account above, so it uses
+  // that. resolveActiveAccount enforces membership + freeze; its personal-account
+  // result only occurs when the user has no active team selected (the correct
+  // default), never as a silent override of an active team.
+  let accountId: string;
+  if (reconnectBundle !== undefined) {
+    accountId = reconnectBundle.accountId;
+  } else {
+    const resolved = await resolveActiveAccount(user.id);
+    if (!resolved.ok) {
+      // Typed, non-leaking mapping: a non-member explicit/stored account → 403;
+      // a frozen target account → 409. No personal fallback, no silent switch.
+      const statusByReason = { not_member: 403, account_frozen: 409 } as const;
+      return NextResponse.json(
+        { error: resolved.reason },
+        { status: statusByReason[resolved.reason] },
+      );
+    }
+    accountId = resolved.accountId;
+  }
+
   try {
     const { redirectUrl } = await connect({
       userId: user.id,
+      accountId,
       provider,
       ...(providerHint !== undefined ? { providerHint } : {}),
       ...(reconnectBundle !== undefined ? { reconnect: reconnectBundle } : {}),

--- a/services/oauth/dispatcher.ts
+++ b/services/oauth/dispatcher.ts
@@ -39,11 +39,8 @@ import {
   upsertActive,
   type IntegrationRecord,
 } from "@/repositories/integrations";
-import { ensurePersonalAccount } from "@/services/accounts/ensurePersonalAccount";
-import {
-  AccountFrozenError,
-  assertAccountOperational,
-} from "@/services/accounts/accountFreeze";
+import { isMemberServiceRole } from "@/repositories/accountMemberships";
+import { assertAccountOperational } from "@/services/accounts/accountFreeze";
 import { refreshLockKey, withRefreshLock } from "./refreshLock";
 import { createState, consumeState, InvalidStateError } from "./state";
 
@@ -114,6 +111,18 @@ const TOKEN_INGEST_BY_PROVIDER: Readonly<Record<string, ProviderTokenIngestAuth>
 
 export interface ConnectInput {
   userId: string;
+  /**
+   * The V2 account the new integration MUST be written to — resolved by the
+   * connect ROUTE at connect-start from the user's ACTIVE account (the account
+   * switcher), then bound into the signed state JWT so the callback writes to
+   * exactly this account regardless of any active-account/session/cookie change
+   * during the OAuth round trip. NEVER defaulted to the personal account here:
+   * defaulting to personal was the OAUTH-ACCT-BIND bug (a connect started on a
+   * Team account silently landed on Personal). In reconnect mode this is ignored
+   * in favor of the already-authorized `reconnect.accountId` (the target row's
+   * account). Required for the normal connect path.
+   */
+  accountId: string;
   provider: string;
   /**
    * Optional per-tenant provider hint (Slice 12). Set by the connect
@@ -157,6 +166,22 @@ export class ReconnectIdentityMismatchError extends Error {
   constructor() {
     super("reconnect identity mismatch");
     this.name = "ReconnectIdentityMismatchError";
+  }
+}
+
+/**
+ * Thrown by `handleCallback` / `handleTokenIngest` when, at callback time, the
+ * flow-initiating user (from the signed state) is NO LONGER a member of the
+ * state-bound account — e.g. they were removed from the team between connect and
+ * callback. No integration row is created or refreshed. The callback route maps
+ * this to a stable, non-leaking code (`account_access_revoked`) — never the raw
+ * account/user id. This is the membership half of the OAUTH-ACCT-BIND hardening:
+ * the write target is the signed-state account, re-verified for live membership.
+ */
+export class StateAccountAccessError extends Error {
+  constructor() {
+    super("state account access revoked");
+    this.name = "StateAccountAccessError";
   }
 }
 
@@ -210,31 +235,21 @@ export async function connect(input: ConnectInput): Promise<ConnectOutput> {
     throw new Error(`Provider '${input.provider}' does not support OAuth.`);
   }
 
-  // Slice 4.ACCOUNT-MODEL-6: resolve the target V2 account at connect
-  // time and bind it into the signed state JWT. No active-account
-  // switcher yet — default to the user's personal account. The future
-  // switcher slice changes only what we resolve here (the active
-  // account over personal-account fallback); the dispatcher contract
-  // is unchanged.
+  // OAUTH-ACCT-BIND fix: the target V2 account is resolved by the connect ROUTE
+  // at connect-start from the user's ACTIVE account (the account switcher) and
+  // passed in as `input.accountId` — it is bound into the signed state JWT below,
+  // so the callback writes the integration to the account the user was actually
+  // on. It is NOT defaulted to the personal account here (that default was the
+  // bug: a connect started on a Team account silently landed on Personal). The
+  // route enforces membership + freeze (via the active-account resolver) before calling
+  // connect; the callback re-verifies both against the signed state.
   //
-  // Slice 4.APPS-RECONNECT: in reconnect mode the target account is the
-  // intended ROW's account (NOT the personal floor) — the connect route already
-  // resolved + authorized it (membership + not-frozen) via the reconnect
-  // service, so we trust `input.reconnect.accountId` and skip the personal-floor
-  // resolution + freeze check here.
-  let accountId: string;
-  if (input.reconnect) {
-    accountId = input.reconnect.accountId;
-  } else {
-    const ownerAccount = await ensurePersonalAccount(input.userId);
-    accountId = ownerAccount.id;
-    // 4.ACCOUNT-MODEL-10b — account freeze. A pending_deletion account cannot
-    // connect new integrations. Checked on the already-resolved record (no extra
-    // round trip) before any state JWT is minted.
-    if (ownerAccount.deletionStatus === "pending_deletion") {
-      throw new AccountFrozenError(accountId);
-    }
-  }
+  // Slice 4.APPS-RECONNECT: in reconnect mode the target account is the intended
+  // ROW's account (NOT the active account) — the connect route already resolved +
+  // authorized it (membership + not-frozen) via the reconnect service, so we use
+  // `input.reconnect.accountId`.
+  const accountId = input.reconnect ? input.reconnect.accountId : input.accountId;
+  if (!accountId) throw new Error("connect: accountId is required.");
 
   // Token-ingest providers (Slice 17+) take a parallel path. They receive
   // the token from the browser via URL fragment + client POST, not via a
@@ -396,6 +411,17 @@ export async function handleCallback(
   // integration. Service-role status read (no session in the callback path).
   await assertAccountOperational(payload.accountId);
 
+  // OAUTH-ACCT-BIND hardening — re-verify the flow initiator is STILL a member of
+  // the state-bound account at callback time (they could have been removed from a
+  // team between connect and callback). The write target is ALWAYS the signed
+  // state's accountId — never the current active account — so it cannot drift; we
+  // only confirm the initiator still has access to it, else fail safe (no upsert).
+  // Service-role read against the signed-state (userId, accountId); no callback
+  // session is required, so cross-redirect cookie loss can't break a legit connect.
+  if (!(await isMemberServiceRole(payload.accountId, payload.userId))) {
+    throw new StateAccountAccessError();
+  }
+
   const oauth = OAUTH_BY_PROVIDER[input.provider];
   if (!oauth) {
     throw new Error(
@@ -487,6 +513,15 @@ export async function handleTokenIngest(
   }
   if (payload.userId !== input.userId) {
     throw new InvalidStateError("session/state user mismatch");
+  }
+
+  // OAUTH-ACCT-BIND hardening (token-ingest parity with handleCallback): refuse to
+  // persist to a frozen state-bound account, and re-verify the initiator is still
+  // a member of it. The write target is the signed-state accountId, never the
+  // current active account.
+  await assertAccountOperational(payload.accountId);
+  if (!(await isMemberServiceRole(payload.accountId, payload.userId))) {
+    throw new StateAccountAccessError();
   }
 
   const { tokens, account } = await ingestAuth.verifyAndIngestToken({

--- a/tests/unit/app/api/integrations/oauth/connect-route-account-binding.test.ts
+++ b/tests/unit/app/api/integrations/oauth/connect-route-account-binding.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ *
+ * OAUTH-ACCT-BIND — route tests for POST /api/integrations/oauth/[provider]/connect.
+ *
+ * Proves the connect ROUTE resolves the user's ACTIVE account at connect-start and
+ * forwards it to the dispatcher (which binds it into the signed state). A plain
+ * connect on a Team account must pass the TEAM account — never the personal one.
+ * resolveActiveAccount failures map to typed, non-leaking HTTP codes and never
+ * start OAuth. Reconnect continues to use the already-authorized row account.
+ */
+const mockGetUser = jest.fn();
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(async () => ({ auth: { getUser: () => mockGetUser() } })),
+}));
+
+const mockResolveActive = jest.fn();
+jest.mock("@/services/accounts/activeAccount", () => ({
+  resolveActiveAccount: (...a: unknown[]) => mockResolveActive(...a),
+}));
+
+const mockResolveReconnect = jest.fn();
+jest.mock("@/services/integrations/reconnect", () => ({
+  resolveReconnectTarget: (...a: unknown[]) => mockResolveReconnect(...a),
+}));
+
+const mockConnect = jest.fn();
+jest.mock("@/services/oauth/dispatcher", () => ({
+  connect: (...a: unknown[]) => mockConnect(...a),
+}));
+
+import { POST } from "@/app/api/integrations/oauth/[provider]/connect/route";
+
+const USER = "user-A";
+const TEAM = "team-acct-A";
+const PERSONAL = "personal-acct-A";
+
+function params(provider = "notion") {
+  return { params: Promise.resolve({ provider }) };
+}
+function signedIn() {
+  mockGetUser.mockResolvedValueOnce({ data: { user: { id: USER } }, error: null });
+}
+function plainReq(provider = "notion") {
+  return new Request(`http://x/api/integrations/oauth/${provider}/connect`, { method: "POST" });
+}
+function jsonReq(body: unknown, provider = "notion") {
+  return new Request(`http://x/api/integrations/oauth/${provider}/connect`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnect.mockResolvedValue({ redirectUrl: "https://api.notion.com/v1/oauth/authorize?x=1" });
+});
+
+it("plain connect resolves the ACTIVE account and forwards it (team, not personal)", async () => {
+  signedIn();
+  mockResolveActive.mockResolvedValueOnce({ ok: true, accountId: TEAM, source: "active" });
+  const res = await POST(plainReq(), params());
+  expect(res.status).toBe(200);
+  expect(mockResolveActive).toHaveBeenCalledWith(USER);
+  expect(mockConnect).toHaveBeenCalledWith({
+    userId: USER,
+    accountId: TEAM,
+    provider: "notion",
+  });
+  // The bug: this would have been the personal account. Guard against regression.
+  expect(mockConnect.mock.calls[0]![0].accountId).not.toBe(PERSONAL);
+});
+
+it("non-member active account → 403, OAuth never starts", async () => {
+  signedIn();
+  mockResolveActive.mockResolvedValueOnce({ ok: false, reason: "not_member", accountId: TEAM });
+  const res = await POST(plainReq(), params());
+  expect(res.status).toBe(403);
+  expect(mockConnect).not.toHaveBeenCalled();
+});
+
+it("frozen active account → 409, OAuth never starts", async () => {
+  signedIn();
+  mockResolveActive.mockResolvedValueOnce({ ok: false, reason: "account_frozen", accountId: TEAM });
+  const res = await POST(plainReq(), params());
+  expect(res.status).toBe(409);
+  expect(mockConnect).not.toHaveBeenCalled();
+});
+
+it("401 unauthenticated never resolves an account nor starts OAuth", async () => {
+  mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+  const res = await POST(plainReq(), params());
+  expect(res.status).toBe(401);
+  expect(mockResolveActive).not.toHaveBeenCalled();
+  expect(mockConnect).not.toHaveBeenCalled();
+});
+
+it("response leaks no account id on failure (typed reason only)", async () => {
+  signedIn();
+  mockResolveActive.mockResolvedValueOnce({ ok: false, reason: "not_member", accountId: TEAM });
+  const res = await POST(plainReq(), params());
+  const json = await res.json();
+  expect(JSON.stringify(json)).not.toContain(TEAM);
+});
+
+it("reconnect uses the authorized ROW account, not the active account", async () => {
+  signedIn();
+  mockResolveReconnect.mockResolvedValueOnce({
+    ok: true,
+    accountId: "row-team-acct",
+    integrationId: "int-77",
+    expectedProviderAccountId: "marcus@example.com",
+  });
+  const res = await POST(
+    jsonReq({ reconnect: { integrationId: "int-77", accountId: "row-team-acct" } }, "gmail"),
+    params("gmail"),
+  );
+  expect(res.status).toBe(200);
+  // Active-account resolution is NOT consulted for reconnect.
+  expect(mockResolveActive).not.toHaveBeenCalled();
+  expect(mockConnect).toHaveBeenCalledWith({
+    userId: USER,
+    accountId: "row-team-acct",
+    provider: "gmail",
+    reconnect: {
+      integrationId: "int-77",
+      accountId: "row-team-acct",
+      expectedProviderAccountId: "marcus@example.com",
+    },
+  });
+});

--- a/tests/unit/app/api/integrations/oauth/connect-route-reconnect.test.ts
+++ b/tests/unit/app/api/integrations/oauth/connect-route-reconnect.test.ts
@@ -23,6 +23,13 @@ jest.mock("@/services/oauth/dispatcher", () => ({
   connect: (...a: unknown[]) => mockConnect(...a),
 }));
 
+// OAUTH-ACCT-BIND — a plain connect now resolves the user's ACTIVE account at the
+// route. Default to a personal-ish account; the reconnect path never calls it.
+const mockResolveActive = jest.fn();
+jest.mock("@/services/accounts/activeAccount", () => ({
+  resolveActiveAccount: (...a: unknown[]) => mockResolveActive(...a),
+}));
+
 import { POST } from "@/app/api/integrations/oauth/[provider]/connect/route";
 
 const CALLER = "user-1";
@@ -108,9 +115,13 @@ it("on authorize success forwards the resolved bundle to connect() and returns o
     integrationId: "int-77",
     callerUserId: CALLER,
   });
-  // Dispatcher receives the SERVER-resolved bundle (incl. the steering identity).
+  // Reconnect does NOT consult the active-account resolver.
+  expect(mockResolveActive).not.toHaveBeenCalled();
+  // Dispatcher receives the SERVER-resolved bundle (incl. the steering identity)
+  // plus the row's account as accountId (OAUTH-ACCT-BIND — reconnect binds the row).
   expect(mockConnect).toHaveBeenCalledWith({
     userId: CALLER,
+    accountId: "team-acct",
     provider: "gmail",
     reconnect: {
       integrationId: "int-77",
@@ -125,11 +136,17 @@ it("on authorize success forwards the resolved bundle to connect() and returns o
   expect(JSON.stringify(json)).not.toContain("marcus@example.com");
 });
 
-it("a plain connect (no reconnect body) never calls the reconnect resolver", async () => {
+it("a plain connect (no reconnect body) resolves the active account, not the reconnect resolver", async () => {
   signedIn();
+  mockResolveActive.mockResolvedValueOnce({ ok: true, accountId: "active-acct", source: "active" });
   mockConnect.mockResolvedValueOnce({ redirectUrl: "https://slack.com/oauth?x=1" });
   const res = await POST(new Request("http://x", { method: "POST" }), params("slack"));
   expect(res.status).toBe(200);
   expect(mockResolveReconnect).not.toHaveBeenCalled();
-  expect(mockConnect).toHaveBeenCalledWith({ userId: CALLER, provider: "slack" });
+  expect(mockResolveActive).toHaveBeenCalledWith(CALLER);
+  expect(mockConnect).toHaveBeenCalledWith({
+    userId: CALLER,
+    accountId: "active-acct",
+    provider: "slack",
+  });
 });

--- a/tests/unit/services/accounts/activeAccount.test.ts
+++ b/tests/unit/services/accounts/activeAccount.test.ts
@@ -272,12 +272,22 @@ describe("resolver wiring is gate-only; background paths never use it (11c)", ()
   const FOREGROUND_HELPER_FILES = [
     resolve(ROOT, "app/notifications/credentialRequestNotice.ts"),
   ];
+  // OAUTH-ACCT-BIND — the OAuth connect route is a FOREGROUND, user-session entry
+  // point (the user clicks "Connect"). It resolves the caller's active account at
+  // connect-start to bind it into the signed OAuth state, so the new integration
+  // lands on the account the user is actually on (the bug: it used to default to
+  // personal). The dispatcher itself never resolves the active account — the route
+  // passes the resolved id in. This is a foreground gate, NOT a background path.
+  const FOREGROUND_ROUTE_FILES = [
+    resolve(ROOT, "app/api/integrations/oauth/[provider]/connect/route.ts"),
+  ];
   // resolveActiveAccount's production callers — the foreground gates + helpers only.
   const RESOLVER_ALLOWED = new Set([
     DEF_FILE,
     GATE_FILE,
     ...FOREGROUND_PAGE_FILES,
     ...FOREGROUND_HELPER_FILES,
+    ...FOREGROUND_ROUTE_FILES,
   ]);
   // Background entry points must NEVER consult active-account state (default
   // OR set): cron/webhook/polling resolve the workflow's owning account instead.

--- a/tests/unit/services/oauth/dispatcher-callback.test.ts
+++ b/tests/unit/services/oauth/dispatcher-callback.test.ts
@@ -24,6 +24,12 @@ jest.mock("@/services/accounts/accountFreeze", () => ({
   AccountFrozenError: class AccountFrozenError extends Error {},
 }));
 
+// OAUTH-ACCT-BIND — handleCallback re-verifies the initiator's membership of the
+// state-bound account. Member-true by default.
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMemberServiceRole: jest.fn().mockResolvedValue(true),
+}));
+
 jest.mock("@/integrations/slack/oauth", () => ({
   slackOAuth: {
     buildAuthUrl: jest.fn(() => "https://slack.com/oauth/v2/authorize?test=1"),

--- a/tests/unit/services/oauth/dispatcher-encryption-contract.test.ts
+++ b/tests/unit/services/oauth/dispatcher-encryption-contract.test.ts
@@ -50,6 +50,11 @@ jest.mock("@/services/accounts/accountFreeze", () => ({
   AccountFrozenError: class AccountFrozenError extends Error {},
 }));
 
+// OAUTH-ACCT-BIND — handleCallback re-verifies state-bound-account membership.
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMemberServiceRole: jest.fn().mockResolvedValue(true),
+}));
+
 jest.mock("@/repositories/oauthStates", () => ({
   create: (...args: unknown[]) => mockOAuthStatesCreate(...args),
   consumeByNonce: (...args: unknown[]) => mockOAuthStatesConsume(...args),

--- a/tests/unit/services/oauth/dispatcher-reconnect.test.ts
+++ b/tests/unit/services/oauth/dispatcher-reconnect.test.ts
@@ -28,6 +28,9 @@ jest.mock("@/services/accounts/accountFreeze", () => ({
   assertAccountOperational: jest.fn().mockResolvedValue(undefined),
   AccountFrozenError: class AccountFrozenError extends Error {},
 }));
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMemberServiceRole: jest.fn().mockResolvedValue(true),
+}));
 jest.mock("@/repositories/integrations", () => ({
   upsertActive: (...a: unknown[]) => mockUpsertActive(...a),
   getByIdForAccountServiceRole: (...a: unknown[]) => mockGetByIdForAccount(...a),
@@ -77,7 +80,7 @@ describe("connect() — reconnect mode", () => {
   };
 
   it("binds the row + the ROW's account into state and steers Google sign-in; does NOT touch the personal floor", async () => {
-    const { redirectUrl } = await connect({ userId: "user-1", provider: "gmail", reconnect });
+    const { redirectUrl } = await connect({ userId: "user-1", accountId: "team-acct", provider: "gmail", reconnect });
     const u = new URL(redirectUrl);
 
     // Steering (Google): pre-selects the row's email + forces the chooser.
@@ -93,21 +96,18 @@ describe("connect() — reconnect mode", () => {
     expect(mockEnsurePersonalAccount).not.toHaveBeenCalled();
   });
 
-  it("a normal connect (no reconnect) still resolves the personal floor and adds no steering", async () => {
-    mockEnsurePersonalAccount.mockResolvedValue({
-      id: "acct-user-1",
-      type: "personal",
-      ownerUserId: "user-1",
-      deletionStatus: "active",
-      createdAt: "x",
-      updatedAt: "x",
-    });
-    const { redirectUrl } = await connect({ userId: "user-1", provider: "gmail" });
+  it("a normal connect (no reconnect) binds the route-PASSED account and never touches the personal floor", async () => {
+    // OAUTH-ACCT-BIND: the dispatcher binds `input.accountId` (the route's active
+    // account) and no longer resolves the personal floor — the prior behavior
+    // (always ensurePersonalAccount) was the account-scoping bug.
+    const { redirectUrl } = await connect({ userId: "user-1", accountId: "team-acct", provider: "gmail" });
     const u = new URL(redirectUrl);
     expect(u.searchParams.get("login_hint")).toBeNull();
     expect(u.searchParams.get("prompt")).toBe("consent");
-    expect(verifyState(u.searchParams.get("state")!).reconnect).toBeUndefined();
-    expect(mockEnsurePersonalAccount).toHaveBeenCalledWith("user-1");
+    const payload = verifyState(u.searchParams.get("state")!);
+    expect(payload.reconnect).toBeUndefined();
+    expect(payload.accountId).toBe("team-acct");
+    expect(mockEnsurePersonalAccount).not.toHaveBeenCalled();
   });
 });
 
@@ -116,6 +116,7 @@ describe("connect() — Shopify per-tenant reconnect (4.APPS-RECONNECT)", () => 
     // The reconnect bundle's expectedProviderAccountId IS the shop domain.
     const { redirectUrl } = await connect({
       userId: "user-1",
+      accountId: "team-acct",
       provider: "shopify",
       reconnect: {
         integrationId: "int-shop",
@@ -141,6 +142,7 @@ describe("connect() — Shopify per-tenant reconnect (4.APPS-RECONNECT)", () => 
     await expect(
       connect({
         userId: "user-1",
+        accountId: "team-acct",
         provider: "shopify",
         reconnect: {
           integrationId: "int-shop",
@@ -153,6 +155,7 @@ describe("connect() — Shopify per-tenant reconnect (4.APPS-RECONNECT)", () => 
     await expect(
       connect({
         userId: "user-1",
+        accountId: "team-acct",
         provider: "shopify",
         reconnect: {
           integrationId: "int-shop",
@@ -175,6 +178,7 @@ describe("connect() — Shopify per-tenant reconnect (4.APPS-RECONNECT)", () => 
     });
     const { redirectUrl } = await connect({
       userId: "user-1",
+      accountId: "team-acct",
       provider: "shopify",
       providerHint: { shop: "client-store.myshopify.com" },
     });

--- a/tests/unit/services/oauth/dispatcher-token-ingest-trello.test.ts
+++ b/tests/unit/services/oauth/dispatcher-token-ingest-trello.test.ts
@@ -38,6 +38,16 @@ jest.mock("@/services/accounts/ensurePersonalAccount", () => ({
   ensurePersonalAccount: (userId: string) => mockEnsurePersonalAccount(userId),
 }));
 
+// OAUTH-ACCT-BIND — handleTokenIngest now enforces freeze + state-bound-account
+// membership before persisting. Mock both operational/member-true by default.
+jest.mock("@/services/accounts/accountFreeze", () => ({
+  assertAccountOperational: jest.fn().mockResolvedValue(undefined),
+  AccountFrozenError: class AccountFrozenError extends Error {},
+}));
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMemberServiceRole: jest.fn().mockResolvedValue(true),
+}));
+
 import { connect, handleTokenIngest } from "@/services/oauth/dispatcher";
 import { createState, InvalidStateError } from "@/services/oauth/state";
 import { decryptToken } from "@/core/encryption/tokens";
@@ -95,7 +105,7 @@ afterEach(() => {
 
 describe("dispatcher.connect (trello — token_ingest happy path)", () => {
   it("returns a Trello authorize URL with verifiable state in return_url", async () => {
-    const { redirectUrl } = await connect({ userId: "user-1", provider: "trello" });
+    const { redirectUrl } = await connect({ userId: "user-1", accountId: "acct-user-1", provider: "trello" });
     const u = new URL(redirectUrl);
     expect(u.origin + u.pathname).toBe("https://trello.com/1/authorize");
     expect(u.searchParams.get("key")).toBe("test-app-key");

--- a/tests/unit/services/oauth/dispatcher-token-ingest.test.ts
+++ b/tests/unit/services/oauth/dispatcher-token-ingest.test.ts
@@ -90,7 +90,7 @@ describe("dispatcher.connect (token_ingest branch)", () => {
     mockGetProvider.mockReturnValue(TOKEN_INGEST_MANIFEST);
     const { connect } = await import("@/services/oauth/dispatcher");
     await expect(
-      connect({ userId: "user-1", provider: "fake-ingest-provider" }),
+      connect({ userId: "user-1", accountId: "acct-1", provider: "fake-ingest-provider" }),
     ).rejects.toThrow(/No token-ingest implementation registered/);
     // Still wrote the state row? No — the registry check runs BEFORE
     // createState. We don't want a half-baked state row left behind.
@@ -103,6 +103,7 @@ describe("dispatcher.connect (token_ingest branch)", () => {
     await expect(
       connect({
         userId: "user-1",
+        accountId: "acct-1",
         provider: "fake-ingest-provider",
         providerHint: { shop: "x" },
       }),
@@ -255,7 +256,7 @@ describe("dispatcher.connect (existing OAuth providers unaffected)", () => {
     // branch, NOT the token-ingest branch (which would have rejected
     // with "No token-ingest implementation registered").
     await expect(
-      connect({ userId: "user-1", provider: "fake-ingest-provider" }),
+      connect({ userId: "user-1", accountId: "acct-1", provider: "fake-ingest-provider" }),
     ).rejects.toThrow(/No OAuth implementation registered/);
   });
 });

--- a/tests/unit/services/oauth/dispatcher.test.ts
+++ b/tests/unit/services/oauth/dispatcher.test.ts
@@ -45,7 +45,7 @@ afterEach(() => {
 
 describe("dispatcher.connect", () => {
   it("returns a Slack redirect URL with a verifiable state token AND writes the nonce row", async () => {
-    const { redirectUrl } = await connect({ userId: "user-123", provider: "slack" });
+    const { redirectUrl } = await connect({ userId: "user-123", accountId: "acct-123", provider: "slack" });
     const u = new URL(redirectUrl);
     expect(u.origin + u.pathname).toBe("https://slack.com/oauth/v2/authorize");
     const state = u.searchParams.get("state");
@@ -66,19 +66,19 @@ describe("dispatcher.connect", () => {
   });
 
   it("rejects an unknown provider", async () => {
-    await expect(connect({ userId: "u", provider: "does-not-exist" })).rejects.toThrow(
+    await expect(connect({ userId: "u", accountId: "acct-u", provider: "does-not-exist" })).rejects.toThrow(
       /Unknown provider/,
     );
     expect(mockOAuthStatesCreate).not.toHaveBeenCalled();
   });
 
   it("rejects when userId is empty", async () => {
-    await expect(connect({ userId: "", provider: "slack" })).rejects.toThrow(/userId/);
+    await expect(connect({ userId: "", accountId: "acct-u", provider: "slack" })).rejects.toThrow(/userId/);
     expect(mockOAuthStatesCreate).not.toHaveBeenCalled();
   });
 
   it("includes optional scopes alongside required scopes in the auth URL", async () => {
-    const { redirectUrl } = await connect({ userId: "u", provider: "slack" });
+    const { redirectUrl } = await connect({ userId: "u", accountId: "acct-u", provider: "slack" });
     const scopes = new URL(redirectUrl).searchParams.get("scope")!.split(",");
     expect(scopes).toEqual(
       expect.arrayContaining([
@@ -91,7 +91,7 @@ describe("dispatcher.connect", () => {
   });
 
   it("does NOT pass PKCE for non-PKCE providers (Slack default v2)", async () => {
-    await connect({ userId: "u", provider: "slack" });
+    await connect({ userId: "u", accountId: "acct-u", provider: "slack" });
     // No PKCE columns persisted on the oauth_states row
     const created = mockOAuthStatesCreate.mock.calls[0]![0] as Record<string, unknown>;
     expect(created.pkceCodeVerifier).toBeUndefined();
@@ -108,7 +108,7 @@ describe("dispatcher.connect — PKCE flow (Slice 2c)", () => {
   });
 
   it("calls provider.generatePkce, persists verifier+method on the state row, embeds challenge in URL", async () => {
-    const { redirectUrl } = await connect({ userId: "user-pkce", provider: "gmail" });
+    const { redirectUrl } = await connect({ userId: "user-pkce", accountId: "acct-pkce", provider: "gmail" });
     const u = new URL(redirectUrl);
     expect(u.origin + u.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
 
@@ -132,8 +132,8 @@ describe("dispatcher.connect — PKCE flow (Slice 2c)", () => {
   });
 
   it("each connect produces a fresh PKCE pair (no verifier reuse)", async () => {
-    const a = await connect({ userId: "u-1", provider: "gmail" });
-    const b = await connect({ userId: "u-2", provider: "gmail" });
+    const a = await connect({ userId: "u-1", accountId: "acct-1", provider: "gmail" });
+    const b = await connect({ userId: "u-2", accountId: "acct-2", provider: "gmail" });
     const aChallenge = new URL(a.redirectUrl).searchParams.get("code_challenge");
     const bChallenge = new URL(b.redirectUrl).searchParams.get("code_challenge");
     expect(aChallenge).toBeTruthy();
@@ -167,6 +167,7 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
   it("validates AND binds providerHint into the state JWT for per-tenant providers (Shopify)", async () => {
     const { redirectUrl } = await connect({
       userId: "user-shop",
+      accountId: "acct-shop",
       provider: "shopify",
       providerHint: { shop: "mystore.myshopify.com" },
     });
@@ -187,6 +188,7 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
   it("normalizes a bare subdomain to .myshopify.com before binding (Shopify)", async () => {
     const { redirectUrl } = await connect({
       userId: "u",
+      accountId: "acct-u",
       provider: "shopify",
       providerHint: { shop: "mystore" },
     });
@@ -208,6 +210,7 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
     await expect(
       connect({
         userId: "u",
+        accountId: "acct-u",
         provider: "shopify",
         providerHint: { shop: "evil.attacker.com" },
       }),
@@ -220,6 +223,7 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
     await expect(
       connect({
         userId: "u",
+        accountId: "acct-u",
         provider: "slack",
         providerHint: { shop: "anything.myshopify.com" },
       }),
@@ -234,13 +238,14 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
     // call that didn't supply a shop is a programming error in the
     // route, surfaced as the build-auth-url throw.
     await expect(
-      connect({ userId: "u", provider: "shopify" }),
+      connect({ userId: "u", accountId: "acct-u", provider: "shopify" }),
     ).rejects.toThrow(/providerHint\.shop is required/);
   });
 
   it("does NOT include providerHint on the oauth_states DB row even when set (JWT-only)", async () => {
     await connect({
       userId: "u",
+      accountId: "acct-u",
       provider: "shopify",
       providerHint: { shop: "mystore.myshopify.com" },
     });
@@ -253,7 +258,7 @@ describe("dispatcher.connect — providerHint plumbing (Slice 12)", () => {
   });
 
   it("preserves backward-compat: connect for non-tenant providers without providerHint works unchanged", async () => {
-    const { redirectUrl } = await connect({ userId: "u", provider: "slack" });
+    const { redirectUrl } = await connect({ userId: "u", accountId: "acct-u", provider: "slack" });
     expect(new URL(redirectUrl).origin + new URL(redirectUrl).pathname).toBe(
       "https://slack.com/oauth/v2/authorize",
     );

--- a/tests/unit/services/oauth/oauth-account-binding.test.ts
+++ b/tests/unit/services/oauth/oauth-account-binding.test.ts
@@ -1,0 +1,285 @@
+/**
+ * @jest-environment node
+ *
+ * OAUTH-ACCT-BIND regression suite — the account-scoping bug fix.
+ *
+ * Production bug: a connect started on a Team account wrote the integration to
+ * the user's Personal account, because `dispatcher.connect` resolved the target
+ * via `ensurePersonalAccount` (always personal) instead of the active account.
+ *
+ * These tests pin the fixed contract at the dispatcher layer:
+ *   - connect() binds the PASSED accountId (the route's resolved ACTIVE account)
+ *     into the signed state — never the personal account.
+ *   - handleCallback() writes to the SIGNED-STATE accountId only; it never reads
+ *     the "current active account", so an active-account switch during the OAuth
+ *     round trip cannot redirect the write.
+ *   - handleCallback() re-verifies the initiator is still a member of the
+ *     state-bound account (fail-safe StateAccountAccessError, no upsert).
+ *   - a frozen state-bound account fails safe (no upsert).
+ *   - reconnect writes only to the state-bound row's account.
+ *   - providerHint (per-tenant) still rides with the state-bound account.
+ *   - Notion-specific regression.
+ */
+import { createHmac, randomBytes } from "node:crypto";
+
+const mockUpsertActive = jest.fn();
+const mockOAuthStatesCreate = jest.fn();
+const mockOAuthStatesConsume = jest.fn();
+const mockGetByIdForAccount = jest.fn();
+const mockAssertOperational = jest.fn();
+const mockIsMember = jest.fn();
+const mockNotionHandleCallback = jest.fn();
+const mockSlackHandleCallback = jest.fn();
+
+jest.mock("@/repositories/integrations", () => ({
+  upsertActive: (...a: unknown[]) => mockUpsertActive(...a),
+  getByIdForAccountServiceRole: (...a: unknown[]) => mockGetByIdForAccount(...a),
+}));
+jest.mock("@/repositories/oauthStates", () => ({
+  create: (...a: unknown[]) => mockOAuthStatesCreate(...a),
+  consumeByNonce: (...a: unknown[]) => mockOAuthStatesConsume(...a),
+}));
+jest.mock("@/services/accounts/accountFreeze", () => ({
+  assertAccountOperational: (...a: unknown[]) => mockAssertOperational(...a),
+  AccountFrozenError: class AccountFrozenError extends Error {},
+}));
+jest.mock("@/repositories/accountMemberships", () => ({
+  isMemberServiceRole: (...a: unknown[]) => mockIsMember(...a),
+}));
+jest.mock("@/integrations/notion/oauth", () => ({
+  notionOAuth: {
+    // Echo the dispatcher-minted state into the URL so the test can read it back.
+    buildAuthUrl: jest.fn(
+      (state: string) =>
+        `https://api.notion.com/v1/oauth/authorize?state=${encodeURIComponent(state)}`,
+    ),
+    handleCallback: (...a: unknown[]) => mockNotionHandleCallback(...a),
+    refreshToken: jest.fn(),
+    revoke: jest.fn(),
+  },
+}));
+jest.mock("@/integrations/slack/oauth", () => ({
+  slackOAuth: {
+    buildAuthUrl: jest.fn(
+      (state: string) =>
+        `https://slack.com/oauth/v2/authorize?state=${encodeURIComponent(state)}`,
+    ),
+    handleCallback: (...a: unknown[]) => mockSlackHandleCallback(...a),
+    refreshToken: jest.fn(),
+    revoke: jest.fn(),
+  },
+}));
+
+// A spy proving the callback never resolves "active account" — if the dispatcher
+// ever imported it, this mock would be in the module graph and we'd assert 0 calls.
+const mockResolveActiveAccount = jest.fn();
+jest.mock("@/services/accounts/activeAccount", () => ({
+  resolveActiveAccount: (...a: unknown[]) => mockResolveActiveAccount(...a),
+}));
+
+import {
+  connect,
+  handleCallback,
+  StateAccountAccessError,
+} from "@/services/oauth/dispatcher";
+import { createState, verifyState } from "@/services/oauth/state";
+
+const TEAM = "team-acct-A";
+const PERSONAL = "personal-acct-A";
+const USER = "user-A";
+
+beforeEach(() => {
+  process.env.OAUTH_STATE_SIGNING_KEY = randomBytes(32).toString("base64");
+  process.env.SLACK_CLIENT_ID = "test-slack";
+  process.env.NOTION_CLIENT_ID = "test-notion";
+  process.env.NOTION_CLIENT_SECRET = "test-notion-secret";
+  process.env.NEXT_PUBLIC_APP_URL = "https://app.example.test";
+  jest.clearAllMocks();
+  mockOAuthStatesCreate.mockResolvedValue(undefined);
+  mockAssertOperational.mockResolvedValue(undefined);
+  mockIsMember.mockResolvedValue(true);
+  mockUpsertActive.mockImplementation(async (args: { accountId: string }) => ({
+    id: "int-1",
+    accountId: args.accountId,
+    provider: "notion",
+  }));
+});
+afterEach(() => {
+  delete process.env.OAUTH_STATE_SIGNING_KEY;
+  delete process.env.SLACK_CLIENT_ID;
+  delete process.env.NOTION_CLIENT_ID;
+  delete process.env.NOTION_CLIENT_SECRET;
+  delete process.env.NEXT_PUBLIC_APP_URL;
+});
+
+/** Mint a real signed state for `accountId` and wire consume to return its row. */
+async function stateFor(accountId: string, provider: string): Promise<string> {
+  const { token, payload } = await createState({
+    userId: USER,
+    accountId,
+    provider,
+    requestedScopes: [],
+  });
+  mockOAuthStatesConsume.mockResolvedValueOnce({
+    nonce: payload.nonce,
+    userId: payload.userId,
+    provider: payload.provider,
+    pkceCodeVerifier: null,
+    pkceCodeChallengeMethod: null,
+  });
+  return token;
+}
+
+describe("connect() binds the passed (active) account — never personal", () => {
+  it("binds the TEAM account passed by the route into the signed state", async () => {
+    const { redirectUrl } = await connect({
+      userId: USER,
+      accountId: TEAM,
+      provider: "slack",
+    });
+    const state = new URL(redirectUrl).searchParams.get("state")!;
+    const payload = verifyState(state);
+    expect(payload.accountId).toBe(TEAM);
+    // The state-row write carries the same user; account lives in the JWT only.
+    expect(mockOAuthStatesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when no accountId is supplied (no personal default)", async () => {
+    await expect(
+      // @ts-expect-error — intentionally omit accountId to prove it's required.
+      connect({ userId: USER, provider: "slack" }),
+    ).rejects.toThrow(/accountId is required/);
+    expect(mockOAuthStatesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleCallback() writes to the SIGNED-STATE account only", () => {
+  beforeEach(() => {
+    mockNotionHandleCallback.mockResolvedValue({
+      tokens: { accessToken: "t", refreshToken: null, scopes: [], expiresAt: null },
+      account: { providerAccountId: "ws-1", displayName: "Team WS", metadata: {} },
+    });
+  });
+
+  it("writes the integration to the TEAM account from state, NOT personal", async () => {
+    const token = await stateFor(TEAM, "notion");
+    const { integration } = await handleCallback({ provider: "notion", code: "c", state: token });
+    expect(mockUpsertActive).toHaveBeenCalledTimes(1);
+    expect(mockUpsertActive.mock.calls[0]![0]).toMatchObject({
+      accountId: TEAM,
+      connectedByUserId: USER,
+      provider: "notion",
+    });
+    expect(integration.accountId).toBe(TEAM);
+  });
+
+  it("active-account switch to PERSONAL before callback does NOT change the write target", async () => {
+    // Simulate the bug scenario: the user flips active account to personal mid-flow.
+    mockResolveActiveAccount.mockResolvedValue({ ok: true, accountId: PERSONAL, source: "active" });
+    const token = await stateFor(TEAM, "notion");
+    await handleCallback({ provider: "notion", code: "c", state: token });
+    // The callback never consults the active account — it writes to state's TEAM.
+    expect(mockResolveActiveAccount).not.toHaveBeenCalled();
+    expect(mockUpsertActive.mock.calls[0]![0]).toMatchObject({ accountId: TEAM });
+  });
+
+  it("non-member of the state-bound account → StateAccountAccessError, NO upsert", async () => {
+    mockIsMember.mockResolvedValueOnce(false);
+    const token = await stateFor(TEAM, "notion");
+    await expect(
+      handleCallback({ provider: "notion", code: "c", state: token }),
+    ).rejects.toBeInstanceOf(StateAccountAccessError);
+    expect(mockUpsertActive).not.toHaveBeenCalled();
+    // membership was checked against the SIGNED-STATE (accountId, userId).
+    expect(mockIsMember).toHaveBeenCalledWith(TEAM, USER);
+  });
+
+  it("frozen state-bound account → fails safe, NO upsert", async () => {
+    mockAssertOperational.mockRejectedValueOnce(new Error("account frozen"));
+    const token = await stateFor(TEAM, "notion");
+    await expect(
+      handleCallback({ provider: "notion", code: "c", state: token }),
+    ).rejects.toThrow(/frozen/);
+    expect(mockUpsertActive).not.toHaveBeenCalled();
+  });
+
+  it("membership check runs BEFORE the provider token exchange (no provider call on revoked access)", async () => {
+    mockIsMember.mockResolvedValueOnce(false);
+    const token = await stateFor(TEAM, "notion");
+    await expect(
+      handleCallback({ provider: "notion", code: "c", state: token }),
+    ).rejects.toBeInstanceOf(StateAccountAccessError);
+    expect(mockNotionHandleCallback).not.toHaveBeenCalled();
+  });
+});
+
+describe("missing/invalid state account fails safe", () => {
+  it("verifyState rejects a token whose payload has no accountId", () => {
+    // Hand-forge a payload missing accountId, signed with the real key, to prove
+    // the verifier refuses it (defense beyond createState's own required check).
+    const payload = {
+      userId: USER,
+      provider: "slack",
+      nonce: "n",
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
+      requestedScopes: [],
+    };
+    const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = createHmac("sha256", Buffer.from(process.env.OAUTH_STATE_SIGNING_KEY!, "base64"))
+      .update(data)
+      .digest("base64url");
+    expect(() => verifyState(`${data}.${sig}`)).toThrow(/missing required fields/);
+  });
+});
+
+describe("reconnect stays row/account-bound", () => {
+  beforeEach(() => {
+    mockNotionHandleCallback.mockResolvedValue({
+      tokens: { accessToken: "t", refreshToken: null, scopes: [], expiresAt: null },
+      account: { providerAccountId: "ws-1", displayName: "Team WS", metadata: {} },
+    });
+  });
+
+  it("reconnect callback refuses to write outside the state row's account (identity mismatch)", async () => {
+    // State carries reconnect intent for a row in TEAM; the row's stored identity
+    // differs from the provider-returned identity → no upsert.
+    const { token, payload } = await createState({
+      userId: USER,
+      accountId: TEAM,
+      provider: "notion",
+      requestedScopes: [],
+      reconnect: { integrationId: "int-77" },
+    });
+    mockOAuthStatesConsume.mockResolvedValueOnce({
+      nonce: payload.nonce,
+      userId: payload.userId,
+      provider: payload.provider,
+      pkceCodeVerifier: null,
+      pkceCodeChallengeMethod: null,
+    });
+    mockGetByIdForAccount.mockResolvedValueOnce({ id: "int-77", providerAccountId: "DIFFERENT-ws" });
+    await expect(
+      handleCallback({ provider: "notion", code: "c", state: token }),
+    ).rejects.toThrow(/reconnect identity mismatch/);
+    expect(mockUpsertActive).not.toHaveBeenCalled();
+    // Lookup was scoped to the state's account, never a different one.
+    expect(mockGetByIdForAccount).toHaveBeenCalledWith(TEAM, "int-77");
+  });
+});
+
+describe("Notion-specific regression (the reported provider)", () => {
+  it("Notion connect→callback lands the row on the team account it started from", async () => {
+    mockNotionHandleCallback.mockResolvedValue({
+      tokens: { accessToken: "t", refreshToken: null, scopes: [], expiresAt: null },
+      account: { providerAccountId: "ws-team", displayName: "Marcus Team", metadata: {} },
+    });
+    // 1. Connect on the TEAM account → state binds TEAM.
+    const { redirectUrl } = await connect({ userId: USER, accountId: TEAM, provider: "notion" });
+    expect(verifyState(new URL(redirectUrl).searchParams.get("state")!).accountId).toBe(TEAM);
+    // 2. Callback writes to TEAM (the bug wrote to PERSONAL here).
+    const token = await stateFor(TEAM, "notion");
+    await handleCallback({ provider: "notion", code: "c", state: token });
+    expect(mockUpsertActive.mock.calls[0]![0]).toMatchObject({ accountId: TEAM });
+    expect(mockUpsertActive.mock.calls[0]![0].accountId).not.toBe(PERSONAL);
+  });
+});


### PR DESCRIPTION
## OAuth account-binding hotfix (scoped)

Fixes a live production account-scoping bug: a connect started on a Team account wrote the new integration to the user's **Personal** account. Root cause: `dispatcher.connect` resolved the target via `ensurePersonalAccount` instead of the active account; the OAuth path was never wired to `resolveActiveAccount`. Affected **all** OAuth + token-ingest providers.

**Fix:** connect route resolves the active account at connect-start and binds it into signed state; dispatcher requires that account (no personal default); callback re-verifies state-bound-account membership + freeze before upsert (typed `account_access_revoked`); reconnect stays row-bound.

**Scope:** OAuth only — 3 source files + 10 test files. No AI-DIAG/AI-CREDITS/billing/MCP/CONN-SHARE/migration/env changes. Logic-only (no migration).

**Verified on this commit (`92da7c036`, rebased on current v2-main):** typecheck 0 · lint 0 errors · lint:structure · lint:migrations · build 75/75 · targeted OAuth/Notion/reconnect/account-switch/Apps/CONN-SHARE 615 pass · full Jest 17,731 pass (2 unrelated suites flaky under parallel run, pass on isolated re-run).
