### PR TITLE
feat(conn-share): accurate workflow-list run/edit eligibility (batched)

### DIFF
--- a/app/api/workflows/_shared.ts
+++ b/app/api/workflows/_shared.ts
@@ -12,7 +12,10 @@ import {
   viewerMayRunEdit,
 } from "@/core/integrations/workflowCredentialScope";
 import { isConnectionSharingEnabled } from "@/services/integrations/connectionSharingFlags";
-import { buildWorkflowCredentialPlan } from "@/services/integrations/connectionResolution";
+import {
+  buildWorkflowCredentialPlan,
+  buildWorkflowCredentialPlansBatch,
+} from "@/services/integrations/connectionResolution";
 import { emptyRunStats } from "@/repositories/workflowRunStats";
 import * as workflowsRepo from "@/repositories/workflows";
 import type { WorkflowRecord } from "@/repositories/workflows";
@@ -298,6 +301,62 @@ export async function computeViewerCanRunEdit(
   return plan.allTeamRunnable;
 }
 
+/**
+ * Batched `viewerCanRunEdit` for a LIST of workflows (CS-5b) — the dashboard
+ * counterpart to `computeViewerCanRunEdit`, producing the SAME decision but in
+ * **bounded queries** instead of one `buildWorkflowCredentialPlan` per row.
+ *
+ * Flag OFF → pure `viewerMayRunEdit` per record, NO DB (byte-for-byte the old
+ * conservative WF-RUNPERM list behavior). Flag ON → creator / no-private records
+ * short-circuit to `true` with no query; the remaining "candidate" records (non-
+ * creator, private-credential) are resolved by `buildWorkflowCredentialPlansBatch`
+ * (≤3 reads total per account), and the row is runnable iff `allTeamRunnable` —
+ * identical to the detail DTO + the run/edit gate, so the list can never over- or
+ * under-permit relative to the chokepoint. Records are grouped by `accountId`
+ * (defensive; the list is single-account today). Display only — the gate is still
+ * the real enforcement.
+ */
+export async function computeViewerCanRunEditBatch(
+  records: readonly WorkflowRecord[],
+  callerUserId: string,
+): Promise<Map<string, boolean>> {
+  const out = new Map<string, boolean>();
+  if (!isConnectionSharingEnabled()) {
+    for (const r of records) {
+      out.set(
+        r.id,
+        viewerMayRunEdit({ createdByUserId: r.createdByUserId, definition: r.draftDefinition }, callerUserId),
+      );
+    }
+    return out;
+  }
+
+  // Flag ON: short-circuit creator / no-private (no DB); batch the rest by account.
+  const candidatesByAccount = new Map<string, WorkflowRecord[]>();
+  for (const r of records) {
+    if (!workflowUsesPrivateCredential(r.draftDefinition) || r.createdByUserId === callerUserId) {
+      out.set(r.id, true);
+      continue;
+    }
+    const bucket = candidatesByAccount.get(r.accountId) ?? [];
+    bucket.push(r);
+    candidatesByAccount.set(r.accountId, bucket);
+  }
+
+  for (const [accountId, candidates] of candidatesByAccount) {
+    const plans = await buildWorkflowCredentialPlansBatch({
+      accountId,
+      records: candidates.map((r) => ({
+        id: r.id,
+        createdByUserId: r.createdByUserId,
+        nodes: r.draftDefinition.nodes,
+      })),
+    });
+    for (const r of candidates) out.set(r.id, plans.get(r.id)?.allTeamRunnable ?? false);
+  }
+  return out;
+}
+
 export async function toWorkflowDetail(
   record: WorkflowRecord,
   callerUserId: string,
@@ -322,18 +381,20 @@ export async function toWorkflowDetail(
  * runs get zeroed stats. Only provider id/label/iconUrl + counts + numeric
  * run stats leave the server — no raw definition, config, or values.
  *
- * `viewerCanRunEdit` here stays the CONSERVATIVE sync `viewerMayRunEdit` (creator-
- * only for private-credential workflows) even with the sharing flag ON: the list
- * renders N rows and a per-row `buildWorkflowCredentialPlan` (3 DB reads each)
- * is too costly. This is SAFE — it never over-permits; a non-creator who CAN run a
- * shared workflow simply sees the conservative chip until they open it (the detail
- * DTO `toWorkflowDetail` is accurate). Batching list resolvability is a CS-5b
- * follow-up. The run/edit GATE is the real enforcement regardless.
+ * `viewerCanRunEdit` is ACCURATE under the sharing flag (CS-5b): the caller passes
+ * `viewerCanRunEditByWorkflow` — the result of `computeViewerCanRunEditBatch` over
+ * all visible rows in BOUNDED queries — so a row reflects the SAME eligibility the
+ * detail DTO + run/edit gate use (a team-runnable shared workflow is no longer shown
+ * as a blocked "private connection"). When the map is omitted (or lacks the id), it
+ * falls back to the CONSERVATIVE sync `viewerMayRunEdit` (creator-only) — safe
+ * (never over-permits) and the exact flag-OFF behavior. The run/edit GATE is the
+ * real enforcement regardless; this is display only.
  */
 export function toWorkflowListItem(
   record: WorkflowRecord,
   runStatsByWorkflow: ReadonlyMap<string, WorkflowRunStats>,
   callerUserId: string,
+  viewerCanRunEditByWorkflow?: ReadonlyMap<string, boolean>,
 ): WorkflowListItem {
   const summary = summarizeDefinition(record.draftDefinition);
   const providers: WorkflowProviderChip[] = summary.providerIds.map((id) => ({
@@ -341,6 +402,12 @@ export function toWorkflowListItem(
     label: getProvider(id)?.displayName ?? id,
     iconUrl: providerIconUrl(id) ?? null,
   }));
+  const viewerCanRunEdit =
+    viewerCanRunEditByWorkflow?.get(record.id) ??
+    viewerMayRunEdit(
+      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
+      callerUserId,
+    );
   return {
     ...toWorkflowSummary(record),
     providers,
@@ -349,10 +416,7 @@ export function toWorkflowListItem(
     runStats: runStatsByWorkflow.get(record.id) ?? emptyRunStats(),
     folderId: record.folderId,
     usesPrivateCredential: workflowUsesPrivateCredential(record.draftDefinition),
-    viewerCanRunEdit: viewerMayRunEdit(
-      { createdByUserId: record.createdByUserId, definition: record.draftDefinition },
-      callerUserId,
-    ),
+    viewerCanRunEdit,
   };
 }
 

--- a/app/api/workflows/route.ts
+++ b/app/api/workflows/route.ts
@@ -3,6 +3,7 @@ import { CreateWorkflowRequestSchema } from "@/contracts/workflow";
 import * as workflowsRepo from "@/repositories/workflows";
 import * as workflowRunStatsRepo from "@/repositories/workflowRunStats";
 import {
+  computeViewerCanRunEditBatch,
   parseJsonBody,
   requireUserWithAccount,
   toWorkflowListItem,
@@ -49,7 +50,10 @@ export async function GET() {
     // list is scoped to (not user-wide), so refreshed stats match the rows.
     workflowRunStatsRepo.getStatsForAccount(auth.accountId),
   ]);
+  // CS-5b — accurate per-row run/edit eligibility in BOUNDED queries (≤3 reads
+  // total, not 3×N). Flag OFF → conservative WF-RUNPERM, no DB.
+  const viewerCanRunEdit = await computeViewerCanRunEditBatch(records, auth.userId);
   return NextResponse.json({
-    workflows: records.map((r) => toWorkflowListItem(r, runStats, auth.userId)),
+    workflows: records.map((r) => toWorkflowListItem(r, runStats, auth.userId, viewerCanRunEdit)),
   });
 }

--- a/app/workflows/page.tsx
+++ b/app/workflows/page.tsx
@@ -7,7 +7,7 @@ import * as foldersRepo from "@/repositories/workflowFolders";
 import { ensurePersonalAccount } from "@/services/accounts/ensurePersonalAccount";
 import { resolveActiveAccount } from "@/services/accounts/activeAccount";
 import { folderLimitFor } from "@/services/workflowFolders/folderLimits";
-import { toWorkflowListItem } from "@/app/api/workflows/_shared";
+import { computeViewerCanRunEditBatch, toWorkflowListItem } from "@/app/api/workflows/_shared";
 import { toWorkflowFolder } from "@/app/api/folders/_shared";
 import { WorkflowsDashboard } from "@/features/workflows/WorkflowsDashboard";
 import { AppShell } from "@/components/app-shell/AppShell";
@@ -65,7 +65,9 @@ export default async function WorkflowsPage() {
         limit: NOTIFICATION_BELL_PREVIEW_LIMIT,
       }),
     ]);
-  const workflows = records.map((r) => toWorkflowListItem(r, runStats, user.id));
+  // CS-5b — accurate per-row run/edit eligibility in bounded queries (flag OFF → conservative, no DB).
+  const viewerCanRunEdit = await computeViewerCanRunEditBatch(records, user.id);
+  const workflows = records.map((r) => toWorkflowListItem(r, runStats, user.id, viewerCanRunEdit));
   const folders = folderRecords.map(toWorkflowFolder);
   const recentNotifications = recentNotificationRecords.map(toNotificationPreview);
   // CS-8: surface pending credential-reassignment requests in the bell (derived,

--- a/repositories/integrations.ts
+++ b/repositories/integrations.ts
@@ -405,6 +405,41 @@ export async function listSharedConnectorUserIdsServiceRole(
 }
 
 /**
+ * Service-role: shared-connector user-id sets for MANY providers in ONE query
+ * (CS-5b list-DTO batching). The single-provider `listSharedConnectorUserIdsServiceRole`
+ * called per provider per workflow would be N×; this is one `provider IN (...)`
+ * read for the whole dashboard. Returns a map provider → Set<connectorUserId>
+ * (every requested provider is present, empty set when unshared). Selects ONLY
+ * `provider` + `connected_by_user_id`; no token/scope/providerAccountId/label/
+ * metadata. Same `shared_with_account` + `disconnected_at IS NULL` filter.
+ */
+export async function listSharedConnectorsByProviderServiceRole(
+  accountId: string,
+  providers: readonly string[],
+): Promise<Map<string, Set<string>>> {
+  const out = new Map<string, Set<string>>();
+  for (const p of providers) out.set(p, new Set<string>());
+  if (providers.length === 0) return out;
+  const supabase = getServiceRoleClient(
+    `integrations: listSharedConnectorsByProvider for account ${accountId} (${providers.length})`,
+  );
+  const { data, error } = await supabase
+    .from("integrations")
+    .select("provider, connected_by_user_id")
+    .eq("account_id", accountId)
+    .in("provider", [...providers])
+    .eq("integration_sharing_scope", "shared_with_account")
+    .is("disconnected_at", null);
+  if (error) {
+    throw new Error(`integrations.listSharedConnectorsByProviderServiceRole failed: ${error.message}`);
+  }
+  for (const r of (data ?? []) as Array<{ provider: string; connected_by_user_id: string | null }>) {
+    if (r.connected_by_user_id) out.get(r.provider)?.add(r.connected_by_user_id);
+  }
+  return out;
+}
+
+/**
  * Offboarding soft-disconnect (Slice 4.ACCOUNT-MODEL-22C).
  *
  * When a member is removed from a Team, the PERSONAL credentials they connected

--- a/repositories/workflowNodeConnectorBindings.ts
+++ b/repositories/workflowNodeConnectorBindings.ts
@@ -72,6 +72,37 @@ export async function listByWorkflowServiceRole(
   return (data ?? []).map((r) => rowToRecord(r as WorkflowNodeConnectorBindingsRow));
 }
 
+/**
+ * Bindings for MANY workflows in ONE query (CS-5b list-DTO batching). Keyed by
+ * `workflow_id IN (...)` so the workflows dashboard resolves N workflows' bindings
+ * in a single bounded read instead of N per-workflow calls. Returns a map
+ * workflowId → bindings (workflows with none are simply absent). Service-role.
+ */
+export async function listByWorkflowsServiceRole(
+  workflowIds: readonly string[],
+): Promise<Map<string, WorkflowNodeConnectorBindingRecord[]>> {
+  const out = new Map<string, WorkflowNodeConnectorBindingRecord[]>();
+  if (workflowIds.length === 0) return out;
+  const supabase = getServiceRoleClient(
+    `workflow_node_connector_bindings: listByWorkflows (${workflowIds.length})`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_connector_bindings")
+    .select("*")
+    .in("workflow_id", [...workflowIds])
+    .order("created_at", { ascending: true });
+  if (error) {
+    throw new Error(`workflow_node_connector_bindings.listByWorkflowsServiceRole failed: ${error.message}`);
+  }
+  for (const row of (data ?? []) as WorkflowNodeConnectorBindingsRow[]) {
+    const rec = rowToRecord(row);
+    const bucket = out.get(rec.workflowId) ?? [];
+    bucket.push(rec);
+    out.set(rec.workflowId, bucket);
+  }
+  return out;
+}
+
 /** The binding for one node, or null. The unique index guarantees at most one. Service-role. */
 export async function getForNodeServiceRole(
   workflowId: string,

--- a/repositories/workflowNodeCredentials.ts
+++ b/repositories/workflowNodeCredentials.ts
@@ -112,6 +112,37 @@ export async function listAcceptedByWorkflowServiceRole(
 }
 
 /**
+ * Accepted grants for MANY workflows in ONE query (CS-5b list-DTO batching).
+ * `workflow_id IN (...)` + `status = 'accepted'` — one bounded read for the whole
+ * dashboard instead of N per-workflow calls. Returns a map workflowId → accepted
+ * records (workflows with none are absent). Service-role.
+ */
+export async function listAcceptedByWorkflowsServiceRole(
+  workflowIds: readonly string[],
+): Promise<Map<string, WorkflowNodeCredentialRecord[]>> {
+  const out = new Map<string, WorkflowNodeCredentialRecord[]>();
+  if (workflowIds.length === 0) return out;
+  const supabase = getServiceRoleClient(
+    `workflow_node_credentials: listAcceptedByWorkflows (${workflowIds.length})`,
+  );
+  const { data, error } = await supabase
+    .from("workflow_node_credentials")
+    .select("*")
+    .in("workflow_id", [...workflowIds])
+    .eq("status", "accepted");
+  if (error) {
+    throw new Error(`workflow_node_credentials.listAcceptedByWorkflowsServiceRole failed: ${error.message}`);
+  }
+  for (const row of (data ?? []) as WorkflowNodeCredentialsRow[]) {
+    const rec = rowToRecord(row);
+    const bucket = out.get(rec.workflowId) ?? [];
+    bucket.push(rec);
+    out.set(rec.workflowId, bucket);
+  }
+  return out;
+}
+
+/**
  * The single LIVE (pending|accepted) grant for a node, or null. The partial
  * unique index guarantees at most one. Service-role.
  */

--- a/services/integrations/connectionResolution.ts
+++ b/services/integrations/connectionResolution.ts
@@ -1,8 +1,19 @@
 import { isPrivateCredentialProvider } from "@/core/integrations/workflowCredentialScope";
 import { resolveNodeOwner, type NodeOwnerResolution } from "@/core/integrations/sharingEligibility";
-import { loadAcceptedNodeOwners } from "@/services/teamCredentials/nodeCredentialOwners";
-import { listByWorkflowServiceRole } from "@/repositories/workflowNodeConnectorBindings";
-import { listSharedConnectorUserIdsServiceRole } from "@/repositories/integrations";
+import {
+  loadAcceptedNodeOwners,
+  loadAcceptedNodeOwnersBatch,
+  type AcceptedNodeOwners,
+} from "@/services/teamCredentials/nodeCredentialOwners";
+import {
+  listByWorkflowServiceRole,
+  listByWorkflowsServiceRole,
+  type WorkflowNodeConnectorBindingRecord,
+} from "@/repositories/workflowNodeConnectorBindings";
+import {
+  listSharedConnectorUserIdsServiceRole,
+  listSharedConnectorsByProviderServiceRole,
+} from "@/repositories/integrations";
 
 /**
  * Shared workflow credential plan (Slice 4.CONN-SHARE / CS-4b).
@@ -40,6 +51,51 @@ interface PlanInputNode {
   readonly provider: string;
 }
 
+const EMPTY_PLAN: WorkflowCredentialPlan = {
+  ownerByNode: new Map(),
+  resolutions: new Map(),
+  allTeamRunnable: true,
+};
+
+/**
+ * PURE per-node resolution from pre-gathered data — the single source of the
+ * gate/executor/detail/list decision. No I/O: the caller supplies the accepted
+ * grants, node bindings, and per-provider shared-connector sets (gathered either
+ * per-workflow by `buildWorkflowCredentialPlan` or batched by
+ * `buildWorkflowCredentialPlansBatch`). Same `resolveNodeOwner` precedence either
+ * way, so the single and batched paths can never drift.
+ */
+function computeCredentialPlanFromData(input: {
+  createdByUserId: string;
+  personalNodes: readonly PlanInputNode[];
+  acceptedOwners: AcceptedNodeOwners;
+  bindingByNode: ReadonlyMap<string, WorkflowNodeConnectorBindingRecord>;
+  sharedByProvider: ReadonlyMap<string, ReadonlySet<string>>;
+}): WorkflowCredentialPlan {
+  const ownerByNode = new Map<string, string>();
+  const resolutions = new Map<string, NodeOwnerResolution>();
+  let allTeamRunnable = true;
+
+  for (const node of input.personalNodes) {
+    const binding = input.bindingByNode.get(node.id);
+    // Binding is per-node; only honor it when its provider still matches the node.
+    const bindingConnector =
+      binding && binding.provider === node.provider ? binding.connectorUserId : null;
+
+    const resolution = resolveNodeOwner({
+      creatorUserId: input.createdByUserId,
+      acceptedGrantOwner: input.acceptedOwners.get(node.id) ?? null,
+      bindingConnector,
+      sharedConnectors: input.sharedByProvider.get(node.provider) ?? new Set<string>(),
+    });
+    ownerByNode.set(node.id, resolution.owner);
+    resolutions.set(node.id, resolution);
+    if (!resolution.teamRunnable) allTeamRunnable = false;
+  }
+
+  return { ownerByNode, resolutions, allTeamRunnable };
+}
+
 /**
  * Build the plan for a workflow's nodes. Gathers — once — the accepted per-node
  * grants (flag-gated inside `loadAcceptedNodeOwners`), the node connector
@@ -55,9 +111,7 @@ export async function buildWorkflowCredentialPlan(input: {
   const personalNodes = input.nodes.filter(
     (n) => n.provider && isPrivateCredentialProvider(n.provider),
   );
-  if (personalNodes.length === 0) {
-    return { ownerByNode: new Map(), resolutions: new Map(), allTeamRunnable: true };
-  }
+  if (personalNodes.length === 0) return EMPTY_PLAN;
 
   const distinctProviders = [...new Set(personalNodes.map((n) => n.provider))];
 
@@ -72,29 +126,72 @@ export async function buildWorkflowCredentialPlan(input: {
     ),
   ]);
 
-  const sharedByProvider = new Map(sharedSetEntries);
-  // Binding is per-node; only honor it when its provider still matches the node.
-  const bindingByNode = new Map(bindings.map((b) => [b.nodeId, b]));
+  return computeCredentialPlanFromData({
+    createdByUserId: input.createdByUserId,
+    personalNodes,
+    acceptedOwners,
+    bindingByNode: new Map(bindings.map((b) => [b.nodeId, b])),
+    sharedByProvider: new Map(sharedSetEntries),
+  });
+}
 
-  const ownerByNode = new Map<string, string>();
-  const resolutions = new Map<string, NodeOwnerResolution>();
-  let allTeamRunnable = true;
+/**
+ * Batched plan builder for the workflows LIST/dashboard (CS-5b). Resolves the
+ * SAME `allTeamRunnable` decision as the single `buildWorkflowCredentialPlan`, for
+ * ALL records of one account, in **bounded queries** — at most THREE reads total
+ * regardless of how many workflows are shown:
+ *   1. shared-connector sets for every distinct private provider (one `IN` query)
+ *   2. accepted node-credential grants for every workflow (one `IN` query, flag-gated)
+ *   3. node connector bindings for every workflow (one `IN` query)
+ * Records with no private-provider nodes get the trivially-runnable plan with NO
+ * query attributed to them. Returns a map workflowId → plan for the supplied records.
+ *
+ * No-leak: identical to the single path — user ids are used only for in-memory
+ * resolution; nothing here is serialized to a client.
+ */
+export async function buildWorkflowCredentialPlansBatch(input: {
+  accountId: string;
+  records: ReadonlyArray<{
+    id: string;
+    createdByUserId: string;
+    nodes: readonly PlanInputNode[];
+  }>;
+}): Promise<Map<string, WorkflowCredentialPlan>> {
+  const result = new Map<string, WorkflowCredentialPlan>();
+  const personalByWorkflow = new Map<string, PlanInputNode[]>();
+  const allProviders = new Set<string>();
 
-  for (const node of personalNodes) {
-    const binding = bindingByNode.get(node.id);
-    const bindingConnector =
-      binding && binding.provider === node.provider ? binding.connectorUserId : null;
-
-    const resolution = resolveNodeOwner({
-      creatorUserId: input.createdByUserId,
-      acceptedGrantOwner: acceptedOwners.get(node.id) ?? null,
-      bindingConnector,
-      sharedConnectors: sharedByProvider.get(node.provider) ?? new Set<string>(),
-    });
-    ownerByNode.set(node.id, resolution.owner);
-    resolutions.set(node.id, resolution);
-    if (!resolution.teamRunnable) allTeamRunnable = false;
+  for (const rec of input.records) {
+    const personal = rec.nodes.filter((n) => n.provider && isPrivateCredentialProvider(n.provider));
+    if (personal.length === 0) {
+      result.set(rec.id, EMPTY_PLAN); // no private providers → team-runnable, no query
+      continue;
+    }
+    personalByWorkflow.set(rec.id, personal);
+    for (const n of personal) allProviders.add(n.provider);
   }
+  if (personalByWorkflow.size === 0) return result;
 
-  return { ownerByNode, resolutions, allTeamRunnable };
+  const workflowIds = [...personalByWorkflow.keys()];
+  const [sharedByProvider, acceptedByWorkflow, bindingsByWorkflow] = await Promise.all([
+    listSharedConnectorsByProviderServiceRole(input.accountId, [...allProviders]),
+    loadAcceptedNodeOwnersBatch(workflowIds),
+    listByWorkflowsServiceRole(workflowIds),
+  ]);
+
+  for (const [workflowId, personalNodes] of personalByWorkflow) {
+    const rec = input.records.find((r) => r.id === workflowId)!;
+    const bindings = bindingsByWorkflow.get(workflowId) ?? [];
+    result.set(
+      workflowId,
+      computeCredentialPlanFromData({
+        createdByUserId: rec.createdByUserId,
+        personalNodes,
+        acceptedOwners: acceptedByWorkflow.get(workflowId) ?? new Map<string, string>(),
+        bindingByNode: new Map(bindings.map((b) => [b.nodeId, b])),
+        sharedByProvider,
+      }),
+    );
+  }
+  return result;
 }

--- a/services/teamCredentials/nodeCredentialOwners.ts
+++ b/services/teamCredentials/nodeCredentialOwners.ts
@@ -1,6 +1,7 @@
 import { isNodeCredentialReassignmentEnabled } from "./flags";
 import {
   listAcceptedByWorkflowServiceRole,
+  listAcceptedByWorkflowsServiceRole,
   getForNodeServiceRole,
 } from "@/repositories/workflowNodeCredentials";
 import { isPersonalCredentialProvider } from "@/core/integrations/credentialSharing";
@@ -44,6 +45,26 @@ export async function loadAcceptedNodeOwners(
   const map = new Map<string, string>();
   for (const r of rows) map.set(r.nodeId, r.credentialOwnerUserId);
   return map;
+}
+
+/**
+ * Batched twin of `loadAcceptedNodeOwners` (CS-5b list-DTO): accepted node owners
+ * for MANY workflows in ONE query. Flag OFF → empty map, NO DB call (byte-for-byte
+ * the pre-CS-2 path for the list). Returns workflowId → (nodeId → ownerUserId);
+ * workflows with no accepted grants are absent (callers read an empty map).
+ */
+export async function loadAcceptedNodeOwnersBatch(
+  workflowIds: readonly string[],
+): Promise<Map<string, AcceptedNodeOwners>> {
+  const out = new Map<string, AcceptedNodeOwners>();
+  if (!isNodeCredentialReassignmentEnabled() || workflowIds.length === 0) return out;
+  const byWorkflow = await listAcceptedByWorkflowsServiceRole(workflowIds);
+  for (const [workflowId, rows] of byWorkflow) {
+    const map = new Map<string, string>();
+    for (const r of rows) map.set(r.nodeId, r.credentialOwnerUserId);
+    out.set(workflowId, map);
+  }
+  return out;
 }
 
 /**

--- a/tests/unit/app/api/workflows/workflow-list-eligibility.test.ts
+++ b/tests/unit/app/api/workflows/workflow-list-eligibility.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ *
+ * CS-5b — accurate workflow LIST DTO eligibility (`computeViewerCanRunEditBatch` +
+ * `toWorkflowListItem`). Proves the dashboard reflects the SAME run/edit decision
+ * as the detail DTO + gate, computed in BOUNDED queries, while leaking nothing.
+ *
+ * `buildWorkflowCredentialPlansBatch` and the sharing flag are mocked; the pure
+ * `workflowUsesPrivateCredential` / `viewerMayRunEdit` run for real.
+ */
+jest.mock("@/utils/supabase/server", () => ({
+  createClient: jest.fn(async () => ({ auth: { getUser: jest.fn() } })),
+}));
+
+const mockFlag = jest.fn();
+jest.mock("@/services/integrations/connectionSharingFlags", () => ({
+  isConnectionSharingEnabled: () => mockFlag(),
+}));
+
+const mockPlansBatch = jest.fn();
+jest.mock("@/services/integrations/connectionResolution", () => ({
+  buildWorkflowCredentialPlan: jest.fn(),
+  buildWorkflowCredentialPlansBatch: (...a: unknown[]) => mockPlansBatch(...a),
+}));
+
+import { computeViewerCanRunEditBatch, toWorkflowListItem } from "@/app/api/workflows/_shared";
+import type { WorkflowRecord } from "@/repositories/workflows";
+
+function node(provider: string) {
+  return { id: provider, kind: "action" as const, provider, type: "x", config: {}, position: { x: 0, y: 0 } };
+}
+function recordWith(over: Partial<WorkflowRecord>): WorkflowRecord {
+  return {
+    id: "wf-1",
+    accountId: "acct-1",
+    createdByUserId: "creator-1",
+    name: "WF",
+    state: "draft",
+    disabledReason: null,
+    disabledContext: null,
+    activeRevisionId: null,
+    draftDefinition: { nodes: [], edges: [] },
+    deletedAt: null,
+    folderId: null,
+    deletedByUserId: null,
+    purgeAfter: null,
+    deletedFromFolderId: null,
+    deleteOperationId: null,
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-01T00:00:00Z",
+    ...over,
+  } as WorkflowRecord;
+}
+function plansMap(entries: Record<string, boolean>) {
+  return new Map(Object.entries(entries).map(([id, allTeamRunnable]) => [id, { allTeamRunnable }]));
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("computeViewerCanRunEditBatch — flag OFF (conservative WF-RUNPERM, no DB)", () => {
+  beforeEach(() => mockFlag.mockReturnValue(false));
+
+  it("creator allowed; non-creator on a private workflow blocked; NO batch query", async () => {
+    const recs = [
+      recordWith({ id: "own", createdByUserId: "me", draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
+      recordWith({ id: "other", createdByUserId: "someone", draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
+    ];
+    const map = await computeViewerCanRunEditBatch(recs, "me");
+    expect(map.get("own")).toBe(true);
+    expect(map.get("other")).toBe(false); // conservative: private + non-creator
+    expect(mockPlansBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("computeViewerCanRunEditBatch — flag ON (accurate, batched)", () => {
+  beforeEach(() => mockFlag.mockReturnValue(true));
+
+  it("creator + no-private short-circuit to true with NO batch entry; only candidates go to the batch", async () => {
+    mockPlansBatch.mockResolvedValue(plansMap({ shared: true, ambiguous: false }));
+    const recs = [
+      recordWith({ id: "creator", createdByUserId: "me", draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
+      recordWith({ id: "noprivate", createdByUserId: "x", draftDefinition: { nodes: [node("slack")], edges: [] } as never }),
+      recordWith({ id: "shared", createdByUserId: "x", draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
+      recordWith({ id: "ambiguous", createdByUserId: "x", draftDefinition: { nodes: [node("gmail")], edges: [] } as never }),
+    ];
+    const map = await computeViewerCanRunEditBatch(recs, "me");
+    expect(map.get("creator")).toBe(true);
+    expect(map.get("noprivate")).toBe(true);
+    expect(map.get("shared")).toBe(true); // single-sharer resolved by batch
+    expect(map.get("ambiguous")).toBe(false); // ambiguous, no binding
+    // Only the 2 non-creator private candidates were sent to the bounded batch.
+    expect(mockPlansBatch).toHaveBeenCalledTimes(1);
+    const sentIds = (mockPlansBatch.mock.calls[0]![0] as { records: { id: string }[] }).records.map((r) => r.id).sort();
+    expect(sentIds).toEqual(["ambiguous", "shared"]);
+  });
+
+  it("valid binding makes a non-creator row runnable (batch returns allTeamRunnable true)", async () => {
+    mockPlansBatch.mockResolvedValue(plansMap({ bound: true }));
+    const map = await computeViewerCanRunEditBatch(
+      [recordWith({ id: "bound", createdByUserId: "x", draftDefinition: { nodes: [node("gmail")], edges: [] } as never })],
+      "me",
+    );
+    expect(map.get("bound")).toBe(true);
+  });
+});
+
+describe("toWorkflowListItem — accurate viewerCanRunEdit + no-leak", () => {
+  it("uses the precomputed eligibility map; falls back to conservative when absent", () => {
+    const rec = recordWith({ id: "wf-x", createdByUserId: "x", draftDefinition: { nodes: [node("gmail")], edges: [] } as never });
+    const runnable = toWorkflowListItem(rec, new Map(), "me", new Map([["wf-x", true]]));
+    expect(runnable.viewerCanRunEdit).toBe(true);
+    expect(runnable.usesPrivateCredential).toBe(true);
+    // No map → conservative (non-creator on a private workflow → false).
+    const conservative = toWorkflowListItem(rec, new Map(), "me");
+    expect(conservative.viewerCanRunEdit).toBe(false);
+  });
+
+  it("DTO leaks no identity: no createdByUserId / accountId / draftDefinition / connector ids", () => {
+    const rec = recordWith({
+      id: "wf-x",
+      accountId: "secret-account-id",
+      createdByUserId: "secret-creator-id",
+      draftDefinition: { nodes: [node("gmail")], edges: [] } as never,
+    });
+    const item = toWorkflowListItem(rec, new Map(), "me", new Map([["wf-x", true]]));
+    for (const forbidden of ["createdByUserId", "accountId", "draftDefinition", "connectorUserId", "connected_by_user_id"]) {
+      expect(item).not.toHaveProperty(forbidden);
+    }
+    const json = JSON.stringify(item);
+    expect(json).not.toContain("secret-account-id");
+    expect(json).not.toContain("secret-creator-id");
+  });
+});

--- a/tests/unit/services/integrations/connectionResolution-batch.test.ts
+++ b/tests/unit/services/integrations/connectionResolution-batch.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the CS-5b BATCHED credential-plan builder
+ * (`buildWorkflowCredentialPlansBatch`) — the workflows-dashboard counterpart to
+ * the per-workflow `buildWorkflowCredentialPlan`. Proves:
+ *   - it resolves the SAME `allTeamRunnable` decision per workflow as the single
+ *     builder (single-sharer / ambiguous / valid binding / unshared / accepted grant);
+ *   - it does so in BOUNDED queries — each batched repo is called EXACTLY ONCE for
+ *     the whole list (not once per workflow);
+ *   - records with no private providers get a runnable plan with NO query attributed.
+ * The three batched reads are mocked; the pure precedence runs for real.
+ */
+const mockAcceptedBatch = jest.fn();
+const mockBindingsBatch = jest.fn();
+const mockSharedBatch = jest.fn();
+
+jest.mock("@/services/teamCredentials/nodeCredentialOwners", () => ({
+  loadAcceptedNodeOwners: jest.fn(),
+  loadAcceptedNodeOwnersBatch: (...a: unknown[]) => mockAcceptedBatch(...a),
+}));
+jest.mock("@/repositories/workflowNodeConnectorBindings", () => ({
+  listByWorkflowServiceRole: jest.fn(),
+  listByWorkflowsServiceRole: (...a: unknown[]) => mockBindingsBatch(...a),
+}));
+jest.mock("@/repositories/integrations", () => ({
+  listSharedConnectorUserIdsServiceRole: jest.fn(),
+  listSharedConnectorsByProviderServiceRole: (...a: unknown[]) => mockSharedBatch(...a),
+}));
+
+import { buildWorkflowCredentialPlansBatch } from "@/services/integrations/connectionResolution";
+
+const CREATOR = "creator-1";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAcceptedBatch.mockResolvedValue(new Map()); // no grants
+  mockBindingsBatch.mockResolvedValue(new Map()); // no bindings
+  mockSharedBatch.mockResolvedValue(new Map()); // no sharers (per-provider sets filled per test)
+});
+
+function rec(id: string, nodes: { id: string; provider: string }[], createdBy = CREATOR) {
+  return { id, createdByUserId: createdBy, nodes };
+}
+
+describe("buildWorkflowCredentialPlansBatch — bounded queries", () => {
+  it("calls each batched repo EXACTLY ONCE for many workflows (not 3×N)", async () => {
+    mockSharedBatch.mockResolvedValue(new Map([["gmail", new Set(["alice"])]]));
+    const records = [
+      rec("wf-1", [{ id: "n1", provider: "gmail" }]),
+      rec("wf-2", [{ id: "n2", provider: "gmail" }]),
+      rec("wf-3", [{ id: "n3", provider: "gmail" }]),
+    ];
+    await buildWorkflowCredentialPlansBatch({ accountId: "acc-1", records });
+    expect(mockSharedBatch).toHaveBeenCalledTimes(1);
+    expect(mockAcceptedBatch).toHaveBeenCalledTimes(1);
+    expect(mockBindingsBatch).toHaveBeenCalledTimes(1);
+    // Shared set queried for the single distinct provider; workflow-keyed reads get all 3 ids.
+    expect(mockSharedBatch).toHaveBeenCalledWith("acc-1", ["gmail"]);
+    expect(mockAcceptedBatch.mock.calls[0]![0]).toEqual(["wf-1", "wf-2", "wf-3"]);
+    expect(mockBindingsBatch.mock.calls[0]![0]).toEqual(["wf-1", "wf-2", "wf-3"]);
+  });
+
+  it("no private-provider workflows → runnable plans, ZERO queries", async () => {
+    const records = [
+      rec("wf-native", [{ id: "t", provider: "native" }]),
+      rec("wf-account", [{ id: "a", provider: "slack" }]),
+    ];
+    const plans = await buildWorkflowCredentialPlansBatch({ accountId: "acc-1", records });
+    expect(plans.get("wf-native")!.allTeamRunnable).toBe(true);
+    expect(plans.get("wf-account")!.allTeamRunnable).toBe(true);
+    expect(mockSharedBatch).not.toHaveBeenCalled();
+    expect(mockAcceptedBatch).not.toHaveBeenCalled();
+    expect(mockBindingsBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildWorkflowCredentialPlansBatch — per-workflow resolution (matches the single builder)", () => {
+  it("single shared connector → runnable; ambiguous (2 sharers, no binding) → blocked; unshared → blocked", async () => {
+    mockSharedBatch.mockResolvedValue(new Map([["gmail", new Set(["alice", "bob"])], ["google-drive", new Set(["carol"])]]));
+    const plans = await buildWorkflowCredentialPlansBatch({
+      accountId: "acc-1",
+      records: [
+        rec("wf-single", [{ id: "n", provider: "google-drive" }]), // 1 sharer → runnable
+        rec("wf-ambig", [{ id: "n", provider: "gmail" }]),          // 2 sharers, no binding → blocked
+        rec("wf-unshared", [{ id: "n", provider: "outlook" }]),     // 0 sharers → blocked
+      ],
+    });
+    expect(plans.get("wf-single")!.allTeamRunnable).toBe(true);
+    expect(plans.get("wf-ambig")!.allTeamRunnable).toBe(false);
+    expect(plans.get("wf-unshared")!.allTeamRunnable).toBe(false);
+  });
+
+  it("valid node binding for an ambiguous provider → runnable (bound connector owns the node)", async () => {
+    mockSharedBatch.mockResolvedValue(new Map([["gmail", new Set(["alice", "bob"])]]));
+    mockBindingsBatch.mockResolvedValue(
+      new Map([["wf-bound", [{ nodeId: "n", provider: "gmail", connectorUserId: "bob" }]]]),
+    );
+    const plans = await buildWorkflowCredentialPlansBatch({
+      accountId: "acc-1",
+      records: [rec("wf-bound", [{ id: "n", provider: "gmail" }])],
+    });
+    expect(plans.get("wf-bound")!.allTeamRunnable).toBe(true);
+    expect(plans.get("wf-bound")!.ownerByNode.get("n")).toBe("bob");
+  });
+
+  it("accepted grant beats binding + share for the right workflow only", async () => {
+    mockSharedBatch.mockResolvedValue(new Map([["gmail", new Set(["alice", "bob"])]]));
+    mockAcceptedBatch.mockResolvedValue(new Map([["wf-grant", new Map([["n", "grantOwner"]])]]));
+    const plans = await buildWorkflowCredentialPlansBatch({
+      accountId: "acc-1",
+      records: [
+        rec("wf-grant", [{ id: "n", provider: "gmail" }]),
+        rec("wf-ambig", [{ id: "n", provider: "gmail" }]),
+      ],
+    });
+    expect(plans.get("wf-grant")!.ownerByNode.get("n")).toBe("grantOwner");
+    expect(plans.get("wf-grant")!.allTeamRunnable).toBe(true);
+    expect(plans.get("wf-ambig")!.allTeamRunnable).toBe(false); // no grant → still ambiguous
+  });
+});


### PR DESCRIPTION
## CONN-SHARE workflow-list eligibility polish (scoped)

Makes the workflows list/dashboard DTO accurately reflect CONN-SHARE run/edit eligibility (it stayed conservative since CS-5a to avoid N× reads), using **batched** reads — ≤3 queries total per account regardless of list size (shared-connector sets by provider, accepted grants by workflows, bindings by workflows), via a pure resolver shared with the per-workflow path so gate/executor/detail/list can't drift.

**Result:** a team-runnable shared-connection workflow no longer shows the misleading "Private connection" blocked badge to non-creators; unshared/ambiguous still show it. Display-only — the run/edit gate remains the enforcement.

**Scope:** 8 source + 2 test files. No execution-resolver behavior change, no Apps sharing change, no Disconnect/Reconnect, no AI/MCP/billing, no migration.

**Verified on `a0ea1cffe` (rebased on current v2-main):** typecheck 0 · lint 0 · lint:structure · lint:migrations · build 75/75 · targeted list/gate/detail/resolution/dashboard/picker/Apps 220 pass · full Jest 17,788 pass (1 unrelated suite flaky under parallel run, passes in isolation).
